### PR TITLE
Correct the stale 4-GPU requirement and document notebook diff churn

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,10 @@
 pixi.lock linguist-generated=true
 flake.lock linguist-generated=true
+
+# Executed notebooks are committed with their outputs, so re-running them
+# rewrites iopub timestamps, execution counts and embedded images. Inert
+# unless the reader runs `nbdime config-git --enable --global`, which
+# registers these drivers and merges notebooks structurally rather than as
+# raw JSON. Do not swap this for nbstripout: that discards the outputs.
+*.ipynb diff=jupyternotebook
+*.ipynb merge=jupyternotebook

--- a/REPRODUCING.md
+++ b/REPRODUCING.md
@@ -41,8 +41,9 @@ different code.
 
 ## Running it from scratch
 
-Requires Nix with flakes, and a machine with 4 GPUs (see caveats). Roughly
-3.5 hours of wall clock for the three configs.
+Requires Nix with flakes, and at least one CUDA GPU (see caveats). Roughly
+3.5 hours of wall clock for the three configs on a 4-GPU node; expect longer
+on fewer GPUs.
 
 **1. Environments.** R comes from Nix; Python and snakemake come from pixi.
 Everything below assumes you are inside the Nix shell.
@@ -114,7 +115,7 @@ cd ..
 
 Use `--cores 4`, not more: no rule declares `threads:` or `resources:`, several
 rules spawn their own pools sized to the whole machine, and the four classifier
-rules each expect all 4 GPUs.
+rules each run 4 workers across every GPU they can see.
 
 **4. Notebooks.** Which environment matters -- the repo mixes two incompatible
 polars API generations (see the table in `pixi.toml`). Run in this order; the
@@ -127,6 +128,13 @@ override, execution fails on a missing kernel rather than on anything real.
 The loops below are fail-fast (`set -e`). Do not drop that: a plain `for` loop
 lets an early failure scroll past while later notebooks succeed, which is how
 `3_2_1` was wrongly recorded as passing in an earlier revision of this file.
+
+`--inplace` rewrites the notebooks. They are committed with their outputs, so a
+clean run produces a large diff (~10k lines) that is entirely execution
+metadata: iopub timestamps, execution counts and embedded images. That is
+expected, and it is not evidence of a behaviour change. `.gitattributes`
+registers nbdime as the notebook diff and merge driver; run
+`nbdime config-git --enable --global` once to make it take effect.
 
 ```bash
 set -e
@@ -278,8 +286,13 @@ Each is a separate commit on this branch.
   `*_ap.json` configs reach it, so it does not affect the three-config first
   pass.
 
-- **Hardware assumption.** `classifier/classify.py` hardcodes `num_gpus = 4`
-  and indexes `cp.cuda.Device(i % 4)`. It requires a 4-GPU node.
+- **Hardware assumption.** `classifier/classify.py` used to hardcode
+  `num_gpus = 4` and index `cp.cuda.Device(i % 4)`, which required a 4-GPU node.
+  Worse, `process_label_and_agg` catches every exception and returns `None`, and
+  the caller filters `None` out, so on a smaller node three quarters of the
+  classifier tasks were dropped silently while snakemake still exited 0.
+  It now takes the device count from `cp.cuda.runtime.getDeviceCount()` and keeps
+  the worker count at 4, which is a no-op on a 4-GPU node and correct below that.
   `concresponse/compute_distances.R` hardcodes 30 R workers; `concresponse/ap.py`
   hardcodes 10. No rule declares `threads:` or `resources:`, so `--cores N`
   will oversubscribe.

--- a/pixi.toml
+++ b/pixi.toml
@@ -41,8 +41,8 @@ python = "3.11.*"
 # in with it, so a pypi numpy pin loses to the conda solve. Pinning here keeps
 # requirements.txt's 1.24.3 and lets the solver pick a cupy built against it.
 numpy = "1.24.*"
-# classifier/classify.py hardcodes num_gpus = 4 and calls cp.cuda.Device().
-# cupy is imported but absent from requirements.txt.
+# classifier/classify.py sizes its GPU pool from cp.cuda.runtime.getDeviceCount()
+# and calls cp.cuda.Device(). cupy is imported but absent from requirements.txt.
 #
 # No upper bound needed: CUDA minor-version compatibility lets a 12.9 runtime
 # run on the 12.7-capable driver (565.57.01). What matters is that the flake


### PR DESCRIPTION
Follow-up to #37.

## Stale 4-GPU requirement

`REPRODUCING.md` and `pixi.toml` still stated that the pipeline requires a 4-GPU node and that `classify.py` hardcodes `num_gpus = 4`. Neither has been true since #37.

The "Hardware assumption" caveat now records what the old code did, why its failure mode mattered -- `process_label_and_agg` swallowed every exception and returned `None`, so a smaller node silently lost three quarters of the classifier tasks while snakemake exited 0 -- and what it does now. The "Running it from scratch" preamble asks for at least one CUDA GPU, and the 3.5 hour wall-clock figure is kept but qualified as a 4-GPU number.

The remaining mentions of "4-GPU" are deliberate: they describe the historical behaviour and the baseline the timings came from.

## Notebook diff churn

The twelve notebooks are committed with their outputs, so any clean `nbconvert --execute --inplace` run produces roughly 10k lines of diff that is entirely execution metadata -- iopub timestamps, execution counts, embedded images. That is now stated next to the notebook loops so the next person does not read it as a behaviour change.

`.gitattributes` registers nbdime as the notebook diff and merge driver, which merges notebooks structurally rather than as raw JSON. It is inert until the reader runs `nbdime config-git --enable --global`, so it adds no hard dependency.

nbstripout is explicitly ruled out in both the attributes comment and this change: it would discard the outputs committed in #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)