### PR TITLE
Make snakemake pipeline more accessible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@ cython_debug/
 .DS_Store
 
 test.ipynb
+scratch_outputs/
 s3_credentials.sh
 to_do.txt
 

--- a/0_prepare_data/1B_download_dino.py
+++ b/0_prepare_data/1B_download_dino.py
@@ -2,7 +2,7 @@
 
 Use CPG index to download all Axiom Dino profiles.
 
-"""  # noqa: CPY001, INP001
+"""  # noqa: INP001
 
 import re
 
@@ -23,11 +23,11 @@ def main() -> None:
     # get Dino embedding paths
     for batch in batches:
         batch_path = f"{aws_path}/{batch}/"
-        aws_output = aws("s3", "ls", batch_path)
+        aws_output = aws("s3", "ls", batch_path, "--no-sign-request")
         plates = re.findall(r"plate_\d{8}", aws_output)
 
         for plate in plates:
-            aws("s3", "cp", f"{batch_path}{plate}/{plate}.parquet", f"{prof_dir}/{plate}.parquet")
+            aws("s3", "cp", f"{batch_path}{plate}/{plate}.parquet", f"{prof_dir}/{plate}.parquet", "--no-sign-request")
 
 
 if __name__ == "__main__":

--- a/0_prepare_data/1C_download_cpcnn.py
+++ b/0_prepare_data/1C_download_cpcnn.py
@@ -2,7 +2,7 @@
 
 Use CPG index to download all Axiom CPCNN profiles.
 
-"""  # noqa: CPY001, INP001
+"""  # noqa: INP001
 
 import re
 
@@ -23,11 +23,11 @@ def main() -> None:
     # get Dino embedding paths
     for batch in batches:
         batch_path = f"{aws_path}/{batch}/"
-        aws_output = aws("s3", "ls", batch_path)
+        aws_output = aws("s3", "ls", batch_path, "--no-sign-request")
         plates = re.findall(r"plate_\d{8}.parquet", aws_output)
 
         for plate in plates:
-            aws("s3", "cp", f"{batch_path}{plate}", f"{prof_dir}/{plate}")
+            aws("s3", "cp", f"{batch_path}{plate}", f"{prof_dir}/{plate}", "--no-sign-request")
 
 
 if __name__ == "__main__":

--- a/0_prepare_data/1D_download_cellprofiler.py
+++ b/0_prepare_data/1D_download_cellprofiler.py
@@ -23,11 +23,11 @@ def main() -> None:
     # get Dino embedding paths
     for batch in batches:
         batch_path = f"{aws_path}/{batch}/"
-        aws_output = aws("s3", "ls", batch_path)
+        aws_output = aws("s3", "ls", batch_path, "--no-sign-request")
         plates = re.findall(r"plate_\d{8}", aws_output)
 
         for plate in plates:
-            aws("s3", "cp", f"{batch_path}{plate}/{plate}.csv.gz", f"{prof_dir}/{plate}.csv.gz")
+            aws("s3", "cp", f"{batch_path}{plate}/{plate}.csv.gz", f"{prof_dir}/{plate}.csv.gz", "--no-sign-request")
 
 
 if __name__ == "__main__":

--- a/0_prepare_data/2B_format_dino.py
+++ b/0_prepare_data/2B_format_dino.py
@@ -78,7 +78,9 @@ def main() -> None:
     feat_cols = [i for i in data.columns if "Metadata_" not in i]
 
     data = data.group_by(["Metadata_Plate", "Metadata_Well"]).agg([
-        pl.first(meta_cols).exclude(["Metadata_well_id", "Metadata_Plate", "Metadata_Well"]),
+        pl.col(meta_cols)
+        .exclude(["Metadata_well_id", "Metadata_Plate", "Metadata_Well"])
+        .first(),
         pl.median(feat_cols),
     ])
 

--- a/0_prepare_data/2C_format_cpcnn.py
+++ b/0_prepare_data/2C_format_cpcnn.py
@@ -28,7 +28,9 @@ def main() -> None:
         dat = (
             dat.group_by(["Metadata_Plate", "Metadata_Well"])
             .agg([
-                pl.first(meta_cols).exclude(["Metadata_Plate", "Metadata_Well"]),
+                pl.col(meta_cols)
+                .exclude(["Metadata_Plate", "Metadata_Well"])
+                .first(),
                 pl.median(feat_cols),
             ])
             .collect()

--- a/0_prepare_data/4A_download_compiled_inputs.py
+++ b/0_prepare_data/4A_download_compiled_inputs.py
@@ -1,0 +1,50 @@
+"""Download compiled inputs.
+
+Download raw.parquet, metadata.parquet, and index.parquet from Zenodo instead of running 1A-2E.
+
+"""  # noqa: INP001
+
+import os
+import requests
+
+# List of files: (URL, target directory, filename)
+files_to_download = [
+    (
+        "https://zenodo.org/records/17067683/files/cellprofiler_raw.parquet",
+        "../1_snakemake/inputs/profiles/cellprofiler",
+        "raw.parquet",
+    ),
+    (
+        "https://zenodo.org/records/17067683/files/dino_raw.parquet",
+        "../1_snakemake/inputs/profiles/dino",
+        "raw.parquet",
+    ),
+    (
+        "https://zenodo.org/records/17067683/files/cpcnn_raw.parquet",
+        "../1_snakemake/inputs/profiles/cpcnn",
+        "raw.parquet",
+    ),
+    (
+        "https://zenodo.org/records/17067683/files/metadata.parquet",
+        "../1_snakemake/inputs/metadata",
+        "metadata.parquet",
+    ),
+    (
+        "https://zenodo.org/records/17067683/files/index.parquet",
+        "../1_snakemake/inputs/images",
+        "index.parquet",
+    ),
+]
+
+for url, dir_path, filename in files_to_download:
+    # Create the directory if it doesn't exist
+    os.makedirs(dir_path, exist_ok=True)
+
+    local_path = os.path.join(dir_path, filename)
+
+    # Stream download to handle large files
+    with requests.get(url, stream=True) as r:
+        r.raise_for_status()
+        with open(local_path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                f.write(chunk)

--- a/1_snakemake/Snakefile
+++ b/1_snakemake/Snakefile
@@ -1,4 +1,4 @@
-configfile: "./inputs/conf/dino.json"
+configfile: "./inputs/conf/cpcnn.json"
 
 # Load rules
 include: "rules/common.smk"
@@ -15,9 +15,10 @@ features = config["features"]
 
 rule all:
      input:
-          f"outputs/{features}/{name}/classifier_results/axiom_continuous_predictions.parquet",
-          f"outputs/{features}/{name}/curves/plots/cp_plots.pdf"
+          #f"outputs/{features}/{name}/classifier_results/axiom_continuous_predictions.parquet",
+          #f"outputs/{features}/{name}/curves/plots/cp_plots.pdf"
           #f"outputs/{features}/{name}/classifier_results/axiom_binary_predictions.parquet",
           #f"outputs/{features}/{name}/classifier_results/toxcast_cellfree_binary_predictions.parquet",
           #f"outputs/{features}/{name}/classifier_results/toxcast_cellbased_binary_predictions.parquet",
           #f"outputs/{features}/{name}/classifier_results/toxcast_cytotox_binary_predictions.parquet",
+          f"outputs/{features}/{name}/profiles/mad_featselect.parquet"

--- a/1_snakemake/classifier/classify.py
+++ b/1_snakemake/classifier/classify.py
@@ -1,13 +1,16 @@
-import traceback  # noqa: CPY001, D100
+import traceback  # noqa: D100
+
+try:
+    import cupy as cp
+except ImportError:
+    import numpy as cp  # fallback for macOS
 
 import pandas as pd
 import polars as pl
 from sklearn.model_selection import StratifiedKFold
-from tqdm import tqdm
-from xgboost import XGBClassifier
-import cupy as cp
 from sklearn.preprocessing import LabelEncoder
 from tqdm.contrib.concurrent import thread_map
+from xgboost import XGBClassifier
 
 
 def binary_classifier(

--- a/1_snakemake/inputs/conf/README.md
+++ b/1_snakemake/inputs/conf/README.md
@@ -1,0 +1,14 @@
+# Tracking experiments
+
+Each of the config files contains different analysis parameters, and is thus a separate experiment into how various preprocessing steps impact assay prediction performance. The authors of 'Cell Painting for Cytotoxicity and Mode-of-Action Analysis' hope that the results presented in their paper are just the beginning, and that improved methods for predicting specific cellular events from images of cells will be developed in the future. We therefore hope that many more config files will be added to this repository over time.
+
+## Reproduce manuscript results
+
+To reproduce the manuscript results, use cellprofiler_filt.json, cpcnn.json, and dino.json to generate results for each cell representation with repo commit 6ea26865b1fedd7aed52c2184bdc5da9b6facbf0.
+
+## Config naming conventions
+
+- Prefixes of cellprofiler, cpcnn, and dino mean the pipeline was run starting with raw.parquet from that cell representation.
+- The config parameter 'workflow' specifies the main processing steps used to generate input features for dose-response and classifier analysis.
+- Sometimes additional transformations / filters were applied in the downstream analysis. The config name after the "_" reflect this, as does the 'name' config parameter.
+- TODO future: provide definitions for all config parameters.

--- a/README.md
+++ b/README.md
@@ -3,4 +3,5 @@
 This repository is for analyzing the Axiom OASIS imaging data. Scripts for downloading the data from the CellPainting Gallery are included in the 0_data_download folder. The main analysis is in the 1_snakemake folder, and exploratory notebooks for visualizing results and comparing across pipeline variations are in the 2_downstream_analysis folder.
 
 ## Plotting images
+
 If you are only interested in viewing example images from OASIS, check out the `2_downstream_analysis/other_notebooks/Plot_images.ipynb` notebook. It contains instructions for downloading the necessary metadata for downloading images from AWS and functions for combining them into nice plots.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository is for analyzing the Axiom OASIS imaging data. Scripts for downloading the data from the CellPainting Gallery are included in the 0_data_download folder. The main analysis is in the 1_snakemake folder, and exploratory notebooks for visualizing results and comparing across pipeline variations are in the 2_downstream_analysis folder.
 
+## Skipping input data formatting
+
+The scripts in `0_prepare_data` compile profiles, metadata, and image locations across plates and batches, and ensure that formatting is consistent across different cell representations. These compiled files are the inputs to the snakemake pipeline. To make things easier, we've deposited a [copy of the compiled inputs on Zenodo](https://zenodo.org/records/17067683). The script `4A_download_compiled_inputs.py` can be run instead of scripts 1A - 2E.
+
 ## Plotting images
 
 If you are only interested in viewing example images from OASIS, check out the `2_downstream_analysis/other_notebooks/Plot_images.ipynb` notebook. It contains instructions for downloading the necessary metadata for downloading images from AWS and functions for combining them into nice plots.


### PR DESCRIPTION
- Add option to download snakemake inputs from Zenodo and therefore skip most scripts in 0_prepare_data
- Remove cupy dependency: only call this import if on a system that supports it
- Improve documentation in readmes