### PR TITLE
Add an executable tracked-paper audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # 2024_09_09_Axiom_OASIS
 
-> **Reproducing the results?** See [REPRODUCING.md](REPRODUCING.md) for a
-> from-scratch recipe (Nix + pixi environments, data, pipeline, notebooks) and
-> for what the regenerated results look like next to the committed ones. The
-> instructions below describe the original layout; several of the scripts they
-> reference do not run as published, and `REPRODUCING.md` says which.
+> **Reproducing the results?**
+> See [REPRODUCING.md](REPRODUCING.md) for a from-scratch recipe (Nix + pixi environments, data, pipeline, notebooks) and for what the regenerated results look like next to the committed ones.
+> The instructions below describe the original layout; several of the scripts they reference do not run as published, and `REPRODUCING.md` says which.
 
 > **Working from the paper?**
-> See [paper/README.md](paper/README.md) for the searchable paper, published source files, target inventory, flexible acceptance rules, and evidence workflow for systematic reproduction.
+> Run `uv run paper/reproduce.py` for the repository-only executable paper.
+> See [paper/README.md](paper/README.md) for the searchable paper, published source files, complete target inventory, acceptance rules, and evidence workflow.
 
 This repository is for analyzing the Axiom OASIS imaging data. Scripts for downloading the data from the Cell Painting Gallery are included in the 0_data_download folder. The main analysis is in the 1_snakemake folder, and exploratory notebooks for visualizing results and comparing across pipeline variations are in the 2_downstream_analysis folder.
 

--- a/paper/README.md
+++ b/paper/README.md
@@ -25,6 +25,29 @@ sha256sum -c SHA256SUMS
 The original 135 MB submission bundle contains draft manuscripts, administrative documents, and redundant figure sources.
 It is deliberately excluded from Git because the compact published source set is sufficient for this workflow.
 
+## Run the executable paper
+
+Run the tracked-data reproduction from the repository root:
+
+```bash
+uv run paper/reproduce.py
+```
+
+The command evaluates or accounts for every row in `targets.tsv` using only committed inputs.
+It writes a deterministic Markdown report, a machine-readable JSON report, summary tables, and simplified SVG figures under `paper/reproduction/`.
+The standalone Python environment is pinned by `reproduce.py.lock`.
+The canonical outputs are committed, and the test suite fails if they no longer match a fresh render.
+Use `uv run paper/reproduce.py --list` to list target IDs.
+For a focused scratch report, repeat `--target ID` as needed and set `--output`, for example `uv run paper/reproduce.py --target FILTER-002 --output /tmp/oasis-filter-002`.
+
+Each target keeps four ideas separate: the historical ledger status, this run's execution outcome, the available evidence strength, and the target-specific acceptance class.
+An execution outcome of `checked` means that the declared tracked-input checks passed; it does not claim that upstream workflows or the full acceptance target were regenerated.
+A reported blocker or out-of-scope target is a complete accounting result, not a reproduced result.
+The command fails if the explicit recipe registry no longer covers the ledger exactly or if a declared check contradicts the tracked evidence.
+
+This is the small, repository-only entry point for reviewing the whole paper.
+The longer GPU workflow in `REPRODUCING.md` remains the path for regenerating upstream compiled artifacts from downloaded raw inputs.
+
 ## Agent workflow
 
 1. Read this file, the relevant section of `paper.md`, and the existing top-level `REPRODUCING.md`.

--- a/paper/reproduce.py
+++ b/paper/reproduce.py
@@ -1,0 +1,3786 @@
+# /// script
+# requires-python = "==3.11.*"
+# dependencies = [
+#   "matplotlib==3.9.2",
+#   "numpy==1.24.3",
+#   "pandas==2.2.2",
+#   "pyarrow==14.0.1",
+#   "scipy==1.13.1",
+#   "statsmodels==0.14.3",
+# ]
+# ///
+# ruff: noqa: ANN401, C901, COM812, E402, E501, EM101, EM102, FBT001, FBT003, I001, ICN001, PD008, PD010, PD101, PERF401, PLR0912, PLR0915, PLR2004, PTH105, S314, T201, TRY003, TRY203, TRY300, TRY301
+"""Run the archive-safe, tracked-artifact paper audit.
+
+This program deliberately reanalyzes only explicit, committed inputs.
+It does not run notebooks or workflows, inspect ignored outputs, query Git, or
+contact external services.  The resulting figures describe tracked-artifact
+reanalysis and are not publisher-figure reproductions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import posixpath
+import re
+import sys
+import tempfile
+import tomllib
+import xml.etree.ElementTree as ET
+import zlib
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
+from contextvars import ContextVar
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from zipfile import BadZipFile, LargeZipFile, ZipFile
+
+# ``uv run paper/reproduce.py`` puts paper/, rather than the checkout root, on
+# sys.path.  Add the root before importing the repository verifier constants.
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+# Some archive and sandbox environments make the user's normal Matplotlib
+# config directory read-only.  Keep this process cache explicit and outside
+# the repository so importing the runner never inspects or writes a repo cache.
+os.environ.setdefault("MPLCONFIGDIR", str(Path(tempfile.gettempdir()) / "oasis-paper-matplotlib"))
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy.stats import hypergeom, ttest_rel
+from statsmodels.stats.multitest import multipletests
+
+from verification.compiled_results import (
+    EXPECTED_AGG_TYPES,
+    EXPECTED_ENRICHMENT_ROWS,
+    EXPECTED_ENRICHMENT_UNIVERSE,
+    EXPECTED_METRIC_ROWS,
+    HIT_COLUMNS,
+    HIT_SUMMARY_COLUMNS,
+    METRIC_COLUMNS,
+    METRIC_KEY,
+    POD_FILES,
+)
+
+SCHEMA_VERSION = 3
+
+# The registry is intentionally explicit.  A new ledger row must be assigned
+# deliberately instead of inheriting a result from a filename or prefix.
+TARGET_GROUPS: dict[str, tuple[str, ...]] = {
+    "sources_design": (
+        "DESIGN-001",
+        "DESIGN-002",
+        "DESIGN-003",
+        "FIG-1",
+        "TABLE-S1",
+        "TABLE-KEY-RESOURCES",
+        "METHOD-STATS",
+        "RESOURCE-001",
+    ),
+    "activity_pods": (
+        "ACTIVITY-001",
+        "ACTIVITY-002",
+        "ACTIVITY-003",
+        "FIG-2A",
+        "BIOACTIVITY-001",
+        "FIG-2B",
+        "BIOACTIVITY-002",
+        "FIG-2C",
+        "BIOACTIVITY-003",
+        "FIG-2D",
+        "TABLE-S2",
+        "TABLE-S3",
+        "TABLE-S4",
+        "METHOD-POD",
+        "CONCLUSION-001",
+    ),
+    "regression_enrichment": (
+        "TABLE-1",
+        "REGRESSION-001",
+        "REGRESSION-002",
+        "ENRICH-001",
+        "ENRICH-002",
+        "ENRICH-003",
+        "ENRICH-004",
+        "SFIG-2",
+        "METHOD-REGRESSION",
+        "INTERPRETATION-001",
+    ),
+    "toxcast": (
+        "TOXCAST-001",
+        "TOXCAST-002",
+        "TOXCAST-003",
+        "SFIG-3",
+        "TABLE-S5",
+        "METHOD-TOXCAST",
+    ),
+    "classifier": (
+        "TABLE-2",
+        "CLASSIFIER-001",
+        "FIG-3AB",
+        "FIG-3C",
+        "FILTER-001",
+        "FILTER-002",
+        "FIG-4A",
+        "REPRESENTATION-001",
+        "FIG-4B",
+        "SFIG-4",
+        "METHOD-CLASSIFIER",
+        "CONCLUSION-002",
+        "CONCLUSION-003",
+    ),
+    "external_image": ("SFIG-1",),
+}
+
+SOURCE_INPUTS = (
+    "paper/sources/manifest.toml",
+    "paper/sources/SHA256SUMS",
+    "paper/sources/main.pdf",
+    "paper/sources/supplemental-figures.pdf",
+    "paper/sources/table-s1.xlsx",
+    "paper/sources/table-s2.xlsx",
+    "paper/sources/table-s3.xlsx",
+    "paper/sources/table-s4.xlsx",
+    "paper/sources/table-s5.xlsx",
+    "paper/sources/manuscript-source.docx",
+)
+ANNOTATION_INPUTS = (
+    "1_snakemake/inputs/annotations/arevalo_input/compound_gene.parquet",
+    "1_snakemake/inputs/annotations/cg_motive.parquet",
+    "1_snakemake/inputs/annotations/motive_binary.parquet",
+    "1_snakemake/inputs/annotations/toxcast_cellbased_binary.parquet",
+    "1_snakemake/inputs/annotations/toxcast_cellbased_info.parquet",
+    "1_snakemake/inputs/annotations/toxcast_cellfree_binary.parquet",
+    "1_snakemake/inputs/annotations/toxcast_cellfree_info.parquet",
+    "1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet",
+    "1_snakemake/inputs/annotations/toxcast_cytotox_info.parquet",
+    "1_snakemake/inputs/annotations/v5_oasis_03Sept2024_simple.csv",
+)
+COMPILED_INPUTS = (
+    "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",
+    "2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet",
+    "2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet",
+    "2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet",
+    "2_downstream_analysis/compiled_results/err_higher_targets.csv",
+    "2_downstream_analysis/compiled_results/err_lower_targets.csv",
+    "2_downstream_analysis/compiled_results/mtt_higher_targets.csv",
+    "2_downstream_analysis/compiled_results/mtt_lower_targets.csv",
+    "2_downstream_analysis/compiled_results/motive_highexp_PHH.parquet",
+    "2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/readme.txt",
+)
+TRACE_INPUTS = (
+    "README.md",
+    "REPRODUCING.md",
+    "paper/paper.md",
+    "paper/targets.tsv",
+    "paper/evidence/activity-and-figure-2a.md",
+    "paper/evidence/bioactivity-and-figure-2b-d.md",
+    "paper/evidence/classifier-results.md",
+    "paper/evidence/experimental-design-and-figure-1.md",
+    "paper/evidence/method-deviations.md",
+    "paper/evidence/mt-discrepancy-enrichment.md",
+    "paper/evidence/prediction-error-enrichment.md",
+    "paper/evidence/published-table-bridge.md",
+    "paper/evidence/regression-and-figure-s2.md",
+    "paper/evidence/remaining-paper-reproduction-targets.md",
+    "paper/evidence/toxcast-curation-and-figure-s3.md",
+    "paper/figures/figure-1.jpg",
+    "paper/figures/figure-s1.jpg",
+    "0_prepare_data/4A_download_compiled_inputs.py",
+    "1_snakemake/Snakefile",
+    "1_snakemake/concresponse/fit_curves.R",
+    "1_snakemake/concresponse/fit_curves_meta.R",
+    "1_snakemake/concresponse/select_pod.R",
+    "1_snakemake/classifier/aggregate_profiles.py",
+    "1_snakemake/classifier/classify.py",
+    "1_snakemake/classifier/hitcalls.py",
+    "1_snakemake/classifier/metrics.py",
+    "1_snakemake/classifier/regression.py",
+    "1_snakemake/rules/classifier.smk",
+    "1_snakemake/rules/concresponse.smk",
+    "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+    "2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb",
+    "2_downstream_analysis/other_notebooks/01_checkwelleffects.ipynb",
+)
+ALLOWED_INPUTS = frozenset((*SOURCE_INPUTS, *ANNOTATION_INPUTS, *COMPILED_INPUTS, *TRACE_INPUTS))
+
+PROTECTED_INPUT_TREES = (
+    "paper/sources",
+    "paper/figures",
+    "paper/evidence",
+    "2_downstream_analysis/compiled_results",
+    "1_snakemake/inputs/annotations",
+)
+FORBIDDEN_OUTPUT_TREES = (
+    "1_snakemake/inputs/metadata",
+    "1_snakemake/inputs/profiles",
+    "1_snakemake/outputs",
+    ".git",
+    ".pixi",
+    ".cache",
+    "__pycache__",
+)
+KNOWN_OUTPUT_FILENAMES = frozenset(
+    {
+        "report.json",
+        "report.md",
+        "evidence-coverage.svg",
+        "pod-summary.svg",
+        "enrichment-summary.svg",
+        "toxcast-summary.svg",
+        "classifier-summary.svg",
+    }
+)
+ANALYSIS_FIGURE_FILENAMES = {
+    "activity_pods": "pod-summary.svg",
+    "regression_enrichment": "enrichment-summary.svg",
+    "toxcast": "toxcast-summary.svg",
+    "classifier": "classifier-summary.svg",
+}
+
+LEDGER_HEADER = (
+    "id",
+    "source",
+    "kind",
+    "description",
+    "expected",
+    "acceptance",
+    "producer",
+    "evidence",
+    "status",
+    "deviation",
+)
+LEDGER_STATUSES = frozenset({"reproduced", "reproduced-with-deviation", "blocked", "out-of-scope"})
+EVIDENCE_STRENGTHS = frozenset(
+    {"source-recomputation", "derived-artifact-reanalysis", "documentary-trace", "unavailable"}
+)
+ACCEPTANCE_CLASSES = frozenset({"exact", "close", "qualitative", "trace-only"})
+
+_XLSX_NS = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+_OFFICE_REL_NS = "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}"
+
+_VALIDATED_INPUTS: ContextVar[set[str] | None] = ContextVar("validated_inputs", default=None)
+
+
+@dataclass(frozen=True)
+class TargetRecipe:
+    """One explicit tracked-only execution contract for a ledger target."""
+
+    group: str
+    evidence_strength: str
+    availability: str
+    inputs: tuple[str, ...]
+    check_builder: Callable[[Mapping[str, Any]], list[dict[str, object]]]
+
+
+class InputValidationError(ValueError):
+    """An input is missing, malformed, unsafe, or outside registry coverage."""
+
+
+class ScientificContradictionError(RuntimeError):
+    """Tracked evidence contradicts the pinned scientific or ledger contract."""
+
+
+def _inside(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _input_path(root: Path, relative: str) -> Path:
+    if relative not in ALLOWED_INPUTS:
+        raise InputValidationError(f"input is not allowlisted: {relative}")
+    root_resolved = root.resolve()
+    path = (root_resolved / relative).resolve()
+    if not _inside(path, root_resolved):
+        raise InputValidationError(f"input escapes repository root: {relative}")
+    if not path.is_file():
+        raise InputValidationError(f"missing tracked input: {relative}")
+    validated = _VALIDATED_INPUTS.get()
+    if validated is not None:
+        validated.add(relative)
+    return path
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise InputValidationError(message)
+
+
+def _confirm(condition: bool, message: str) -> None:
+    if not condition:
+        raise ScientificContradictionError(message)
+
+
+def _native_float(value: object, *, digits: int = 15) -> float:
+    result = float(value)
+    if not np.isfinite(result):
+        raise InputValidationError("report value is not finite")
+    return float(f"{result:.{digits}g}")
+
+
+def _check(name: str, observed: object, expected: object, passed: bool | None = None) -> dict[str, object]:
+    return {
+        "name": name,
+        "passed": bool(observed == expected) if passed is None else bool(passed),
+        "observed": observed,
+        "expected": expected,
+    }
+
+
+def load_targets(root: Path) -> list[dict[str, str]]:
+    """Load and structurally validate the paper target ledger."""
+    path = _input_path(root, "paper/targets.tsv")
+    try:
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle, delimiter="\t")
+            if tuple(reader.fieldnames or ()) != LEDGER_HEADER:
+                raise InputValidationError(
+                    f"paper/targets.tsv has header {tuple(reader.fieldnames or ())!r}; expected {LEDGER_HEADER!r}"
+                )
+            rows = [dict(row) for row in reader]
+    except UnicodeDecodeError as exc:
+        raise InputValidationError("paper/targets.tsv is not UTF-8") from exc
+
+    _require(bool(rows), "paper/targets.tsv is empty")
+    seen: set[str] = set()
+    for line_number, row in enumerate(rows, start=2):
+        _require(set(row) == set(LEDGER_HEADER), f"ledger row {line_number} has unexpected fields")
+        _require(all(value is not None for value in row.values()), f"ledger row {line_number} is incomplete")
+        target_id = row["id"]
+        _require(bool(re.fullmatch(r"[A-Z]+(?:-[A-Z0-9]+)+", target_id)), f"invalid target ID {target_id!r}")
+        _require(target_id not in seen, f"duplicate target ID {target_id}")
+        seen.add(target_id)
+        _require(row["status"] in LEDGER_STATUSES, f"{target_id}: invalid ledger status {row['status']!r}")
+        acceptance_class = row["acceptance"].partition(":")[0]
+        _require(acceptance_class in ACCEPTANCE_CLASSES, f"{target_id}: invalid acceptance class")
+        _require(bool(row["description"] and row["expected"]), f"{target_id}: empty description or expectation")
+    return rows
+
+
+def _column_index(reference: str) -> int:
+    index = 0
+    for character in reference:
+        if not character.isalpha():
+            break
+        index = index * 26 + ord(character.upper()) - ord("A") + 1
+    if index == 0:
+        raise InputValidationError(f"invalid XLSX cell reference {reference!r}")
+    return index - 1
+
+
+def _xlsx_tables(path: Path) -> list[tuple[str, list[dict[str, object]]]]:
+    """Read simple worksheet tables with only the Python standard library."""
+    try:
+        with ZipFile(path) as archive:
+            bad_member = archive.testzip()
+            if bad_member is not None:
+                raise InputValidationError(f"{path.name}: corrupt Office member {bad_member}")
+            names = set(archive.namelist())
+            _require("xl/workbook.xml" in names, f"{path.name}: missing xl/workbook.xml")
+
+            shared: list[str] = []
+            if "xl/sharedStrings.xml" in names:
+                root = ET.fromstring(archive.read("xl/sharedStrings.xml"))
+                shared = ["".join(node.text or "" for node in item.iter(f"{_XLSX_NS}t")) for item in root]
+
+            workbook = ET.fromstring(archive.read("xl/workbook.xml"))
+            rel_root = ET.fromstring(archive.read("xl/_rels/workbook.xml.rels"))
+            relationships = {item.attrib["Id"]: item.attrib["Target"] for item in rel_root}
+            sheets = workbook.find(f"{_XLSX_NS}sheets")
+            _require(sheets is not None, f"{path.name}: workbook has no sheets")
+            result: list[tuple[str, list[dict[str, object]]]] = []
+            for sheet in sheets:
+                relationship_id = sheet.attrib[f"{_OFFICE_REL_NS}id"]
+                target = relationships.get(relationship_id)
+                _require(target is not None, f"{path.name}: unresolved worksheet relationship")
+                member = target.lstrip("/") if target.startswith("/") else posixpath.normpath(f"xl/{target}")
+                _require(member in names, f"{path.name}: missing worksheet {member}")
+                xml_root = ET.fromstring(archive.read(member))
+                raw_rows: list[list[object]] = []
+                for row in xml_root.iter(f"{_XLSX_NS}row"):
+                    values: list[object] = []
+                    for cell in row.findall(f"{_XLSX_NS}c"):
+                        column = _column_index(cell.attrib.get("r", ""))
+                        while len(values) <= column:
+                            values.append("")
+                        cell_type = cell.attrib.get("t")
+                        value_node = cell.find(f"{_XLSX_NS}v")
+                        if cell_type == "inlineStr":
+                            inline = cell.find(f"{_XLSX_NS}is")
+                            value: object = (
+                                "".join(node.text or "" for node in inline.iter(f"{_XLSX_NS}t"))
+                                if inline is not None
+                                else ""
+                            )
+                        elif value_node is None or value_node.text is None:
+                            value = ""
+                        elif cell_type == "s":
+                            try:
+                                value = shared[int(value_node.text)]
+                            except (IndexError, ValueError) as exc:
+                                raise InputValidationError(f"{path.name}: invalid shared-string index") from exc
+                        elif cell_type == "b":
+                            value = value_node.text == "1"
+                        else:
+                            value = value_node.text
+                        values[column] = value
+                    if any(value not in ("", None) for value in values):
+                        raw_rows.append(values)
+                _require(bool(raw_rows), f"{path.name}: worksheet {sheet.attrib['name']} is empty")
+                header = [str(value) for value in raw_rows[0]]
+                _require(all(header), f"{path.name}: worksheet has blank header cells")
+                _require(len(header) == len(set(header)), f"{path.name}: worksheet has duplicate headers")
+                table = [
+                    {column: row[index] if index < len(row) else "" for index, column in enumerate(header)}
+                    for row in raw_rows[1:]
+                ]
+                result.append((sheet.attrib["name"], table))
+            return result
+    except (BadZipFile, LargeZipFile, ET.ParseError, KeyError, UnicodeDecodeError, zlib.error) as exc:
+        raise InputValidationError(f"cannot parse Office archive {path.name}: {exc}") from exc
+
+
+def _first_xlsx_table(root: Path, relative: str) -> list[dict[str, object]]:
+    tables = _xlsx_tables(_input_path(root, relative))
+    _require(len(tables) == 1, f"{relative}: expected exactly one worksheet")
+    return tables[0][1]
+
+
+def _norm_string(value: object) -> str | None:
+    if value in (None, "") or value is pd.NA:
+        return None
+    if isinstance(value, float) and np.isnan(value):
+        return None
+    return str(value)
+
+
+def _read_csv(root: Path, relative: str) -> pd.DataFrame:
+    try:
+        return pd.read_csv(_input_path(root, relative))
+    except Exception as exc:
+        raise InputValidationError(f"cannot read CSV {relative}: {exc}") from exc
+
+
+def _read_parquet(root: Path, relative: str) -> pd.DataFrame:
+    try:
+        return pd.read_parquet(_input_path(root, relative), engine="pyarrow")
+    except Exception as exc:
+        raise InputValidationError(f"cannot read Parquet {relative}: {exc}") from exc
+
+
+def _validate_columns(frame: pd.DataFrame, expected: set[str] | frozenset[str], label: str) -> None:
+    actual = set(frame.columns)
+    _require(actual == set(expected), f"{label}: unexpected columns; got {sorted(actual)!r}")
+    _require(not frame.empty, f"{label}: table is empty")
+
+
+def _analyze_sources_design(root: Path) -> dict[str, object]:
+    manifest_path = _input_path(root, "paper/sources/manifest.toml")
+    sums_path = _input_path(root, "paper/sources/SHA256SUMS")
+    try:
+        manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+        raise InputValidationError(f"cannot parse paper/sources/manifest.toml: {exc}") from exc
+    records = manifest.get("source")
+    _require(isinstance(records, list), "source manifest has no source records")
+    _confirm(len(records) == 8, f"source manifest has {len(records)} records; expected 8")
+
+    checksums: dict[str, str] = {}
+    try:
+        checksum_lines = sums_path.read_text(encoding="ascii").splitlines()
+    except UnicodeDecodeError as exc:
+        raise InputValidationError("paper/sources/SHA256SUMS is not ASCII") from exc
+    for line in checksum_lines:
+        parts = line.split()
+        _require(len(parts) == 2 and re.fullmatch(r"[0-9a-f]{64}", parts[0]) is not None, "malformed SHA256SUMS")
+        _require(parts[1] not in checksums, f"duplicate checksum entry {parts[1]}")
+        checksums[parts[1]] = parts[0]
+
+    source_rows: list[dict[str, object]] = []
+    office_rows: list[dict[str, object]] = []
+    for raw_record in records:
+        _require(isinstance(raw_record, dict), "malformed source manifest record")
+        filename = raw_record.get("path")
+        expected_sha = raw_record.get("sha256")
+        expected_bytes = raw_record.get("bytes")
+        _require(isinstance(filename, str) and "/" not in filename, "unsafe source manifest path")
+        _require(
+            isinstance(expected_sha, str) and re.fullmatch(r"[0-9a-f]{64}", expected_sha) is not None,
+            "invalid source SHA-256",
+        )
+        _require(isinstance(expected_bytes, int) and expected_bytes > 0, "invalid source byte count")
+        relative = f"paper/sources/{filename}"
+        path = _input_path(root, relative)
+        actual_sha = _sha256(path)
+        actual_bytes = path.stat().st_size
+        if path.suffix.lower() in {".xlsx", ".docx"}:
+            try:
+                with ZipFile(path) as archive:
+                    bad_member = archive.testzip()
+                    member_count = len(archive.infolist())
+            except (BadZipFile, LargeZipFile, KeyError, zlib.error) as exc:
+                raise InputValidationError(f"{filename}: invalid Office archive") from exc
+            if bad_member is not None:
+                raise InputValidationError(f"{filename}: Office ZIP CRC failed for {bad_member}")
+            office_rows.append({"path": relative, "members": member_count, "crc_passed": True})
+        _confirm(checksums.get(filename) == expected_sha, f"{filename}: manifest and SHA256SUMS disagree")
+        _confirm(actual_sha == expected_sha, f"{filename}: SHA-256 differs from source manifest")
+        _confirm(actual_bytes == expected_bytes, f"{filename}: byte count differs from source manifest")
+        source_rows.append(
+            {
+                "id": str(raw_record.get("id")),
+                "path": relative,
+                "sha256": actual_sha,
+                "bytes": actual_bytes,
+                "canonical": bool(raw_record.get("canonical")),
+            }
+        )
+    _confirm(
+        set(checksums) == {str(record["path"]) for record in records}, "source checksum inventory differs from manifest"
+    )
+    _confirm(len(office_rows) == 6, f"found {len(office_rows)} Office archives; expected 6")
+
+    table_s1 = _first_xlsx_table(root, "paper/sources/table-s1.xlsx")
+    _confirm(len(table_s1) == 1_085, f"Table S1 has {len(table_s1)} rows; expected 1085")
+    stable_rows = [row for row in table_s1 if _norm_string(row.get("OASIS_ID")) is not None]
+    blank_rows = [row for row in table_s1 if _norm_string(row.get("OASIS_ID")) is None]
+    stable_ids = [_norm_string(row["OASIS_ID"]) for row in stable_rows]
+    _require(len(stable_ids) == len(set(stable_ids)), "Table S1 contains duplicate stable IDs")
+
+    catalog = _read_csv(root, "1_snakemake/inputs/annotations/v5_oasis_03Sept2024_simple.csv")
+    required_catalog = {"OASIS_ID", "PREFERRED_NAME", "Purchased_Axiom_Medchemxpress"}
+    _require(required_catalog <= set(catalog.columns), "annotation catalog is missing Table S1 join fields")
+    # The catalog has 1,494 rows for 1,477 stable IDs.  Repeated IDs are an
+    # established source-layer property, so collapse only after confirming
+    # that the fields used by this audit are internally consistent.
+    for target_id, group in catalog.groupby("OASIS_ID", dropna=False):
+        _require(
+            group["PREFERRED_NAME"].nunique(dropna=False) == 1
+            and group["Purchased_Axiom_Medchemxpress"].nunique(dropna=False) == 1,
+            f"annotation catalog has conflicting Table S1 fields for {target_id}",
+        )
+    catalog_by_id = catalog.drop_duplicates("OASIS_ID").set_index("OASIS_ID")
+    covered_ids = [target_id for target_id in stable_ids if target_id in catalog_by_id.index]
+    purchased_ids = [
+        target_id
+        for target_id in covered_ids
+        if str(catalog_by_id.at[target_id, "Purchased_Axiom_Medchemxpress"]) == "Yes"
+    ]
+    preferred_matches = sum(
+        str(row["Compound Name"]) == str(catalog_by_id.at[str(row["OASIS_ID"]), "PREFERRED_NAME"])
+        for row in stable_rows
+        if str(row["OASIS_ID"]) in catalog_by_id.index
+    )
+    table_s1_report = {
+        "rows": len(table_s1),
+        "unique_compound_names": len({str(row["Compound Name"]) for row in table_s1}),
+        "stable_id_count": len(stable_ids),
+        "blank_id_count": len(blank_rows),
+        "annotation_rows": len(catalog),
+        "annotation_unique_ids": int(catalog["OASIS_ID"].nunique()),
+        "annotation_covered_ids": len(covered_ids),
+        "purchased_annotation_ids": len(purchased_ids),
+        "preferred_name_matches": preferred_matches,
+        "url_count": sum(bool(_norm_string(row.get("Compound URL"))) for row in table_s1),
+    }
+    expected_s1 = {
+        "rows": 1_085,
+        "stable_id_count": 966,
+        "blank_id_count": 119,
+        "annotation_covered_ids": 966,
+        "purchased_annotation_ids": 966,
+        "preferred_name_matches": 790,
+    }
+    for field, expected in expected_s1.items():
+        _confirm(
+            table_s1_report[field] == expected, f"Table S1 {field} is {table_s1_report[field]}; expected {expected}"
+        )
+
+    paper_text = _input_path(root, "paper/paper.md").read_text(encoding="utf-8")
+    design_evidence = _input_path(root, "paper/evidence/experimental-design-and-figure-1.md").read_text(
+        encoding="utf-8"
+    )
+    remaining_evidence = _input_path(root, "paper/evidence/remaining-paper-reproduction-targets.md").read_text(
+        encoding="utf-8"
+    )
+    readme_text = _input_path(root, "README.md").read_text(encoding="utf-8")
+    reproducing_text = _input_path(root, "REPRODUCING.md").read_text(encoding="utf-8")
+    figure_1_bytes = _input_path(root, "paper/figures/figure-1.jpg").read_bytes()
+    _require(
+        figure_1_bytes.startswith(b"\xff\xd8") and figure_1_bytes.endswith(b"\xff\xd9"),
+        "paper/figures/figure-1.jpg is not a complete JPEG",
+    )
+    key_resources_section = paper_text.split("## Key Resources Table", maxsplit=1)
+    _require(len(key_resources_section) == 2, "paper transcription has no Key Resources Table")
+    key_resource_lines = key_resources_section[1].split("\n## ", maxsplit=1)[0].splitlines()
+    key_resource_rows = [
+        line
+        for line in key_resource_lines
+        if line.startswith("|") and not line.startswith("| ---") and not line.startswith("| **")
+    ]
+    _confirm(
+        len(key_resource_rows) == 35, f"Key Resources table has {len(key_resource_rows) - 1} data rows; expected 34"
+    )
+    trace = {
+        "experimental_design": all(
+            token in paper_text
+            for token in ("1,085 compounds", "0.01 to 100 uM", "two biological replicates", "384-well", "44 hours")
+        ),
+        "feature_count_claims": all(token in paper_text for token in ("5,640", "672", "4,608")),
+        "assay_and_exposure_design": all(token in paper_text for token in ("44 hours", "Cell Painting", "LDH", "MT")),
+        "figure_1_workflow": all(
+            token in design_evidence for token in ("connect the exposures", "Cell Painting", "cell count", "LDH", "MT")
+        ),
+        "statistical_thresholds": all(
+            token in paper_text for token in ("p \\< 0.05", "FDR cutoff of \\< 0.05", "5,500 cells")
+        ),
+        "resource_locations": all(
+            token in paper_text + readme_text for token in ("cpg0037-oasis/axiom", "10.5281/zenodo.18242918")
+        ),
+        "table_key_resources": len(key_resource_rows) - 1 == 34,
+        "tracked_only_boundary": "normal clone" in reproducing_text
+        and "ignored inputs and outputs" in reproducing_text
+        and "five are ignored" in remaining_evidence,
+    }
+    _confirm(all(trace.values()), "paper or workflow documentary trace is incomplete")
+    return {
+        "source_count": len(source_rows),
+        "office_archive_count": len(office_rows),
+        "sources": source_rows,
+        "office_archives": office_rows,
+        "table_s1": table_s1_report,
+        "key_resources_data_rows": len(key_resource_rows) - 1,
+        "documentary_trace": trace,
+    }
+
+
+def _semantic_key(frame: pd.DataFrame, columns: Sequence[str]) -> list[tuple[str | None, ...]]:
+    return [
+        tuple(_norm_string(value) for value in values)
+        for values in frame.loc[:, list(columns)].itertuples(index=False, name=None)
+    ]
+
+
+def _rows_to_frame(rows: list[dict[str, object]], columns: Sequence[str], label: str) -> pd.DataFrame:
+    _require(bool(rows), f"{label}: workbook table is empty")
+    _require(set(rows[0]) == set(columns), f"{label}: unexpected workbook columns")
+    return pd.DataFrame(rows, columns=list(columns))
+
+
+def _supplemental_table_audit(
+    root: Path, pods: Mapping[str, pd.DataFrame], hit_summary: pd.DataFrame
+) -> dict[str, object]:
+    s2_columns = ("OASIS_ID", "Assay", "Compound_name", "POD_um", "POD_um_l", "POD_um_u")
+    s2_book = _rows_to_frame(_first_xlsx_table(root, "paper/sources/table-s2.xlsx"), s2_columns, "Table S2")
+    s2_parts: list[pd.DataFrame] = []
+    for assay, key in (("MT", "mt"), ("Cell count", "cellcount"), ("LDH", "ldh")):
+        part = pods[key].copy()
+        part.insert(1, "Assay", assay)
+        s2_parts.append(part.loc[:, list(s2_columns)])
+    s2_compiled = pd.concat(s2_parts, ignore_index=True)
+    s2_key_columns = ("OASIS_ID", "Assay", "Compound_name")
+    s2_book_keys = _semantic_key(s2_book, s2_key_columns)
+    s2_compiled_keys = _semantic_key(s2_compiled, s2_key_columns)
+    _require(len(s2_book_keys) == len(set(s2_book_keys)), "Table S2 workbook has duplicate semantic keys")
+    _require(len(s2_compiled_keys) == len(set(s2_compiled_keys)), "Table S2 compiled data have duplicate semantic keys")
+    _confirm(set(s2_book_keys) == set(s2_compiled_keys), "Table S2 workbook and compiled semantic keys differ")
+    s2_book_index = {key: index for index, key in enumerate(s2_book_keys)}
+    s2_compiled_index = {key: index for index, key in enumerate(s2_compiled_keys)}
+    s2_max_difference = 0.0
+    for key in s2_book_index:
+        for column in ("POD_um", "POD_um_l", "POD_um_u"):
+            difference = abs(
+                float(s2_book.iloc[s2_book_index[key]][column])
+                - float(s2_compiled.iloc[s2_compiled_index[key]][column])
+            )
+            s2_max_difference = max(s2_max_difference, difference)
+    _confirm(s2_max_difference <= 1e-12, f"Table S2 numeric drift is {s2_max_difference}")
+
+    s3_columns = (
+        "OASIS_ID",
+        "Cell_representation",
+        "Compound_name",
+        "Assay_Endpoint",
+        "POD_um",
+        "POD_um_l",
+        "POD_um_u",
+        "Bioactivity_POD",
+    )
+    s3_book = _rows_to_frame(_first_xlsx_table(root, "paper/sources/table-s3.xlsx"), s3_columns, "Table S3")
+    # Style-only spreadsheet rows are removed by _xlsx_tables; every retained
+    # row must contain its representation and numerical payload.
+    _require(not (s3_book["Cell_representation"] == "").any(), "Table S3 contains an incomplete data row")
+    s3_parts = []
+    for representation, key in (("CellProfiler", "cellprofiler"), ("CP-CNN", "cpcnn"), ("DINO", "dino")):
+        part = pods[key].copy()
+        part.insert(1, "Cell_representation", representation)
+        s3_parts.append(part.loc[:, list(s3_columns)])
+    s3_compiled = pd.concat(s3_parts, ignore_index=True)
+    s3_key_columns = ("OASIS_ID", "Cell_representation", "Compound_name", "Assay_Endpoint")
+    s3_book_keys = _semantic_key(s3_book, s3_key_columns)
+    s3_compiled_keys = _semantic_key(s3_compiled, s3_key_columns)
+    _require(len(s3_book_keys) == len(set(s3_book_keys)), "Table S3 workbook has duplicate semantic keys")
+    _require(len(s3_compiled_keys) == len(set(s3_compiled_keys)), "Table S3 compiled data have duplicate semantic keys")
+    _confirm(set(s3_book_keys) == set(s3_compiled_keys), "Table S3 workbook and compiled semantic keys differ")
+    s3_book_index = {key: index for index, key in enumerate(s3_book_keys)}
+    s3_compiled_index = {key: index for index, key in enumerate(s3_compiled_keys)}
+    s3_max_difference = 0.0
+    s3_bioactivity_matches = 0
+    for key in s3_book_index:
+        left = s3_book.iloc[s3_book_index[key]]
+        right = s3_compiled.iloc[s3_compiled_index[key]]
+        for column in ("POD_um", "POD_um_l", "POD_um_u"):
+            s3_max_difference = max(s3_max_difference, abs(float(left[column]) - float(right[column])))
+        workbook_flag = left["Bioactivity_POD"] in (True, "1", 1)
+        s3_bioactivity_matches += int(workbook_flag == bool(right["Bioactivity_POD"]))
+    _confirm(s3_max_difference <= 1e-12, f"Table S3 numeric drift is {s3_max_difference}")
+    _confirm(s3_bioactivity_matches == len(s3_book), "Table S3 Bioactivity_POD flags differ")
+
+    s4_columns = (
+        "OASIS_ID",
+        "Compound_name",
+        "Cell_count_hit",
+        "MT_hit",
+        "LDH_hit",
+        "Cell_Painting_hit",
+        "Hit_in_all_assays",
+    )
+    s4_book = _rows_to_frame(_first_xlsx_table(root, "paper/sources/table-s4.xlsx"), s4_columns, "Table S4")
+    s4_keys = ("OASIS_ID", "Compound_name")
+    book_keys = _semantic_key(s4_book, s4_keys)
+    compiled_keys = _semantic_key(hit_summary, s4_keys)
+    _require(len(book_keys) == len(set(book_keys)), "Table S4 workbook has duplicate semantic keys")
+    _require(len(compiled_keys) == len(set(compiled_keys)), "Table S4 compiled data have duplicate semantic keys")
+    _confirm(set(book_keys) == set(compiled_keys), "Table S4 workbook and compiled semantic keys differ")
+    book_index = {key: index for index, key in enumerate(book_keys)}
+    compiled_index = {key: index for index, key in enumerate(compiled_keys)}
+    exact_rows = 0
+    for key in book_index:
+        left = s4_book.iloc[book_index[key]]
+        right = hit_summary.iloc[compiled_index[key]]
+        exact_rows += int(all(str(left[column]) == str(right[column]) for column in HIT_COLUMNS))
+    _confirm(exact_rows == len(s4_book), "Table S4 hit calls differ from compiled hit summary")
+    return {
+        "table_s2": {
+            "workbook_rows": len(s2_book),
+            "compiled_rows": len(s2_compiled),
+            "matched_semantic_keys": len(s2_book_keys),
+            "maximum_absolute_pod_difference": _native_float(s2_max_difference),
+        },
+        "table_s3": {
+            "workbook_rows": len(s3_book),
+            "compiled_rows": len(s3_compiled),
+            "matched_semantic_keys": len(s3_book_keys),
+            "bioactivity_flag_exact_rows": s3_bioactivity_matches,
+            "maximum_absolute_pod_difference": _native_float(s3_max_difference),
+        },
+        "table_s4": {
+            "workbook_rows": len(s4_book),
+            "compiled_rows": len(hit_summary),
+            "matched_semantic_keys": len(book_keys),
+            "all_hit_calls_exact_rows": exact_rows,
+        },
+    }
+
+
+def _pod_series(frame: pd.DataFrame, endpoint_mode: str) -> pd.Series:
+    if endpoint_mode == "global":
+        selected = frame[frame["Assay_Endpoint"] == "gmd"]
+    elif endpoint_mode == "categorical":
+        selected = frame[frame["Assay_Endpoint"] != "gmd"]
+    elif endpoint_mode == "general":
+        selected = frame
+    else:
+        raise AssertionError(endpoint_mode)
+    return selected.groupby(["OASIS_ID", "Compound_name"], dropna=False)["POD_um"].min().sort_index()
+
+
+def _paired_effect(left: pd.Series, right: pd.Series, *, log10: bool = False) -> dict[str, object]:
+    matched = pd.concat([left.rename("left"), right.rename("right")], axis=1, join="inner").dropna()
+    _require(not matched.empty, "paired analysis has no matched rows")
+    left_values = matched["left"].to_numpy(dtype=float)
+    right_values = matched["right"].to_numpy(dtype=float)
+    if log10:
+        _require(
+            bool((left_values > 0).all() and (right_values > 0).all()), "paired POD analysis has nonpositive values"
+        )
+        left_test = np.log10(left_values)
+        right_test = np.log10(right_values)
+    else:
+        left_test = left_values
+        right_test = right_values
+    test = ttest_rel(left_test, right_test)
+    statistic = None if not np.isfinite(test.statistic) else _native_float(test.statistic)
+    p_value = None if not np.isfinite(test.pvalue) else _native_float(test.pvalue)
+    return {
+        "matched_rows": len(matched),
+        "paired_t_statistic": statistic,
+        "paired_t_p_value": p_value,
+        "mean_difference": _native_float(np.mean(right_values - left_values)),
+        "median_difference": _native_float(np.median(right_values - left_values)),
+    }
+
+
+def _analyze_activity_pods(root: Path) -> dict[str, object]:
+    pod_paths = {
+        "mt": "2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv",
+        "cellcount": "2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv",
+        "ldh": "2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv",
+        "cellprofiler": "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv",
+        "cpcnn": "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv",
+        "dino": "2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv",
+    }
+    pods: dict[str, pd.DataFrame] = {}
+    for key, relative in pod_paths.items():
+        frame = _read_csv(root, relative)
+        expected_columns = POD_FILES[relative.split("compiled_results/")[1]]
+        _validate_columns(frame, expected_columns, relative)
+        semantic_keys = _semantic_key(frame, ("OASIS_ID", "Compound_name", "Assay_Endpoint"))
+        _require(len(semantic_keys) == len(set(semantic_keys)), f"{relative}: duplicate semantic key")
+        for column in ("POD_um", "POD_um_l", "POD_um_u"):
+            values = pd.to_numeric(frame[column], errors="coerce").to_numpy(dtype=float)
+            _require(bool(np.isfinite(values).all() and (values > 0).all()), f"{relative}: invalid {column}")
+        pods[key] = frame
+
+    hit_relative = "2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv"
+    hit_summary = _read_csv(root, hit_relative)
+    _validate_columns(hit_summary, HIT_SUMMARY_COLUMNS, hit_relative)
+    _require(
+        all(set(hit_summary[column].dropna().unique()) <= {"Yes", "No"} for column in HIT_COLUMNS),
+        "hit summary contains a value other than Yes/No",
+    )
+    hit_keys = _semantic_key(hit_summary, ("OASIS_ID", "Compound_name"))
+    _require(len(hit_keys) == len(set(hit_keys)), "hit summary contains duplicate semantic keys")
+
+    activity_evidence = _input_path(root, "paper/evidence/activity-and-figure-2a.md").read_text(encoding="utf-8")
+    bioactivity_evidence = _input_path(root, "paper/evidence/bioactivity-and-figure-2b-d.md").read_text(
+        encoding="utf-8"
+    )
+    method_evidence = _input_path(root, "paper/evidence/method-deviations.md").read_text(encoding="utf-8")
+    paper_text = _input_path(root, "paper/paper.md").read_text(encoding="utf-8")
+    fit_curves_text = _input_path(root, "1_snakemake/concresponse/fit_curves.R").read_text(encoding="utf-8")
+    fit_meta_text = _input_path(root, "1_snakemake/concresponse/fit_curves_meta.R").read_text(encoding="utf-8")
+    select_pod_text = _input_path(root, "1_snakemake/concresponse/select_pod.R").read_text(encoding="utf-8")
+
+    table_s2_counts = {
+        "MT": len(pods["mt"]),
+        "Cell count": len(pods["cellcount"]),
+        "LDH": len(pods["ldh"]),
+        "unique_compounds": len(
+            set(pods["mt"]["Compound_name"])
+            | set(pods["cellcount"]["Compound_name"])
+            | set(pods["ldh"]["Compound_name"])
+        ),
+    }
+    expected_s2_counts = {"MT": 429, "Cell count": 220, "LDH": 147, "unique_compounds": 437}
+    _confirm(
+        table_s2_counts == expected_s2_counts, f"Table S2 counts are {table_s2_counts}; expected {expected_s2_counts}"
+    )
+
+    figure_2a_expected = {
+        "Benzarone": 69.337144,
+        "Tiratricol": 25.860426,
+        "Tolcapone": 23.606292,
+        "2-Ethylanthracene-9,10-dione": 8.660848,
+    }
+    mt_by_name = pods["mt"].set_index("Compound_name")
+    figure_2a_rows: list[dict[str, object]] = []
+    for compound, expected_pod in figure_2a_expected.items():
+        _require(compound in mt_by_name.index, f"Figure 2A compound is absent from Table S2: {compound}")
+        row = mt_by_name.loc[compound]
+        _require(isinstance(row, pd.Series), f"Figure 2A compound is duplicated in Table S2: {compound}")
+        observed_pod = float(row["POD_um"])
+        _confirm(
+            abs(observed_pod - expected_pod) <= 1e-6,
+            f"Figure 2A Table S2 POD differs for {compound}: {observed_pod}",
+        )
+        figure_2a_rows.append(
+            {
+                "compound": compound,
+                "pod_um": _native_float(observed_pod),
+                "expected_published_pod_um": expected_pod,
+            }
+        )
+    _confirm(
+        all(compound in activity_evidence for compound in figure_2a_expected)
+        and "increasing direction" in activity_evidence,
+        "Figure 2A compound or direction trace is incomplete",
+    )
+
+    direction_aware_trace = {
+        "count": 429,
+        "definition": "decreased MT union decreased cell count union increased LDH",
+        "documented_in_tracked_evidence": all(
+            token in activity_evidence
+            for token in (
+                "identical 429-compound direction-aware cytotoxic set",
+                "decreased MT, decreased cell count, and increased LDH",
+            )
+        ),
+        "directly_encoded_in_hit_summary": False,
+        "mt_increasing_count": 10,
+        "mt_increasing_count_documented": "MT increasing |" in activity_evidence
+        and "| Camera-ready text | 430 | 221 | 144 | 438 | 429 | 10 |" in activity_evidence,
+    }
+    _confirm(
+        bool(direction_aware_trace["documented_in_tracked_evidence"]),
+        "direction-aware 429-compound trace is missing",
+    )
+
+    morphology_counts: dict[str, object] = {}
+    morphology_series: dict[str, pd.Series] = {}
+    for representation in ("cellprofiler", "cpcnn", "dino"):
+        morphology_counts[representation] = {}
+        for mode in ("global", "categorical", "general"):
+            series = _pod_series(pods[representation], mode)
+            morphology_series[f"{representation}_{mode}"] = series
+            morphology_counts[representation][mode] = {
+                "count": len(series),
+                "median_pod_um": None if series.empty else _native_float(series.median()),
+            }
+    expected_morphology = {
+        "cellprofiler": {"global": 169, "categorical": 598, "general": 607},
+        "cpcnn": {"global": 539, "categorical": 0, "general": 539},
+        "dino": {"global": 545, "categorical": 626, "general": 644},
+    }
+    observed_morphology = {
+        representation: {
+            mode: int(morphology_counts[representation][mode]["count"]) for mode in expected_morphology[representation]
+        }
+        for representation in expected_morphology
+    }
+    _confirm(observed_morphology == expected_morphology, "morphology activity counts differ from tracked SI contract")
+    morphology_activity_summary = {
+        representation: {
+            mode: {
+                "count": observed_morphology[representation][mode],
+                "fraction_of_1085": _native_float(observed_morphology[representation][mode] / 1_085),
+            }
+            for mode in ("global", "categorical", "general")
+        }
+        for representation in ("cellprofiler", "cpcnn", "dino")
+    }
+    published_si_count_order = [
+        f"{representation}_{mode}"
+        for representation, mode in sorted(
+            (
+                (representation, mode)
+                for representation in ("cellprofiler", "cpcnn", "dino")
+                for mode in ("global", "categorical", "general")
+            ),
+            key=lambda item: observed_morphology[item[0]][item[1]],
+        )
+    ]
+
+    complete = pd.concat(
+        {
+            key: morphology_series[key]
+            for key in (
+                "cellprofiler_global",
+                "cellprofiler_categorical",
+                "dino_global",
+                "dino_categorical",
+                "cpcnn_global",
+            )
+        },
+        axis=1,
+        join="inner",
+    ).dropna()
+    _confirm(len(complete) == 156, f"Figure 2C tracked complete-case count is {len(complete)}; expected 156")
+    representation_complete_case = {
+        "count": len(complete),
+        "median_pod_um": {column: _native_float(complete[column].median()) for column in complete.columns},
+        "paired_log10_tests": {
+            "cellprofiler_global_vs_dino_global": _paired_effect(
+                complete["cellprofiler_global"], complete["dino_global"], log10=True
+            ),
+            "cellprofiler_categorical_vs_dino_categorical": _paired_effect(
+                complete["cellprofiler_categorical"], complete["dino_categorical"], log10=True
+            ),
+            "dino_global_vs_cpcnn_global": _paired_effect(
+                complete["dino_global"], complete["cpcnn_global"], log10=True
+            ),
+        },
+        "camera_ready_count_trace": 342,
+        "source_si_count_deviation": 342 - len(complete),
+    }
+    expected_five_series_order = [
+        "cellprofiler_categorical",
+        "dino_categorical",
+        "dino_global",
+        "cpcnn_global",
+        "cellprofiler_global",
+    ]
+    representation_complete_case["median_order"] = sorted(
+        representation_complete_case["median_pod_um"],
+        key=lambda name: representation_complete_case["median_pod_um"][name],
+    )
+    representation_complete_case["finite_nonempty_pod_summaries"] = bool(
+        len(complete) > 0
+        and len(representation_complete_case["median_pod_um"]) == 5
+        and all(np.isfinite(value) and value > 0 for value in representation_complete_case["median_pod_um"].values())
+    )
+    representation_complete_case["camera_ready_order_trace"] = expected_five_series_order
+    representation_complete_case["ordering_preserved"] = (
+        representation_complete_case["median_order"] == expected_five_series_order
+        and "reports 342 compounds" in bioactivity_evidence
+    )
+    _confirm(
+        bool(representation_complete_case["ordering_preserved"])
+        and bool(representation_complete_case["finite_nonempty_pod_summaries"]),
+        "Figure 2C source-SI ordering or camera-ready trace differs",
+    )
+
+    general_complete = pd.concat(
+        {
+            "cellprofiler": morphology_series["cellprofiler_general"],
+            "cpcnn": morphology_series["cpcnn_general"],
+            "dino": morphology_series["dino_general"],
+        },
+        axis=1,
+        join="inner",
+    ).dropna()
+    _confirm(len(general_complete) == 488, f"three-general complete count is {len(general_complete)}; expected 488")
+    cpcnn_cellprofiler_ratio = float(
+        10 ** np.mean(np.log10(general_complete["cpcnn"]) - np.log10(general_complete["cellprofiler"]))
+    )
+    cpcnn_dino_ratio = float(10 ** np.mean(np.log10(general_complete["cpcnn"]) - np.log10(general_complete["dino"])))
+    general_cp_dino_test = _paired_effect(general_complete["cellprofiler"], general_complete["dino"], log10=True)
+    _confirm(abs(cpcnn_cellprofiler_ratio - 1.8181) <= 5e-5, "three-general CP-CNN/CellProfiler ratio drifted")
+    _confirm(abs(cpcnn_dino_ratio - 1.6865) <= 5e-5, "three-general CP-CNN/DINO ratio drifted")
+    _confirm(
+        general_cp_dino_test["paired_t_p_value"] is not None
+        and abs(float(general_cp_dino_test["paired_t_p_value"]) - 0.261) <= 5e-4,
+        "three-general CellProfiler/DINO paired test drifted",
+    )
+    three_general = {
+        "count": len(general_complete),
+        "geometric_fold_ratios": {
+            "cpcnn_over_cellprofiler": _native_float(cpcnn_cellprofiler_ratio),
+            "cpcnn_over_dino": _native_float(cpcnn_dino_ratio),
+        },
+        "cellprofiler_vs_dino_paired_log10": general_cp_dino_test,
+    }
+
+    all_hits = hit_summary.loc[hit_summary["Hit_in_all_assays"] == "Yes", ["OASIS_ID", "Compound_name"]]
+    dino_general = morphology_series["dino_general"].rename("Morphology").reset_index()
+    figure_2d_frame = all_hits.merge(dino_general, on=["OASIS_ID", "Compound_name"], validate="one_to_one")
+    assay_columns: dict[str, str] = {}
+    for key, display in (("mt", "MT"), ("cellcount", "Cell count"), ("ldh", "LDH")):
+        assay_columns[key] = display
+        frame = pods[key].loc[:, ["OASIS_ID", "Compound_name", "POD_um"]].rename(columns={"POD_um": display})
+        figure_2d_frame = figure_2d_frame.merge(frame, on=["OASIS_ID", "Compound_name"], validate="one_to_one")
+    _confirm(len(figure_2d_frame) == 121, f"Figure 2D complete-case count is {len(figure_2d_frame)}; expected 121")
+    medians = {
+        column: _native_float(figure_2d_frame[column].median()) for column in ("Morphology", *assay_columns.values())
+    }
+    fold_ratios: dict[str, float] = {}
+    paired_tests: dict[str, object] = {}
+    for key, display in assay_columns.items():
+        log_difference = np.log10(figure_2d_frame[display]) - np.log10(figure_2d_frame["Morphology"])
+        fold_ratios[key] = _native_float(10 ** log_difference.mean())
+        paired_tests[key] = _paired_effect(figure_2d_frame["Morphology"], figure_2d_frame[display], log10=True)
+    expected_folds = {"mt": 1.7855047048534651, "cellcount": 4.281272280160607, "ldh": 8.153719681891124}
+    _confirm(
+        all(abs(fold_ratios[key] - expected) <= 1e-12 for key, expected in expected_folds.items()),
+        f"Figure 2D fold ratios differ from tracked contract: {fold_ratios}",
+    )
+    figure_2d = {
+        "complete_case_count": len(figure_2d_frame),
+        "median_pod_um": medians,
+        "geometric_fold_ratio_vs_morphology": fold_ratios,
+        "paired_log10_t_tests": paired_tests,
+    }
+    supplemental_tables = _supplemental_table_audit(root, pods, hit_summary)
+    pod_method_trace = {
+        "morphology_residual_sd_selection": 'filt.var = "SDres"' in fit_curves_text,
+        "paired_assay_scorespod_default": "scoresPOD(cc, dose" in fit_meta_text,
+        "dmso_control": 'ctrl <- "DMSO"' in fit_curves_text and 'ctrl <- "DMSO"' in fit_meta_text,
+        "compound_minimum_pod": "Select POD as minimum BMD" in select_pod_text,
+        "known_selection_deviation_traced": "lowest residual standard deviation" in method_evidence
+        and "rounded-AIC" in method_evidence,
+        "documented_eight_model_names": all(
+            model in paper_text for model in ("Exp2", "Exp3", "Exp4", "Exp5", "Poly2", "Lin", "Power", "Hill")
+        )
+        and "eight model families" in method_evidence,
+        "documented_dmso_95th_percentile_benchmark": "95th percentile of Mahalanobis distances (MDs) from DMSO controls"
+        in paper_text
+        and "DMSO 95th-percentile benchmark response" in method_evidence,
+        "documented_ci_ratio_threshold_40": "ratio between the upper and lower 95th confidence intervals was greater than 40"
+        in paper_text
+        and "confidence-interval ratio filtering" in method_evidence,
+        "documented_highest_tested_concentration_filter": "benchmark dose was higher than the highest tested concentration"
+        in paper_text
+        and "tested-concentration filtering" in method_evidence,
+    }
+    _confirm(all(pod_method_trace.values()), "POD method implementation trace is incomplete")
+    conclusion_gates = {
+        "general_morphology_count_exceeds_mt": min(
+            int(morphology_counts[name]["general"]["count"]) for name in ("cellprofiler", "cpcnn", "dino")
+        )
+        > table_s2_counts["MT"],
+        "complete_case_median_order": medians["Morphology"] < medians["MT"] < medians["Cell count"] < medians["LDH"],
+    }
+    _confirm(all(conclusion_gates.values()), "morphology sensitivity conclusion inequality failed")
+    return {
+        "table_s2_counts": table_s2_counts,
+        "morphology_counts": morphology_counts,
+        "morphology_activity_summary": morphology_activity_summary,
+        "published_si_count_order": published_si_count_order,
+        "figure_2a": {
+            "rows": figure_2a_rows,
+            "compound_names": list(figure_2a_expected),
+            "direction": "increasing MT",
+        },
+        "direction_aware_cytotoxicity": direction_aware_trace,
+        "figure_2c_complete_case": representation_complete_case,
+        "figure_2c_three_general": three_general,
+        "figure_2d": figure_2d,
+        "supplemental_tables": supplemental_tables,
+        "hit_summary_counts": {column: int((hit_summary[column] == "Yes").sum()) for column in HIT_COLUMNS},
+        "pod_method_trace": pod_method_trace,
+        "conclusion_gates": conclusion_gates,
+    }
+
+
+def _analyze_regression_enrichment(root: Path) -> dict[str, object]:
+    configurations = (
+        ("err_higher_targets.csv", 304),
+        ("err_lower_targets.csv", 138),
+        ("mtt_higher_targets.csv", 261),
+        ("mtt_lower_targets.csv", 131),
+    )
+    expected_significant = {
+        "err_higher_targets.csv": 178,
+        "err_lower_targets.csv": 0,
+        "mtt_higher_targets.csv": 147,
+        "mtt_lower_targets.csv": 107,
+    }
+    reports: dict[str, object] = {}
+    significant_targets: dict[str, set[str]] = {}
+    for filename, configured_hit_size in configurations:
+        relative = f"2_downstream_analysis/compiled_results/{filename}"
+        frame = _read_csv(root, relative)
+        base_columns = {"target_set", "overlap_size", "target_set_size", "p_value", "fdr", "overlap_hits"}
+        expected_columns = (
+            base_columns | {"hit_list_size", "universe_size"} if filename.startswith("err_") else base_columns
+        )
+        _validate_columns(frame, expected_columns, relative)
+        _require(not frame["target_set"].duplicated().any(), f"{filename}: duplicate target_set")
+        _confirm(len(frame) == EXPECTED_ENRICHMENT_ROWS, f"{filename}: row count is {len(frame)}; expected 8858")
+
+        overlap = pd.to_numeric(frame["overlap_size"], errors="coerce").to_numpy(dtype=float)
+        target_size = pd.to_numeric(frame["target_set_size"], errors="coerce").to_numpy(dtype=float)
+        stored_p = pd.to_numeric(frame["p_value"], errors="coerce").to_numpy(dtype=float)
+        stored_fdr = pd.to_numeric(frame["fdr"], errors="coerce").to_numpy(dtype=float)
+        _require(
+            bool(np.isfinite(overlap).all() and np.equal(overlap, np.floor(overlap)).all()),
+            f"{filename}: invalid overlap_size",
+        )
+        _require(
+            bool(np.isfinite(target_size).all() and np.equal(target_size, np.floor(target_size)).all()),
+            f"{filename}: invalid target_set_size",
+        )
+        _require(
+            bool(np.isfinite(stored_p).all() and ((stored_p >= 0) & (stored_p <= 1)).all()),
+            f"{filename}: invalid p_value",
+        )
+        _require(
+            bool(np.isfinite(stored_fdr).all() and ((stored_fdr >= 0) & (stored_fdr <= 1)).all()),
+            f"{filename}: invalid fdr",
+        )
+        universe_size = EXPECTED_ENRICHMENT_UNIVERSE
+        hit_list_size = configured_hit_size
+        if filename.startswith("err_"):
+            universe_values = pd.to_numeric(frame["universe_size"], errors="coerce").to_numpy(dtype=float)
+            hit_values = pd.to_numeric(frame["hit_list_size"], errors="coerce").to_numpy(dtype=float)
+            _require(
+                bool(np.isfinite(universe_values).all() and len(set(universe_values)) == 1),
+                f"{filename}: invalid universe_size",
+            )
+            _require(
+                bool(np.isfinite(hit_values).all() and len(set(hit_values)) == 1), f"{filename}: invalid hit_list_size"
+            )
+            universe_size = int(universe_values[0])
+            hit_list_size = int(hit_values[0])
+        _confirm(
+            universe_size == EXPECTED_ENRICHMENT_UNIVERSE, f"{filename}: universe is {universe_size}; expected 13176"
+        )
+        _confirm(
+            hit_list_size == configured_hit_size,
+            f"{filename}: hit-list size is {hit_list_size}; expected {configured_hit_size}",
+        )
+        _require(
+            bool(
+                ((overlap >= 0) & (target_size >= 1) & (target_size <= universe_size)).all()
+                and (overlap <= target_size).all()
+                and (overlap <= hit_list_size).all()
+            ),
+            f"{filename}: invalid hypergeometric cardinalities",
+        )
+        recomputed_p = hypergeom.sf(
+            overlap.astype(np.int64) - 1,
+            universe_size,
+            target_size.astype(np.int64),
+            hit_list_size,
+        )
+        recomputed_fdr = multipletests(recomputed_p, method="fdr_bh", is_sorted=False)[1]
+        max_p_error = float(np.max(np.abs(stored_p - recomputed_p)))
+        max_fdr_error = float(np.max(np.abs(stored_fdr - recomputed_fdr)))
+        _confirm(max_p_error <= 2e-14, f"{filename}: hypergeometric p-values do not reproduce")
+        _confirm(max_fdr_error <= 2e-14, f"{filename}: BH FDR values do not reproduce")
+        significant_count = int((stored_fdr < 0.05).sum())
+        _confirm(
+            significant_count == expected_significant[filename],
+            f"{filename}: significant count is {significant_count}; expected {expected_significant[filename]}",
+        )
+        significant_targets[filename] = set(frame.loc[stored_fdr < 0.05, "target_set"].astype(str))
+        reports[filename] = {
+            "rows": len(frame),
+            "hit_list_size": hit_list_size,
+            "universe_size": universe_size,
+            "significant_count": significant_count,
+            "minimum_p_value": _native_float(stored_p.min()),
+            "minimum_fdr": _native_float(stored_fdr.min()),
+            "maximum_p_value_recomputation_error": _native_float(max_p_error),
+            "maximum_fdr_recomputation_error": _native_float(max_fdr_error),
+        }
+    regression_text = _input_path(root, "1_snakemake/classifier/regression.py").read_text(encoding="utf-8")
+    paper_text = _input_path(root, "paper/paper.md").read_text(encoding="utf-8")
+    regression_notebook = _input_path(
+        root, "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb"
+    ).read_text(encoding="utf-8")
+    well_effects_notebook = _input_path(
+        root, "2_downstream_analysis/other_notebooks/01_checkwelleffects.ipynb"
+    ).read_text(encoding="utf-8")
+    regression_evidence = _input_path(root, "paper/evidence/regression-and-figure-s2.md").read_text(encoding="utf-8")
+    prediction_evidence = _input_path(root, "paper/evidence/prediction-error-enrichment.md").read_text(encoding="utf-8")
+    mt_evidence = _input_path(root, "paper/evidence/mt-discrepancy-enrichment.md").read_text(encoding="utf-8")
+    method_evidence = _input_path(root, "paper/evidence/method-deviations.md").read_text(encoding="utf-8")
+
+    higher = significant_targets["mtt_higher_targets.csv"]
+    lower = significant_targets["mtt_lower_targets.csv"]
+    transporters = [target for target in ("ABCB1", "ABCG2", "SLCO1B1", "SLCO1B3") if target in higher]
+    significant_classes = {
+        "mtt_higher": {
+            "cyp_prefix_count": sum(target.startswith("CYP") for target in higher),
+            "htr_prefix_count": sum(target.startswith("HTR") for target in higher),
+            "transporters_present": transporters,
+        },
+        "mtt_lower": {
+            "psm_prefix_count": sum(target.startswith("PSM") for target in lower),
+            "cyp_prefix_count": sum(target.startswith("CYP") for target in lower),
+        },
+    }
+    _confirm(
+        significant_classes["mtt_higher"]
+        == {
+            "cyp_prefix_count": 8,
+            "htr_prefix_count": 6,
+            "transporters_present": ["ABCB1", "ABCG2", "SLCO1B1", "SLCO1B3"],
+        },
+        "MT-higher significant target classes differ",
+    )
+    _confirm(
+        significant_classes["mtt_lower"] == {"psm_prefix_count": 18, "cyp_prefix_count": 3},
+        "MT-lower significant target classes differ",
+    )
+    regression_trace = {
+        "group_shuffle_split_count": 10,
+        "test_fraction": 0.2,
+        "compound_group_isolation": "GroupShuffleSplit(n_splits=10, test_size=0.2, random_state=42)" in regression_text
+        and '"Metadata_Compound"' in regression_text,
+        "prediction_artifacts_available": False,
+        "numerical_acceptance_rerun": False,
+        "table_1_documentary": all(
+            token in paper_text + regression_notebook + regression_evidence
+            for token in ("Prediction of paired cytotoxicity", "Metadata_ldh_ridge_norm", "Metadata_mtt_ridge_norm")
+        ),
+        "relative_performance_documentary": all(
+            token in regression_evidence for token in ("practically similar", "technical baseline", "LDH MAE")
+        ),
+        "replicate_effect_documentary": all(
+            token in regression_evidence for token in ("0.2037579853", "1.88446103266e-14")
+        ),
+        "sfig2_documentary": all(
+            token in paper_text + regression_notebook + well_effects_notebook + regression_evidence
+            for token in ("well", "cell count", "DINO", "cluster")
+        ),
+        "err_480_acceptance_available": False,
+        "err_304_acceptance_available": False,
+        "mechanism_claim_is_hypothesis": "testable hypotheses rather than definitive mechanisms" in paper_text,
+        "historical_enrichment_provenance": "304 historical" in prediction_evidence and "261 Higher" in mt_evidence,
+        "method_deviation_traced": "GroupShuffleSplit" in method_evidence,
+    }
+    _confirm(
+        all(
+            bool(regression_trace[key])
+            for key in (
+                "compound_group_isolation",
+                "table_1_documentary",
+                "relative_performance_documentary",
+                "replicate_effect_documentary",
+                "sfig2_documentary",
+                "mechanism_claim_is_hypothesis",
+                "historical_enrichment_provenance",
+                "method_deviation_traced",
+            )
+        ),
+        "regression or enrichment documentary trace is missing",
+    )
+    return {
+        "files": reports,
+        "significant_classes": significant_classes,
+        "regression_trace": regression_trace,
+        "limitations": [
+            "Tracked enrichment tables permit direct reanalysis; regression predictions and metrics are not tracked.",
+            "Enrichment is an association conditional on selected exposure wells and does not establish mechanism.",
+        ],
+    }
+
+
+def _binary_summary(frame: pd.DataFrame, label: str) -> dict[str, object]:
+    _require(frame.columns[0] == "OASIS_ID", f"{label}: first column must be OASIS_ID")
+    _require(not frame["OASIS_ID"].isna().any(), f"{label}: null OASIS_ID")
+    _require(not frame["OASIS_ID"].duplicated().any(), f"{label}: duplicate OASIS_ID")
+    values = frame.iloc[:, 1:].to_numpy(dtype=float)
+    observed = np.isfinite(values)
+    _require(bool(np.isin(values[observed], [0.0, 1.0]).all()), f"{label}: binary matrix has values outside 0/1/null")
+    active = int(values[observed].sum())
+    observed_count = int(observed.sum())
+    endpoint_fractions = [
+        float(frame[column].dropna().mean()) for column in frame.columns[1:] if frame[column].notna().any()
+    ]
+    endpoint_observed = [int(frame[column].notna().sum()) for column in frame.columns[1:]]
+    return {
+        "compound_rows": len(frame),
+        "unique_ids": int(frame["OASIS_ID"].nunique()),
+        "endpoint_count": frame.shape[1] - 1,
+        "observed_values": observed_count,
+        "active_values": active,
+        "active_fraction": _native_float(active / observed_count),
+        "median_endpoint_observed_compounds": _native_float(np.median(endpoint_observed)),
+        "median_endpoint_active_fraction": _native_float(np.median(endpoint_fractions)),
+    }
+
+
+def _analyze_table_s5(
+    root: Path, cellbased_info: pd.DataFrame, cytotox_info: pd.DataFrame, cytotox_binary: pd.DataFrame
+) -> dict[str, object]:
+    rows = _first_xlsx_table(root, "paper/sources/table-s5.xlsx")
+    required = {"NAME", "GENE_SYMBOL", "HIT_CALL", "AC50", "INTENDED_TARGET_FAMILY", "REPR"}
+    _require(bool(rows) and required <= set(rows[0]), "Table S5 is missing required columns")
+    _confirm(len(rows) == 22, f"Table S5 has {len(rows)} rows; expected 22")
+    _confirm(all(str(row["HIT_CALL"]) == "Active" for row in rows), "Table S5 contains a non-active row")
+    _confirm(all(row["REPR"] in (True, "1", 1) for row in rows), "Table S5 contains REPR != TRUE")
+    nuclear = [row for row in rows if str(row["INTENDED_TARGET_FAMILY"]) == "nuclear receptor"]
+    _confirm(len(nuclear) == 12, f"Table S5 has {len(nuclear)} nuclear-receptor assays; expected 12")
+    nuclear_ac50 = np.asarray([float(row["AC50"]) for row in nuclear], dtype=float)
+    workbook_by_endpoint = {str(row["NAME"]): row for row in rows}
+    _require(len(workbook_by_endpoint) == len(rows), "Table S5 contains duplicate endpoint names")
+
+    compound_info = cellbased_info[cellbased_info["OASIS_ID"] == "OASIS483"].copy()
+    _confirm(len(compound_info) == 87, f"OASIS483 has {len(compound_info)} pinned cell-based endpoints; expected 87")
+    _require(
+        not compound_info["assay_component_endpoint_name"].duplicated().any(), "OASIS483 has duplicate pinned endpoints"
+    )
+    info_by_endpoint = compound_info.set_index("assay_component_endpoint_name")
+    retained = sorted(set(workbook_by_endpoint) & set(info_by_endpoint.index))
+    retained_nuclear = sorted({str(row["NAME"]) for row in nuclear} & set(info_by_endpoint.index))
+    ac50_differences = [
+        abs(float(workbook_by_endpoint[endpoint]["AC50"]) - float(info_by_endpoint.at[endpoint, "ac50"]))
+        for endpoint in retained
+    ]
+    _confirm(len(retained) == 15, f"Table S5 retains {len(retained)} pinned endpoints; expected 15")
+    _confirm(
+        len(retained_nuclear) == 8, f"Table S5 retains {len(retained_nuclear)} nuclear-receptor endpoints; expected 8"
+    )
+    _confirm(
+        all(float(info_by_endpoint.at[endpoint, "hitcall"]) > 0.9 for endpoint in retained),
+        "retained Table S5 endpoint has hitcall <= 0.9",
+    )
+    max_ac50_difference = max(ac50_differences)
+    _confirm(max_ac50_difference <= 1e-6, "Table S5 and pinned endpoint AC50 values differ materially")
+
+    cytotox_rows = cytotox_info[cytotox_info["OASIS_ID"] == "OASIS483"]
+    source_tests = int(cytotox_rows["ntested"].sum())
+    source_hits = int(cytotox_rows["nhit"].sum())
+    _confirm(source_tests == 102 and source_hits == 0, "OASIS483 cytotoxicity source-test audit differs")
+    binary_row = cytotox_binary[cytotox_binary["OASIS_ID"] == "OASIS483"]
+    _confirm(len(binary_row) == 1, "OASIS483 is absent or duplicated in cytotoxicity binary matrix")
+    binary_values = binary_row.iloc[0, 1:].dropna().to_numpy(dtype=float)
+    _confirm(len(binary_values) == 19 and int(binary_values.sum()) == 0, "OASIS483 cytotoxicity binary audit differs")
+    _confirm("TOX21_MMP_ratio" in info_by_endpoint.index, "OASIS483 MMP endpoint is absent")
+    mmp = info_by_endpoint.loc["TOX21_MMP_ratio"]
+    _confirm(float(mmp["hitcall"]) > 0.9, "OASIS483 MMP endpoint is not active")
+    return {
+        "workbook_rows": len(rows),
+        "nuclear_receptor_assays": len(nuclear),
+        "nuclear_receptor_ac50_min_um": _native_float(nuclear_ac50.min()),
+        "nuclear_receptor_ac50_max_um": _native_float(nuclear_ac50.max()),
+        "retained_endpoints": len(retained),
+        "retained_nuclear_receptor_assays": len(retained_nuclear),
+        "maximum_shared_ac50_difference_um": _native_float(max_ac50_difference),
+        "cytotoxicity_categories": len(cytotox_rows),
+        "cytotoxicity_source_tests": source_tests,
+        "cytotoxicity_source_hits": source_hits,
+        "cytotoxicity_binary_observed": len(binary_values),
+        "cytotoxicity_binary_active": int(binary_values.sum()),
+        "mmp_hitcall": _native_float(mmp["hitcall"]),
+        "mmp_ac50_um": _native_float(mmp["ac50"]),
+    }
+
+
+def _analyze_toxcast(root: Path) -> dict[str, object]:
+    binary_frames: dict[str, pd.DataFrame] = {}
+    info_frames: dict[str, pd.DataFrame] = {}
+    matrix_summaries: dict[str, object] = {}
+    source_activity: dict[str, object] = {}
+    for category in ("cellbased", "cellfree", "cytotox"):
+        binary_relative = f"1_snakemake/inputs/annotations/toxcast_{category}_binary.parquet"
+        info_relative = f"1_snakemake/inputs/annotations/toxcast_{category}_info.parquet"
+        binary = _read_parquet(root, binary_relative)
+        info = _read_parquet(root, info_relative)
+        binary_frames[category] = binary
+        info_frames[category] = info
+        matrix_summaries[category] = _binary_summary(binary, binary_relative)
+        if category == "cytotox":
+            required = {"OASIS_ID", "assay_label", "ntested", "nhit", "cytotox_median_ac50"}
+            _require(required <= set(info.columns), "cytotoxicity info is missing required columns")
+            positive_ac50 = info.loc[info["cytotox_median_ac50"].notna(), "cytotox_median_ac50"]
+            source_activity[category] = {
+                "rows": len(info),
+                "endpoint_count": int(info["assay_label"].nunique()),
+                "rows_with_source_hits": int((info["nhit"] > 0).sum()),
+                "positive_consensus_ac50_count": len(positive_ac50),
+                "median_positive_ac50_um": _native_float(positive_ac50.median()),
+            }
+        else:
+            required = {"OASIS_ID", "assay_component_endpoint_name", "hitcall", "ac50"}
+            _require(required <= set(info.columns), f"{category} info is missing required columns")
+            active = info["hitcall"] > 0.9
+            positive_ac50 = info.loc[active & info["ac50"].notna(), "ac50"]
+            source_activity[category] = {
+                "rows": len(info),
+                "endpoint_count": int(info["assay_component_endpoint_name"].nunique()),
+                "active_rows": int(active.sum()),
+                "positive_ac50_count": len(positive_ac50),
+                "median_positive_ac50_um": _native_float(positive_ac50.median()),
+            }
+
+    source_endpoint_counts = {
+        "cellbased": int(info_frames["cellbased"]["assay_component_endpoint_name"].nunique()),
+        "cellfree": int(info_frames["cellfree"]["assay_component_endpoint_name"].nunique()),
+        "cytotox": int(info_frames["cytotox"]["assay_label"].nunique()),
+    }
+    binary_endpoint_counts = {category: frame.shape[1] - 1 for category, frame in binary_frames.items()}
+    expected_source = {"cellbased": 292, "cellfree": 72, "cytotox": 48}
+    expected_binary = {"cellbased": 292, "cellfree": 72, "cytotox": 38}
+    _confirm(
+        source_endpoint_counts == expected_source, f"ToxCast source endpoint counts differ: {source_endpoint_counts}"
+    )
+    _confirm(
+        binary_endpoint_counts == expected_binary, f"ToxCast binary endpoint counts differ: {binary_endpoint_counts}"
+    )
+    union_ids = len(set().union(*(set(frame["OASIS_ID"].astype(str)) for frame in binary_frames.values())))
+    _confirm(union_ids == 963, f"ToxCast binary ID union is {union_ids}; expected 963")
+
+    cellbased_info = info_frames["cellbased"]
+    cellfree_info = info_frames["cellfree"]
+    cellbased_tissue_counts = cellbased_info.groupby("tissue")["assay_component_endpoint_name"].nunique().to_dict()
+    cellfree_type_counts = (
+        cellfree_info.groupby("assay_function_type")["assay_component_endpoint_name"].nunique().to_dict()
+    )
+    cellfree_family_counts = (
+        cellfree_info.groupby("intended_target_family")["assay_component_endpoint_name"].nunique().to_dict()
+    )
+    composition = {
+        "cellbased_tissues": {name: int(cellbased_tissue_counts[name]) for name in ("liver", "vascular", "kidney")},
+        "cellfree_assay_types": {name: int(cellfree_type_counts[name]) for name in ("binding", "enzymatic activity")},
+        "cellfree_target_families": {
+            name: int(cellfree_family_counts[name]) for name in ("gpcr", "cyp", "nuclear receptor")
+        },
+    }
+    expected_composition = {
+        "cellbased_tissues": {"liver": 151, "vascular": 63, "kidney": 35},
+        "cellfree_assay_types": {"binding": 37, "enzymatic activity": 35},
+        "cellfree_target_families": {"gpcr": 21, "cyp": 11, "nuclear receptor": 10},
+    }
+    _confirm(composition == expected_composition, f"ToxCast endpoint composition differs: {composition}")
+
+    endpoint_medians = {
+        "observed_compounds": {
+            category: int(matrix_summaries[category]["median_endpoint_observed_compounds"])
+            for category in ("cytotox", "cellbased", "cellfree")
+        },
+        "active_fraction": {
+            category: matrix_summaries[category]["median_endpoint_active_fraction"]
+            for category in ("cytotox", "cellbased", "cellfree")
+        },
+    }
+    _confirm(
+        endpoint_medians["observed_compounds"] == {"cytotox": 346, "cellbased": 306, "cellfree": 33},
+        "ToxCast median endpoint coverage differs",
+    )
+    expected_fractions = {
+        "cytotox": 0.20683488012374324,
+        "cellbased": 0.071161355334425,
+        "cellfree": 0.4134295227524972,
+    }
+    _confirm(
+        all(
+            abs(float(endpoint_medians["active_fraction"][category]) - expected) <= 1e-12
+            for category, expected in expected_fractions.items()
+        ),
+        "ToxCast median endpoint activity fractions differ",
+    )
+
+    cytotox_binary = binary_frames["cytotox"]
+    heatmap_columns = [
+        column for column in cytotox_binary.columns[1:] if int(cytotox_binary[column].notna().sum()) > 800
+    ]
+    heatmap_summary = {
+        "cell_categories": sum(column.startswith("cell_type__") for column in heatmap_columns),
+        "tissue_categories": sum(column.startswith("tissue__") for column in heatmap_columns),
+        "complete_compounds": int(cytotox_binary[heatmap_columns].notna().all(axis=1).sum()),
+    }
+    _confirm(
+        heatmap_summary == {"cell_categories": 12, "tissue_categories": 6, "complete_compounds": 839},
+        f"ToxCast heatmap substrate differs: {heatmap_summary}",
+    )
+
+    paper_text = _input_path(root, "paper/paper.md").read_text(encoding="utf-8")
+    toxcast_notebook = _input_path(
+        root, "2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb"
+    ).read_text(encoding="utf-8")
+    toxcast_evidence = _input_path(root, "paper/evidence/toxcast-curation-and-figure-s3.md").read_text(encoding="utf-8")
+    documented_tested_intersection = {
+        "ids": 670,
+        "percent_of_published_library": _native_float(100 * 670 / 1_085),
+        "documented_in_tracked_evidence": all(
+            token in toxcast_evidence
+            for token in ("Only 670 tested OASIS IDs", "`670 / 1,085 = 61.751152%`", "not 89%")
+        ),
+    }
+    annotation_union_not_tested_library_join = all(
+        token in toxcast_evidence
+        for token in (
+            "does not intersect that 963-ID union with the tested-compound metadata",
+            "not a tested-library intersection",
+        )
+    )
+    _confirm(
+        bool(documented_tested_intersection["documented_in_tracked_evidence"])
+        and annotation_union_not_tested_library_join,
+        "ToxCast annotation-union and tested-library-intersection trace is incomplete",
+    )
+    method_trace = {
+        "hitcall_strictly_above_0_9": "hitcall > 0.9" in toxcast_evidence,
+        "cytotoxicity_consensus_20_percent": "nhit / ntested >= 0.2" in toxcast_evidence,
+        "median_positive_ac50": "median AC50" in paper_text and "median AC50" in toxcast_evidence,
+        "minimum_five_positive_and_negative": "fewer than five positive and negative" in paper_text
+        and "minimum 5 positive" in toxcast_evidence,
+        "notebook_reads_pinned_parquets": "toxcast_cellbased" in toxcast_notebook
+        and "toxcast_cellfree" in toxcast_notebook,
+        "specific_endpoint_100_um_deviation_traced": "100 uM rule" in toxcast_evidence,
+    }
+    _confirm(all(method_trace.values()), "ToxCast method trace is incomplete")
+    table_s5 = _analyze_table_s5(root, info_frames["cellbased"], info_frames["cytotox"], binary_frames["cytotox"])
+    return {
+        "source_endpoint_counts": source_endpoint_counts,
+        "binary_endpoint_counts": binary_endpoint_counts,
+        "union_ids": union_ids,
+        "union_fraction_of_published_library": _native_float(union_ids / 1_085),
+        "documented_tested_intersection": documented_tested_intersection,
+        "annotation_union_not_tested_library_join": annotation_union_not_tested_library_join,
+        "binary_activity": matrix_summaries,
+        "source_activity": source_activity,
+        "composition": composition,
+        "endpoint_medians": endpoint_medians,
+        "heatmap_summary": heatmap_summary,
+        "method_trace": method_trace,
+        "table_s5": table_s5,
+    }
+
+
+def _effect_summary(reference: pd.Series, comparison: pd.Series, contrast: str) -> dict[str, object]:
+    matched = pd.concat([reference.rename("reference"), comparison.rename("comparison")], axis=1, join="inner").dropna()
+    _require(not matched.empty, f"classifier contrast has no matched endpoints: {contrast}")
+    difference = matched["comparison"] - matched["reference"]
+    test = ttest_rel(matched["comparison"], matched["reference"])
+    return {
+        "contrast": contrast,
+        "matched_endpoints": len(matched),
+        "mean_difference": _native_float(difference.mean()),
+        "median_difference": _native_float(difference.median()),
+        "paired_t_statistic": None if not np.isfinite(test.statistic) else _native_float(test.statistic),
+        "paired_t_p_value": None if not np.isfinite(test.pvalue) else _native_float(test.pvalue),
+    }
+
+
+def _classifier_subset(frame: pd.DataFrame, category: str) -> pd.DataFrame:
+    if category == "axiom":
+        return frame[frame["Metadata_Label"] != "cell_count"]
+    return frame
+
+
+def _analyze_classifier(root: Path) -> dict[str, object]:
+    category_files = {
+        "axiom": "compiled_axiom_metrics.parquet",
+        "toxcast_cytotox": "compiled_toxcast_cytotox_metrics.parquet",
+        "toxcast_cellbased": "compiled_toxcast_cellbased_metrics.parquet",
+        "toxcast_cellfree": "compiled_toxcast_cellfree_metrics.parquet",
+    }
+    frames: dict[str, pd.DataFrame] = {}
+    file_rows: dict[str, int] = {}
+    modeled_endpoint_counts: dict[str, int] = {}
+    for category, filename in category_files.items():
+        relative = f"2_downstream_analysis/compiled_results/{filename}"
+        frame = _read_parquet(root, relative)
+        _validate_columns(frame, METRIC_COLUMNS, relative)
+        keys = _semantic_key(frame, METRIC_KEY)
+        _require(len(keys) == len(set(keys)), f"{filename}: duplicate metric semantic key")
+        _confirm(len(frame) == EXPECTED_METRIC_ROWS[filename], f"{filename}: row count is {len(frame)}")
+        _require(
+            set(frame["Metadata_AggType"]) == set(EXPECTED_AGG_TYPES),
+            f"{filename}: invalid aggregation-type domain",
+        )
+        _require(
+            set(frame["Model_type"]) == {"Actual", "Random_baseline", "Cellcount_baseline"},
+            f"{filename}: invalid model domain",
+        )
+        _require(set(frame["Feat_type"]) == {"cellprofiler", "cpcnn", "dino"}, f"{filename}: invalid feature domain")
+        for metric in ("AUROC", "PRAUC"):
+            values = pd.to_numeric(frame[metric], errors="coerce").to_numpy(dtype=float)
+            _require(
+                bool(np.isfinite(values).all() and ((values >= 0) & (values <= 1)).all()),
+                f"{filename}: invalid {metric}",
+            )
+        for column in ("Metadata_Count_0", "Metadata_Count_1"):
+            values = pd.to_numeric(frame[column], errors="coerce").to_numpy(dtype=float)
+            _require(
+                bool(np.isfinite(values).all() and (values > 0).all() and np.equal(values, np.floor(values)).all()),
+                f"{filename}: invalid {column}",
+            )
+        frames[category] = frame
+        file_rows[filename] = len(frame)
+        modeled = frame[
+            (frame["Metadata_AggType"] == "all")
+            & (frame["Model_type"] == "Actual")
+            & (frame["Feat_type"] == "cellprofiler")
+        ]
+        modeled = _classifier_subset(modeled, category)
+        modeled_endpoint_counts[category] = int(modeled["Metadata_Label"].nunique())
+    expected_modeled = {"axiom": 2, "toxcast_cytotox": 34, "toxcast_cellbased": 267, "toxcast_cellfree": 53}
+    _confirm(modeled_endpoint_counts == expected_modeled, f"modeled endpoint counts differ: {modeled_endpoint_counts}")
+
+    table2_rows: list[dict[str, object]] = []
+    axiom = frames["axiom"]
+    table_models = (
+        ("Cell count", "Cellcount_baseline", "cellprofiler"),
+        ("Random", "Random_baseline", "cellprofiler"),
+        ("CellProfiler", "Actual", "cellprofiler"),
+        ("CP-CNN", "Actual", "cpcnn"),
+        ("DINO", "Actual", "dino"),
+    )
+    for endpoint in ("LDH", "MTT"):
+        for display, model_type, feature_type in table_models:
+            selected = axiom[
+                (axiom["Metadata_AggType"] == "all")
+                & (axiom["Metadata_Label"] == endpoint)
+                & (axiom["Model_type"] == model_type)
+                & (axiom["Feat_type"] == feature_type)
+            ]
+            _require(len(selected) == 1, f"Table 2 key is absent or duplicated: {endpoint}/{display}")
+            row = selected.iloc[0]
+            table2_rows.append(
+                {
+                    "endpoint": endpoint,
+                    "row": display,
+                    "auroc": _native_float(row["AUROC"]),
+                    "prauc": _native_float(row["PRAUC"]),
+                    "count_0": int(row["Metadata_Count_0"]),
+                    "count_1": int(row["Metadata_Count_1"]),
+                }
+            )
+
+    ldh_table_rows = [row for row in table2_rows if row["endpoint"] == "LDH"]
+    ldh_morphology_rows = [row for row in ldh_table_rows if row["row"] in {"CellProfiler", "CP-CNN", "DINO"}]
+    ldh_baseline_rows = [row for row in ldh_table_rows if row["row"] in {"Cell count", "Random"}]
+    classifier_001 = {
+        "endpoint": "LDH",
+        "morphology_mean_auroc": _native_float(np.mean([row["auroc"] for row in ldh_morphology_rows])),
+        "morphology_mean_prauc": _native_float(np.mean([row["prauc"] for row in ldh_morphology_rows])),
+        "all_representations_above_both_baselines": all(
+            morphology[metric] > baseline[metric]
+            for morphology in ldh_morphology_rows
+            for baseline in ldh_baseline_rows
+            for metric in ("auroc", "prauc")
+        ),
+    }
+    _confirm(
+        abs(float(classifier_001["morphology_mean_auroc"]) - 0.932625) <= 5e-7
+        and abs(float(classifier_001["morphology_mean_prauc"]) - 0.753212) <= 5e-7
+        and bool(classifier_001["all_representations_above_both_baselines"]),
+        f"LDH classifier target summary differs: {classifier_001}",
+    )
+
+    baseline_effects: dict[str, object] = {}
+    strategy_effects: dict[str, object] = {}
+    filter_effects: dict[str, object] = {}
+    representation_effects: dict[str, object] = {}
+    distributions: dict[str, object] = {}
+    for category, frame in frames.items():
+        baseline_effects[category] = {}
+        strategy_effects[category] = {}
+        filter_effects[category] = {}
+        representation_effects[category] = {}
+        distributions[category] = {}
+        base = frame[(frame["Metadata_AggType"] == "all") & (frame["Feat_type"] == "cellprofiler")]
+        base = _classifier_subset(base, category)
+        for metric in ("AUROC", "PRAUC"):
+            metric_key = metric.lower()
+            baseline_effects[category][metric_key] = {}
+            actual = base[base["Model_type"] == "Actual"].set_index("Metadata_Label")[metric]
+            for report_key, model_type in (("random", "Random_baseline"), ("cell_count", "Cellcount_baseline")):
+                baseline = base[base["Model_type"] == model_type].set_index("Metadata_Label")[metric]
+                baseline_effects[category][metric_key][report_key] = _effect_summary(
+                    baseline,
+                    actual,
+                    f"Actual - {model_type}",
+                )
+
+            strategy_effects[category][metric_key] = {}
+            strategies = frame[(frame["Model_type"] == "Actual") & (frame["Feat_type"] == "cellprofiler")]
+            strategies = _classifier_subset(strategies, category)
+            strategy_pivot = strategies.pivot(index="Metadata_Label", columns="Metadata_AggType", values=metric)
+            for alternative in ("allpod", "allpodcc"):
+                strategy_effects[category][metric_key][alternative] = _effect_summary(
+                    strategy_pivot["all"],
+                    strategy_pivot[alternative],
+                    f"{alternative} - all",
+                )
+            filter_effects[category][metric_key] = _effect_summary(
+                strategy_pivot["allpod"],
+                strategy_pivot["allpodcc"],
+                "allpodcc - allpod",
+            )
+
+            representation_effects[category][metric_key] = {}
+            representations = frame[(frame["Model_type"] == "Actual") & (frame["Metadata_AggType"] == "all")]
+            representations = _classifier_subset(representations, category)
+            representation_pivot = representations.pivot(index="Metadata_Label", columns="Feat_type", values=metric)
+            for alternative in ("cpcnn", "dino"):
+                representation_effects[category][metric_key][alternative] = _effect_summary(
+                    representation_pivot["cellprofiler"],
+                    representation_pivot[alternative],
+                    f"{alternative} - cellprofiler",
+                )
+            representation_effects[category][metric_key]["dino_vs_cpcnn"] = _effect_summary(
+                representation_pivot["cpcnn"],
+                representation_pivot["dino"],
+                "dino - cpcnn",
+            )
+
+        actual_all = frame[(frame["Metadata_AggType"] == "all") & (frame["Model_type"] == "Actual")]
+        actual_all = _classifier_subset(actual_all, category)
+        for representation in ("cellprofiler", "cpcnn", "dino"):
+            representation_rows = actual_all[actual_all["Feat_type"] == representation]
+            distributions[category][representation] = {}
+            for metric in ("AUROC", "PRAUC"):
+                values = representation_rows[metric].astype(float)
+                distributions[category][representation][metric.lower()] = {
+                    "count": len(values),
+                    "minimum": _native_float(values.min()),
+                    "first_quartile": _native_float(values.quantile(0.25)),
+                    "median": _native_float(values.median()),
+                    "third_quartile": _native_float(values.quantile(0.75)),
+                    "maximum": _native_float(values.max()),
+                }
+    classifier_text = _input_path(root, "1_snakemake/classifier/classify.py").read_text(encoding="utf-8")
+    aggregate_text = _input_path(root, "1_snakemake/classifier/aggregate_profiles.py").read_text(encoding="utf-8")
+    hitcall_text = _input_path(root, "1_snakemake/classifier/hitcalls.py").read_text(encoding="utf-8")
+    rules_text = _input_path(root, "1_snakemake/rules/classifier.smk").read_text(encoding="utf-8")
+    method_trace = {
+        "folds": 5,
+        "stratified": "StratifiedKFold(n_splits=n_splits)" in classifier_text,
+        "model": "XGBClassifier" if "XGBClassifier" in classifier_text else "unresolved",
+        "compound_level_label_join": 'rename({"OASIS_ID": "Metadata_OASIS_ID"})' in classifier_text,
+        "published_baselines": all(
+            token in classifier_text for token in ("Random_baseline", "Cellcount_baseline", "shuffle=True", "cc=True")
+        ),
+        "consensus_strategies": all(
+            token in aggregate_text for token in ('method == "all"', 'method == "allpod"', 'method == "allpodcc"')
+        ),
+        "paired_assay_hitcalls": all(token in hitcall_text for token in ("mtt_hits", "ldh_hits", "cc_hits")),
+        "workflow_wiring": all(
+            token in rules_text
+            for token in ("toxcast_cellbased_binary", "toxcast_cellfree_binary", "toxcast_cytotox_binary")
+        ),
+    }
+    _confirm(
+        bool(method_trace["stratified"]) and method_trace["model"] == "XGBClassifier", "classifier method trace differs"
+    )
+
+    all_cellprofiler_medians = {
+        category: {metric: distributions[category]["cellprofiler"][metric]["median"] for metric in ("auroc", "prauc")}
+        for category in category_files
+    }
+    expected_medians = {
+        "axiom": {"auroc": 0.901547, "prauc": 0.805566},
+        "toxcast_cytotox": {"auroc": 0.737210, "prauc": 0.477455},
+        "toxcast_cellbased": {"auroc": 0.607226, "prauc": 0.144840},
+        "toxcast_cellfree": {"auroc": 0.532086, "prauc": 0.454015},
+    }
+    _confirm(
+        all(
+            abs(float(all_cellprofiler_medians[category][metric]) - expected) <= 5e-7
+            for category, metrics in expected_medians.items()
+            for metric, expected in metrics.items()
+        ),
+        f"all-concentration classifier medians differ: {all_cellprofiler_medians}",
+    )
+
+    target_effects = {
+        "dino_vs_cpcnn_cellbased_auroc": {
+            key: representation_effects["toxcast_cellbased"]["auroc"]["dino_vs_cpcnn"][key]
+            for key in ("mean_difference", "median_difference")
+        },
+        "dino_vs_cellprofiler_cellbased_auroc": {
+            key: representation_effects["toxcast_cellbased"]["auroc"]["dino"][key]
+            for key in ("mean_difference", "median_difference")
+        },
+    }
+    _confirm(
+        abs(float(target_effects["dino_vs_cpcnn_cellbased_auroc"]["mean_difference"]) - 0.01079046) <= 5e-8
+        and abs(float(target_effects["dino_vs_cpcnn_cellbased_auroc"]["median_difference"]) - 0.01587302) <= 5e-8
+        and abs(float(target_effects["dino_vs_cellprofiler_cellbased_auroc"]["median_difference"]) - 0.02209021)
+        <= 5e-8,
+        f"classifier representation target effects differ: {target_effects}",
+    )
+
+    axiom_above_baselines = all(
+        baseline_effects["axiom"][metric][baseline]["mean_difference"] > 0
+        for metric in ("auroc", "prauc")
+        for baseline in ("random", "cell_count")
+    )
+    cellbased_not_cellfree = all(
+        baseline_effects[category][metric][baseline]["mean_difference"] > 0
+        for category in ("axiom", "toxcast_cytotox", "toxcast_cellbased")
+        for metric in ("auroc", "prauc")
+        for baseline in ("random", "cell_count")
+    ) and all(
+        abs(baseline_effects["toxcast_cellfree"][metric]["random"]["mean_difference"]) < 0.1
+        for metric in ("auroc", "prauc")
+    )
+    allpod_small_effects = all(
+        abs(strategy_effects[category][metric]["allpod"]["mean_difference"]) < 0.1
+        for category in category_files
+        for metric in ("auroc", "prauc")
+    )
+    allpodcc_filter_direction = all(
+        filter_effects[category][metric]["mean_difference"] < 0
+        for category in ("axiom", "toxcast_cytotox")
+        for metric in ("auroc", "prauc")
+    ) and all(
+        abs(filter_effects[category][metric]["mean_difference"]) < 0.02
+        for category in ("toxcast_cellbased", "toxcast_cellfree")
+        for metric in ("auroc", "prauc")
+    )
+    representation_small_effects = all(
+        abs(representation_effects[category][metric][representation]["mean_difference"]) < 0.1
+        for category in category_files
+        for metric in ("auroc", "prauc")
+        for representation in ("cpcnn", "dino", "dino_vs_cpcnn")
+    )
+    all_concentration_not_worse = all(
+        strategy_effects[category][metric][alternative]["mean_difference"] < 0.1
+        for category in category_files
+        for metric in ("auroc", "prauc")
+        for alternative in ("allpod", "allpodcc")
+    )
+    prauc_no_material_improvement = all(
+        strategy_effects[category]["prauc"][alternative]["mean_difference"] < 0.1
+        for category in category_files
+        for alternative in ("allpod", "allpodcc")
+    ) and all(
+        representation_effects[category]["prauc"][representation]["mean_difference"] < 0.1
+        for category in category_files
+        for representation in ("cpcnn", "dino", "dino_vs_cpcnn")
+    )
+    conclusion_gates = {
+        "table2": len(table2_rows) == 10 and axiom_above_baselines,
+        "axiom_above_baselines": axiom_above_baselines,
+        "cellbased_not_cellfree": cellbased_not_cellfree,
+        "allpod_small_effects": allpod_small_effects,
+        "allpodcc_filter_direction": allpodcc_filter_direction,
+        "all_concentration_not_worse": all_concentration_not_worse,
+        "representation_small_effects": representation_small_effects,
+        "prauc_no_material_improvement": prauc_no_material_improvement,
+        "conclusion_003": allpod_small_effects
+        and allpodcc_filter_direction
+        and representation_small_effects
+        and all_concentration_not_worse,
+    }
+    _confirm(all(conclusion_gates.values()), f"classifier conclusion inequality failed: {conclusion_gates}")
+    return {
+        "file_rows": file_rows,
+        "modeled_endpoint_counts": modeled_endpoint_counts,
+        "table2": {"rows": table2_rows},
+        "classifier_001": classifier_001,
+        "baseline_effects": baseline_effects,
+        "strategy_effects": strategy_effects,
+        "filter_effects": filter_effects,
+        "representation_effects": representation_effects,
+        "distributions": distributions,
+        "all_cellprofiler_medians": all_cellprofiler_medians,
+        "target_effects": target_effects,
+        "method_trace": method_trace,
+        "raw_prediction_recomputation": False,
+        "conclusion_gates": conclusion_gates,
+    }
+
+
+def _analyze_external_image(root: Path) -> dict[str, object]:
+    image = _input_path(root, "paper/figures/figure-s1.jpg").read_bytes()
+    _require(
+        image.startswith(b"\xff\xd8") and image.endswith(b"\xff\xd9"),
+        "paper/figures/figure-s1.jpg is not a complete JPEG",
+    )
+    paper_text = _input_path(root, "paper/paper.md").read_text(encoding="utf-8")
+    identity_trace = all(token in paper_text for token in ("41002889", "L12", "site = 6", "191,754"))
+    _confirm(identity_trace, "Figure S1 identity or inventory trace is incomplete")
+    return {
+        "navigation_image_sha256": hashlib.sha256(image).hexdigest(),
+        "navigation_image_bytes": len(image),
+        "identity_trace": identity_trace,
+        "source_image_available": False,
+        "limitation": "The raw source TIFF and image index are external and intentionally absent.",
+    }
+
+
+CheckGetter = Callable[[Mapping[str, Any]], object]
+CheckPredicate = Callable[[object, object], bool]
+CheckRule = tuple[str, CheckGetter, object, CheckPredicate | None]
+
+
+def _path_getter(*path: str) -> CheckGetter:
+    def get(analyses: Mapping[str, Any]) -> object:
+        value: object = analyses
+        for part in path:
+            if not isinstance(value, Mapping) or part not in value:
+                raise InputValidationError(f"analysis field is absent: {'.'.join(path)}")
+            value = value[part]
+        return value
+
+    return get
+
+
+def _rule(name: str, path: tuple[str, ...], expected: object, predicate: CheckPredicate | None = None) -> CheckRule:
+    return (name, _path_getter(*path), expected, predicate)
+
+
+def _computed_rule(
+    name: str, getter: CheckGetter, expected: object, predicate: CheckPredicate | None = None
+) -> CheckRule:
+    return (name, getter, expected, predicate)
+
+
+def _target_builder(*rules: CheckRule) -> Callable[[Mapping[str, Any]], list[dict[str, object]]]:
+    def build(analyses: Mapping[str, Any]) -> list[dict[str, object]]:
+        checks: list[dict[str, object]] = []
+        for name, getter, expected, predicate in rules:
+            observed = getter(analyses)
+            checks.append(
+                _check(
+                    name,
+                    observed,
+                    expected,
+                    passed=None if predicate is None else predicate(observed, expected),
+                )
+            )
+        return checks
+
+    return build
+
+
+def _all_true(value: object, _expected: object) -> bool:
+    return isinstance(value, Mapping) and all(bool(item) for item in value.values())
+
+
+def _less_than(value: object, expected: object) -> bool:
+    return float(value) < float(expected)
+
+
+def _within(value: object, expected: object) -> bool:
+    observed, tolerance = value if isinstance(value, tuple) else (value, 0.0)
+    return abs(float(observed) - float(expected)) <= float(tolerance)
+
+
+S1_RECIPE_INPUTS = (
+    "paper/sources/table-s1.xlsx",
+    "1_snakemake/inputs/annotations/v5_oasis_03Sept2024_simple.csv",
+)
+ACTIVITY_RECIPE_INPUTS = (
+    "paper/sources/table-s2.xlsx",
+    "paper/sources/table-s3.xlsx",
+    "paper/sources/table-s4.xlsx",
+    "2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv",
+)
+ENRICHMENT_RECIPE_INPUTS = tuple(path for path in COMPILED_INPUTS if path.endswith("_targets.csv"))
+TOXCAST_RECIPE_INPUTS = tuple(path for path in ANNOTATION_INPUTS if "/toxcast_" in path)
+CLASSIFIER_RECIPE_INPUTS = tuple(
+    path for path in COMPILED_INPUTS if "/compiled_" in path and path.endswith("_metrics.parquet")
+)
+
+
+# Each ledger ID has one concrete recipe.  The check builders below are
+# target-scoped even where several targets consume the same validated analysis.
+TARGET_RECIPES: dict[str, TargetRecipe] = {
+    "DESIGN-001": TargetRecipe(
+        "sources_design",
+        "documentary-trace",
+        "documentary-only",
+        ("paper/paper.md", "paper/evidence/experimental-design-and-figure-1.md"),
+        _target_builder(
+            _rule(
+                "published compound, dose, and replicate design",
+                ("sources_design", "documentary_trace", "experimental_design"),
+                True,
+            )
+        ),
+    ),
+    "DESIGN-002": TargetRecipe(
+        "sources_design",
+        "documentary-trace",
+        "documentary-only",
+        ("paper/paper.md", "paper/evidence/experimental-design-and-figure-1.md"),
+        _target_builder(
+            _rule(
+                "published representation feature counts",
+                ("sources_design", "documentary_trace", "feature_count_claims"),
+                True,
+            )
+        ),
+    ),
+    "DESIGN-003": TargetRecipe(
+        "sources_design",
+        "documentary-trace",
+        "documentary-only",
+        ("paper/paper.md", "paper/evidence/experimental-design-and-figure-1.md"),
+        _target_builder(
+            _rule(
+                "published assay and exposure constants",
+                ("sources_design", "documentary_trace", "assay_and_exposure_design"),
+                True,
+            )
+        ),
+    ),
+    "FIG-1": TargetRecipe(
+        "sources_design",
+        "documentary-trace",
+        "documentary-only",
+        ("paper/figures/figure-1.jpg", "paper/evidence/experimental-design-and-figure-1.md"),
+        _target_builder(
+            _rule(
+                "Figure 1 workflow stages and outcomes",
+                ("sources_design", "documentary_trace", "figure_1_workflow"),
+                True,
+            )
+        ),
+    ),
+    "TABLE-S1": TargetRecipe(
+        "sources_design",
+        "source-recomputation",
+        "available",
+        S1_RECIPE_INPUTS,
+        _target_builder(
+            _rule("Table S1 rows", ("sources_design", "table_s1", "rows"), 1085),
+            _rule("Table S1 stable IDs", ("sources_design", "table_s1", "stable_id_count"), 966),
+            _rule("Table S1 blank IDs", ("sources_design", "table_s1", "blank_id_count"), 119),
+        ),
+    ),
+    "TABLE-KEY-RESOURCES": TargetRecipe(
+        "sources_design",
+        "documentary-trace",
+        "documentary-only",
+        ("paper/paper.md", "paper/sources/main.pdf"),
+        _target_builder(
+            _rule(
+                "Key Resources transcription trace",
+                ("sources_design", "documentary_trace", "table_key_resources"),
+                True,
+            ),
+            _rule("Key Resources Markdown data rows", ("sources_design", "key_resources_data_rows"), 34),
+        ),
+    ),
+    "METHOD-STATS": TargetRecipe(
+        "sources_design",
+        "documentary-trace",
+        "documentary-only",
+        ("paper/paper.md",),
+        _target_builder(
+            _rule(
+                "statistical thresholds and sample design trace",
+                ("sources_design", "documentary_trace", "statistical_thresholds"),
+                True,
+            )
+        ),
+    ),
+    "RESOURCE-001": TargetRecipe(
+        "sources_design",
+        "documentary-trace",
+        "documentary-only",
+        ("README.md", "paper/paper.md", "paper/evidence/remaining-paper-reproduction-targets.md"),
+        _target_builder(
+            _rule(
+                "published data and code locations", ("sources_design", "documentary_trace", "resource_locations"), True
+            ),
+            _rule(
+                "tracked-only resource boundary", ("sources_design", "documentary_trace", "tracked_only_boundary"), True
+            ),
+        ),
+    ),
+    "ACTIVITY-001": TargetRecipe(
+        "activity_pods",
+        "source-recomputation",
+        "available",
+        ("paper/sources/table-s2.xlsx", *ACTIVITY_RECIPE_INPUTS[3:6]),
+        _target_builder(
+            _rule(
+                "published Table S2 activity counts",
+                ("activity_pods", "table_s2_counts"),
+                {"MT": 429, "Cell count": 220, "LDH": 147, "unique_compounds": 437},
+            )
+        ),
+    ),
+    "ACTIVITY-002": TargetRecipe(
+        "activity_pods",
+        "documentary-trace",
+        "documentary-only",
+        (
+            "2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv",
+            "paper/evidence/activity-and-figure-2a.md",
+        ),
+        _target_builder(
+            _rule(
+                "direction-aware cytotoxic compound count",
+                ("activity_pods", "direction_aware_cytotoxicity", "count"),
+                429,
+            ),
+            _rule(
+                "direction-aware definition trace",
+                ("activity_pods", "direction_aware_cytotoxicity", "documented_in_tracked_evidence"),
+                True,
+            ),
+        ),
+    ),
+    "ACTIVITY-003": TargetRecipe(
+        "activity_pods",
+        "documentary-trace",
+        "documentary-only",
+        ("paper/evidence/activity-and-figure-2a.md", "2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv"),
+        _target_builder(
+            _rule(
+                "camera-ready increasing-MT call count",
+                ("activity_pods", "direction_aware_cytotoxicity", "mt_increasing_count"),
+                10,
+            ),
+            _rule(
+                "increasing-MT count documentary trace",
+                ("activity_pods", "direction_aware_cytotoxicity", "mt_increasing_count_documented"),
+                True,
+            ),
+            _rule(
+                "four dominant increasing-MT compounds",
+                ("activity_pods", "figure_2a", "compound_names"),
+                ["Benzarone", "Tiratricol", "Tolcapone", "2-Ethylanthracene-9,10-dione"],
+            ),
+            _rule("increasing-MT direction", ("activity_pods", "figure_2a", "direction"), "increasing MT"),
+        ),
+    ),
+    "FIG-2A": TargetRecipe(
+        "activity_pods",
+        "source-recomputation",
+        "available",
+        (
+            "paper/sources/table-s2.xlsx",
+            "2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv",
+            "paper/evidence/activity-and-figure-2a.md",
+        ),
+        _target_builder(
+            _rule(
+                "Figure 2A four published compounds",
+                ("activity_pods", "figure_2a", "compound_names"),
+                ["Benzarone", "Tiratricol", "Tolcapone", "2-Ethylanthracene-9,10-dione"],
+            ),
+            _computed_rule(
+                "Figure 2A Table S2 POD agreement",
+                lambda a: max(
+                    abs(row["pod_um"] - row["expected_published_pod_um"])
+                    for row in a["activity_pods"]["figure_2a"]["rows"]
+                ),
+                1e-6,
+                lambda observed, expected: float(observed) <= float(expected),
+            ),
+        ),
+    ),
+    "BIOACTIVITY-001": TargetRecipe(
+        "activity_pods",
+        "source-recomputation",
+        "available",
+        ("paper/sources/table-s3.xlsx", *ACTIVITY_RECIPE_INPUTS[6:9], "paper/evidence/bioactivity-and-figure-2b-d.md"),
+        _target_builder(
+            _computed_rule(
+                "all published-SI morphology count estimands",
+                lambda a: {
+                    representation: {
+                        mode: a["activity_pods"]["morphology_activity_summary"][representation][mode]["count"]
+                        for mode in ("global", "categorical", "general")
+                    }
+                    for representation in ("cellprofiler", "cpcnn", "dino")
+                },
+                {
+                    "cellprofiler": {"global": 169, "categorical": 598, "general": 607},
+                    "cpcnn": {"global": 539, "categorical": 0, "general": 539},
+                    "dino": {"global": 545, "categorical": 626, "general": 644},
+                },
+            ),
+            _computed_rule(
+                "CellProfiler-global published-SI fraction",
+                lambda a: (
+                    a["activity_pods"]["morphology_activity_summary"]["cellprofiler"]["global"]["fraction_of_1085"],
+                    5e-4,
+                ),
+                0.156,
+                _within,
+            ),
+            _rule(
+                "CellProfiler general published-SI count",
+                ("activity_pods", "morphology_activity_summary", "cellprofiler", "general", "count"),
+                607,
+            ),
+            _computed_rule(
+                "published-SI general morphology ordering over cytotoxic assays",
+                lambda a: (
+                    min(
+                        a["activity_pods"]["morphology_activity_summary"][name]["general"]["count"]
+                        for name in ("cellprofiler", "cpcnn", "dino")
+                    )
+                    > a["activity_pods"]["table_s2_counts"]["MT"]
+                ),
+                True,
+            ),
+        ),
+    ),
+    "FIG-2B": TargetRecipe(
+        "activity_pods",
+        "source-recomputation",
+        "available",
+        ("paper/sources/table-s3.xlsx", *ACTIVITY_RECIPE_INPUTS[6:9]),
+        _target_builder(
+            _rule(
+                "CellProfiler general active compounds",
+                ("activity_pods", "morphology_counts", "cellprofiler", "general", "count"),
+                607,
+            ),
+            _rule(
+                "DINO general active compounds", ("activity_pods", "morphology_counts", "dino", "general", "count"), 644
+            ),
+        ),
+    ),
+    "BIOACTIVITY-002": TargetRecipe(
+        "activity_pods",
+        "source-recomputation",
+        "blocked",
+        ("paper/sources/table-s3.xlsx", *ACTIVITY_RECIPE_INPUTS[6:9], "paper/evidence/bioactivity-and-figure-2b-d.md"),
+        _target_builder(
+            _rule("three-general shared compounds", ("activity_pods", "figure_2c_three_general", "count"), 488),
+            _computed_rule(
+                "CP-CNN over CellProfiler general POD ratio",
+                lambda a: (
+                    a["activity_pods"]["figure_2c_three_general"]["geometric_fold_ratios"]["cpcnn_over_cellprofiler"],
+                    5e-5,
+                ),
+                1.8181,
+                _within,
+            ),
+            _computed_rule(
+                "CellProfiler-DINO null conclusion is substrate-dependent",
+                lambda a: a["activity_pods"]["figure_2c_three_general"]["cellprofiler_vs_dino_paired_log10"][
+                    "paired_t_p_value"
+                ],
+                0.05,
+                lambda observed, expected: float(observed) > float(expected),
+            ),
+        ),
+    ),
+    "FIG-2C": TargetRecipe(
+        "activity_pods",
+        "source-recomputation",
+        "available",
+        ("paper/sources/table-s3.xlsx", *ACTIVITY_RECIPE_INPUTS[6:9], "paper/evidence/bioactivity-and-figure-2b-d.md"),
+        _target_builder(
+            _rule(
+                "camera-ready five-series count trace",
+                ("activity_pods", "figure_2c_complete_case", "camera_ready_count_trace"),
+                342,
+            ),
+            _rule(
+                "published-SI five-series complete cases", ("activity_pods", "figure_2c_complete_case", "count"), 156
+            ),
+            _rule(
+                "published-SI count deviation from camera-ready",
+                ("activity_pods", "figure_2c_complete_case", "source_si_count_deviation"),
+                186,
+            ),
+            _rule(
+                "five-series median ordering preserved",
+                ("activity_pods", "figure_2c_complete_case", "ordering_preserved"),
+                True,
+            ),
+            _computed_rule(
+                "tracked-SI five-series finite POD summaries and median order",
+                lambda a: {
+                    "series_count": len(a["activity_pods"]["figure_2c_complete_case"]["median_pod_um"]),
+                    "finite_nonempty": a["activity_pods"]["figure_2c_complete_case"]["finite_nonempty_pod_summaries"],
+                    "median_order": a["activity_pods"]["figure_2c_complete_case"]["median_order"],
+                },
+                {
+                    "series_count": 5,
+                    "finite_nonempty": True,
+                    "median_order": [
+                        "cellprofiler_categorical",
+                        "dino_categorical",
+                        "dino_global",
+                        "cpcnn_global",
+                        "cellprofiler_global",
+                    ],
+                },
+            ),
+        ),
+    ),
+    "BIOACTIVITY-003": TargetRecipe(
+        "activity_pods",
+        "source-recomputation",
+        "available",
+        ACTIVITY_RECIPE_INPUTS,
+        _target_builder(
+            _computed_rule(
+                "assay median sensitivity ordering",
+                lambda a: list(a["activity_pods"]["figure_2d"]["median_pod_um"].values()),
+                "Morphology < MT < cell count < LDH",
+                lambda values, _expected: values[0] < values[1] < values[2] < values[3],
+            ),
+            _rule("published-SI complete cases", ("activity_pods", "figure_2d", "complete_case_count"), 121),
+        ),
+    ),
+    "FIG-2D": TargetRecipe(
+        "activity_pods",
+        "source-recomputation",
+        "available",
+        ACTIVITY_RECIPE_INPUTS,
+        _target_builder(
+            _rule("published-SI four-assay complete cases", ("activity_pods", "figure_2d", "complete_case_count"), 121),
+            _rule(
+                "MT fold ratio versus morphology",
+                ("activity_pods", "figure_2d", "geometric_fold_ratio_vs_morphology", "mt"),
+                1.78550470485347,
+            ),
+        ),
+    ),
+    "TABLE-S2": TargetRecipe(
+        "activity_pods",
+        "source-recomputation",
+        "available",
+        ("paper/sources/table-s2.xlsx", *ACTIVITY_RECIPE_INPUTS[3:6]),
+        _target_builder(
+            _rule(
+                "Table S2 semantic keys",
+                ("activity_pods", "supplemental_tables", "table_s2", "matched_semantic_keys"),
+                796,
+            ),
+            _rule(
+                "Table S2 maximum POD difference",
+                ("activity_pods", "supplemental_tables", "table_s2", "maximum_absolute_pod_difference"),
+                1e-12,
+                _less_than,
+            ),
+        ),
+    ),
+    "TABLE-S3": TargetRecipe(
+        "activity_pods",
+        "source-recomputation",
+        "available",
+        ("paper/sources/table-s3.xlsx", *ACTIVITY_RECIPE_INPUTS[6:9]),
+        _target_builder(
+            _rule(
+                "Table S3 semantic keys",
+                ("activity_pods", "supplemental_tables", "table_s3", "matched_semantic_keys"),
+                10935,
+            ),
+            _rule(
+                "Table S3 exact bioactivity flags",
+                ("activity_pods", "supplemental_tables", "table_s3", "bioactivity_flag_exact_rows"),
+                10935,
+            ),
+        ),
+    ),
+    "TABLE-S4": TargetRecipe(
+        "activity_pods",
+        "source-recomputation",
+        "available",
+        ("paper/sources/table-s4.xlsx", "2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv"),
+        _target_builder(
+            _rule(
+                "Table S4 semantic keys",
+                ("activity_pods", "supplemental_tables", "table_s4", "matched_semantic_keys"),
+                1086,
+            ),
+            _rule(
+                "Table S4 exact tracked hit rows",
+                ("activity_pods", "supplemental_tables", "table_s4", "all_hit_calls_exact_rows"),
+                1086,
+            ),
+        ),
+    ),
+    "METHOD-POD": TargetRecipe(
+        "activity_pods",
+        "documentary-trace",
+        "documentary-only",
+        (
+            "1_snakemake/concresponse/fit_curves.R",
+            "1_snakemake/concresponse/fit_curves_meta.R",
+            "1_snakemake/concresponse/select_pod.R",
+            "paper/paper.md",
+            "paper/evidence/method-deviations.md",
+        ),
+        _target_builder(
+            _rule("POD implementation and deviation trace", ("activity_pods", "pod_method_trace"), True, _all_true)
+        ),
+    ),
+    "CONCLUSION-001": TargetRecipe(
+        "activity_pods",
+        "derived-artifact-reanalysis",
+        "available",
+        ACTIVITY_RECIPE_INPUTS,
+        _target_builder(
+            _rule("morphology sensitivity inequalities", ("activity_pods", "conclusion_gates"), True, _all_true)
+        ),
+    ),
+    "TABLE-1": TargetRecipe(
+        "regression_enrichment",
+        "documentary-trace",
+        "documentary-only",
+        (
+            "paper/paper.md",
+            "1_snakemake/classifier/regression.py",
+            "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+            "paper/evidence/regression-and-figure-s2.md",
+        ),
+        _target_builder(
+            _rule(
+                "Table 1 documentary schema and value trace",
+                ("regression_enrichment", "regression_trace", "table_1_documentary"),
+                True,
+            ),
+            _rule(
+                "Table 1 numerical acceptance rerun",
+                ("regression_enrichment", "regression_trace", "numerical_acceptance_rerun"),
+                False,
+            ),
+        ),
+    ),
+    "REGRESSION-001": TargetRecipe(
+        "regression_enrichment",
+        "documentary-trace",
+        "documentary-only",
+        (
+            "1_snakemake/classifier/regression.py",
+            "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+            "paper/evidence/regression-and-figure-s2.md",
+        ),
+        _target_builder(
+            _rule(
+                "regression comparison documentary trace",
+                ("regression_enrichment", "regression_trace", "relative_performance_documentary"),
+                True,
+            ),
+            _rule(
+                "regression numerical acceptance rerun",
+                ("regression_enrichment", "regression_trace", "numerical_acceptance_rerun"),
+                False,
+            ),
+        ),
+    ),
+    "REGRESSION-002": TargetRecipe(
+        "regression_enrichment",
+        "documentary-trace",
+        "documentary-only",
+        (
+            "paper/paper.md",
+            "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+            "paper/evidence/regression-and-figure-s2.md",
+        ),
+        _target_builder(
+            _rule(
+                "LDH replicate comparison documentary trace",
+                ("regression_enrichment", "regression_trace", "replicate_effect_documentary"),
+                True,
+            ),
+            _rule(
+                "regression numerical acceptance rerun",
+                ("regression_enrichment", "regression_trace", "numerical_acceptance_rerun"),
+                False,
+            ),
+        ),
+    ),
+    "ENRICH-001": TargetRecipe(
+        "regression_enrichment",
+        "derived-artifact-reanalysis",
+        "blocked",
+        (
+            "2_downstream_analysis/compiled_results/err_higher_targets.csv",
+            "paper/evidence/prediction-error-enrichment.md",
+        ),
+        _target_builder(
+            _rule(
+                "historical higher hit-list size",
+                ("regression_enrichment", "files", "err_higher_targets.csv", "hit_list_size"),
+                304,
+            ),
+            _rule(
+                "stored higher significant sets",
+                ("regression_enrichment", "files", "err_higher_targets.csv", "significant_count"),
+                178,
+            ),
+            _rule(
+                "literal 480-target acceptance available",
+                ("regression_enrichment", "regression_trace", "err_480_acceptance_available"),
+                False,
+            ),
+        ),
+    ),
+    "ENRICH-002": TargetRecipe(
+        "regression_enrichment",
+        "derived-artifact-reanalysis",
+        "blocked",
+        (
+            "2_downstream_analysis/compiled_results/err_lower_targets.csv",
+            "paper/evidence/prediction-error-enrichment.md",
+        ),
+        _target_builder(
+            _rule(
+                "stored lower hit-list size",
+                ("regression_enrichment", "files", "err_lower_targets.csv", "hit_list_size"),
+                138,
+            ),
+            _rule(
+                "stored lower significant sets",
+                ("regression_enrichment", "files", "err_lower_targets.csv", "significant_count"),
+                0,
+            ),
+            _rule(
+                "literal 304-well acceptance available",
+                ("regression_enrichment", "regression_trace", "err_304_acceptance_available"),
+                False,
+            ),
+        ),
+    ),
+    "ENRICH-003": TargetRecipe(
+        "regression_enrichment",
+        "derived-artifact-reanalysis",
+        "available",
+        (
+            "2_downstream_analysis/compiled_results/mtt_higher_targets.csv",
+            "paper/evidence/mt-discrepancy-enrichment.md",
+        ),
+        _target_builder(
+            _rule(
+                "MT higher hit-list size",
+                ("regression_enrichment", "files", "mtt_higher_targets.csv", "hit_list_size"),
+                261,
+            ),
+            _rule(
+                "MT higher significant sets",
+                ("regression_enrichment", "files", "mtt_higher_targets.csv", "significant_count"),
+                147,
+            ),
+            _rule(
+                "MT higher named target classes",
+                ("regression_enrichment", "significant_classes", "mtt_higher"),
+                {
+                    "cyp_prefix_count": 8,
+                    "htr_prefix_count": 6,
+                    "transporters_present": ["ABCB1", "ABCG2", "SLCO1B1", "SLCO1B3"],
+                },
+            ),
+        ),
+    ),
+    "ENRICH-004": TargetRecipe(
+        "regression_enrichment",
+        "derived-artifact-reanalysis",
+        "available",
+        ("2_downstream_analysis/compiled_results/mtt_lower_targets.csv", "paper/evidence/mt-discrepancy-enrichment.md"),
+        _target_builder(
+            _rule(
+                "MT lower hit-list size",
+                ("regression_enrichment", "files", "mtt_lower_targets.csv", "hit_list_size"),
+                131,
+            ),
+            _rule(
+                "MT lower significant sets",
+                ("regression_enrichment", "files", "mtt_lower_targets.csv", "significant_count"),
+                107,
+            ),
+            _rule(
+                "MT lower named target classes",
+                ("regression_enrichment", "significant_classes", "mtt_lower"),
+                {"psm_prefix_count": 18, "cyp_prefix_count": 3},
+            ),
+        ),
+    ),
+    "SFIG-2": TargetRecipe(
+        "regression_enrichment",
+        "documentary-trace",
+        "documentary-only",
+        (
+            "paper/paper.md",
+            "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+            "2_downstream_analysis/other_notebooks/01_checkwelleffects.ipynb",
+            "paper/evidence/regression-and-figure-s2.md",
+        ),
+        _target_builder(
+            _rule(
+                "Figure S2 panel documentary trace",
+                ("regression_enrichment", "regression_trace", "sfig2_documentary"),
+                True,
+            ),
+            _rule(
+                "Figure S2 numerical acceptance rerun",
+                ("regression_enrichment", "regression_trace", "numerical_acceptance_rerun"),
+                False,
+            ),
+        ),
+    ),
+    "METHOD-REGRESSION": TargetRecipe(
+        "regression_enrichment",
+        "documentary-trace",
+        "documentary-only",
+        ("1_snakemake/classifier/regression.py", "paper/evidence/method-deviations.md"),
+        _target_builder(
+            _rule(
+                "ten 80/20 compound-group splits",
+                ("regression_enrichment", "regression_trace", "compound_group_isolation"),
+                True,
+            )
+        ),
+    ),
+    "INTERPRETATION-001": TargetRecipe(
+        "regression_enrichment",
+        "derived-artifact-reanalysis",
+        "available",
+        (
+            "2_downstream_analysis/compiled_results/mtt_higher_targets.csv",
+            "2_downstream_analysis/compiled_results/mtt_lower_targets.csv",
+            "paper/paper.md",
+        ),
+        _target_builder(
+            _rule(
+                "direct enrichment associations separated from mechanism",
+                ("regression_enrichment", "regression_trace", "mechanism_claim_is_hypothesis"),
+                True,
+            )
+        ),
+    ),
+    "TOXCAST-001": TargetRecipe(
+        "toxcast",
+        "source-recomputation",
+        "available",
+        (*TOXCAST_RECIPE_INPUTS, "paper/evidence/toxcast-curation-and-figure-s3.md"),
+        _target_builder(
+            _rule("stored ToxCast annotation-ID union, not tested overlap", ("toxcast", "union_ids"), 963),
+            _computed_rule(
+                "stored annotation-union/library-denominator arithmetic, not tested overlap",
+                lambda a: (a["toxcast"]["union_fraction_of_published_library"], 0.005),
+                0.89,
+                _within,
+            ),
+            _rule(
+                "documented tested-library intersection IDs",
+                ("toxcast", "documented_tested_intersection", "ids"),
+                670,
+            ),
+            _computed_rule(
+                "documented tested-library intersection percentage",
+                lambda a: (a["toxcast"]["documented_tested_intersection"]["percent_of_published_library"], 5e-7),
+                61.751152,
+                _within,
+            ),
+            _rule(
+                "963 is an annotation union rather than a tested-library join",
+                ("toxcast", "annotation_union_not_tested_library_join"),
+                True,
+            ),
+        ),
+    ),
+    "TOXCAST-002": TargetRecipe(
+        "toxcast",
+        "source-recomputation",
+        "available",
+        TOXCAST_RECIPE_INPUTS,
+        _target_builder(
+            _rule(
+                "ToxCast source endpoint counts",
+                ("toxcast", "source_endpoint_counts"),
+                {"cellbased": 292, "cellfree": 72, "cytotox": 48},
+            ),
+            _rule(
+                "classification-ready binary endpoint counts",
+                ("toxcast", "binary_endpoint_counts"),
+                {"cellbased": 292, "cellfree": 72, "cytotox": 38},
+            ),
+        ),
+    ),
+    "TOXCAST-003": TargetRecipe(
+        "toxcast",
+        "source-recomputation",
+        "available",
+        TOXCAST_RECIPE_INPUTS,
+        _target_builder(
+            _rule(
+                "cell-based tissue composition",
+                ("toxcast", "composition", "cellbased_tissues"),
+                {"liver": 151, "vascular": 63, "kidney": 35},
+            ),
+            _rule(
+                "cell-free assay composition",
+                ("toxcast", "composition", "cellfree_assay_types"),
+                {"binding": 37, "enzymatic activity": 35},
+            ),
+            _rule(
+                "cell-free target-family composition",
+                ("toxcast", "composition", "cellfree_target_families"),
+                {"gpcr": 21, "cyp": 11, "nuclear receptor": 10},
+            ),
+            _rule(
+                "median compounds tested per endpoint",
+                ("toxcast", "endpoint_medians", "observed_compounds"),
+                {"cytotox": 346, "cellbased": 306, "cellfree": 33},
+            ),
+            _computed_rule(
+                "median endpoint active fractions",
+                lambda a: a["toxcast"]["endpoint_medians"]["active_fraction"],
+                {"cytotox": 0.2068348801, "cellbased": 0.0711613553, "cellfree": 0.4134295228},
+                lambda observed, expected: all(abs(observed[key] - expected[key]) <= 1e-10 for key in expected),
+            ),
+        ),
+    ),
+    "SFIG-3": TargetRecipe(
+        "toxcast",
+        "source-recomputation",
+        "available",
+        (
+            "1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet",
+            "paper/evidence/toxcast-curation-and-figure-s3.md",
+        ),
+        _target_builder(
+            _rule(
+                "cytotoxicity heatmap summary",
+                ("toxcast", "heatmap_summary"),
+                {"cell_categories": 12, "tissue_categories": 6, "complete_compounds": 839},
+            )
+        ),
+    ),
+    "TABLE-S5": TargetRecipe(
+        "toxcast",
+        "source-recomputation",
+        "available",
+        (
+            "paper/sources/table-s5.xlsx",
+            "1_snakemake/inputs/annotations/toxcast_cellbased_info.parquet",
+            "1_snakemake/inputs/annotations/toxcast_cytotox_info.parquet",
+            "1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet",
+        ),
+        _target_builder(
+            _rule("Table S5 nuclear-receptor assays", ("toxcast", "table_s5", "nuclear_receptor_assays"), 12),
+            _computed_rule(
+                "Table S5 nuclear-receptor AC50 minimum",
+                lambda a: (a["toxcast"]["table_s5"]["nuclear_receptor_ac50_min_um"], 0.001),
+                1.648,
+                _within,
+            ),
+            _rule(
+                "Table S5 nuclear-receptor AC50 maximum", ("toxcast", "table_s5", "nuclear_receptor_ac50_max_um"), 45.0
+            ),
+            _rule(
+                "Table S5 retained pinned receptor assays",
+                ("toxcast", "table_s5", "retained_nuclear_receptor_assays"),
+                8,
+            ),
+            _rule("Table S5 source cytotoxicity hits", ("toxcast", "table_s5", "cytotoxicity_source_hits"), 0),
+            _computed_rule(
+                "Table S5 MMP activity evidence",
+                lambda a: {
+                    "hitcall_above_0_9": a["toxcast"]["table_s5"]["mmp_hitcall"] > 0.9,
+                    "ac50_um": a["toxcast"]["table_s5"]["mmp_ac50_um"],
+                },
+                "active finite MMP signal",
+                lambda observed, _expected: observed["hitcall_above_0_9"] and 0 < observed["ac50_um"] <= 100,
+            ),
+        ),
+    ),
+    "METHOD-TOXCAST": TargetRecipe(
+        "toxcast",
+        "documentary-trace",
+        "documentary-only",
+        (
+            "paper/paper.md",
+            "2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb",
+            "paper/evidence/toxcast-curation-and-figure-s3.md",
+        ),
+        _target_builder(
+            _rule("ToxCast threshold and decision-rule trace", ("toxcast", "method_trace"), True, _all_true)
+        ),
+    ),
+    "TABLE-2": TargetRecipe(
+        "classifier",
+        "derived-artifact-reanalysis",
+        "available",
+        ("2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",),
+        _target_builder(
+            _computed_rule("Table 2 row count", lambda a: len(a["classifier"]["table2"]["rows"]), 10),
+            _rule("Table 2 conclusion gates", ("classifier", "conclusion_gates", "table2"), True),
+        ),
+    ),
+    "CLASSIFIER-001": TargetRecipe(
+        "classifier",
+        "derived-artifact-reanalysis",
+        "available",
+        ("2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",),
+        _target_builder(
+            _computed_rule(
+                "LDH morphology mean AUROC",
+                lambda a: (a["classifier"]["classifier_001"]["morphology_mean_auroc"], 5e-7),
+                0.932625,
+                _within,
+            ),
+            _computed_rule(
+                "LDH morphology mean PRAUC",
+                lambda a: (a["classifier"]["classifier_001"]["morphology_mean_prauc"], 5e-7),
+                0.753212,
+                _within,
+            ),
+            _rule(
+                "LDH representations beat both baselines",
+                ("classifier", "classifier_001", "all_representations_above_both_baselines"),
+                True,
+            ),
+        ),
+    ),
+    "FIG-3AB": TargetRecipe(
+        "classifier",
+        "derived-artifact-reanalysis",
+        "available",
+        CLASSIFIER_RECIPE_INPUTS,
+        _target_builder(
+            _rule(
+                "classifier modeled endpoint distributions",
+                ("classifier", "modeled_endpoint_counts"),
+                {"axiom": 2, "toxcast_cytotox": 34, "toxcast_cellbased": 267, "toxcast_cellfree": 53},
+            ),
+            _rule(
+                "all-concentration CellProfiler distribution summaries",
+                ("classifier", "all_cellprofiler_medians"),
+                {
+                    "axiom": {"auroc": 0.901547, "prauc": 0.805566},
+                    "toxcast_cytotox": {"auroc": 0.73721, "prauc": 0.477455},
+                    "toxcast_cellbased": {"auroc": 0.607226, "prauc": 0.14484},
+                    "toxcast_cellfree": {"auroc": 0.532086, "prauc": 0.454015},
+                },
+                lambda observed, expected: all(
+                    abs(observed[c][m] - expected[c][m]) <= 5e-7 for c in expected for m in expected[c]
+                ),
+            ),
+        ),
+    ),
+    "FIG-3C": TargetRecipe(
+        "classifier",
+        "derived-artifact-reanalysis",
+        "available",
+        CLASSIFIER_RECIPE_INPUTS,
+        _target_builder(
+            _rule(
+                "cell-based versus cell-free baseline conclusion",
+                ("classifier", "conclusion_gates", "cellbased_not_cellfree"),
+                True,
+            )
+        ),
+    ),
+    "FILTER-001": TargetRecipe(
+        "classifier",
+        "derived-artifact-reanalysis",
+        "available",
+        CLASSIFIER_RECIPE_INPUTS,
+        _target_builder(
+            _rule(
+                "allpod versus all effects remain small",
+                ("classifier", "conclusion_gates", "allpod_small_effects"),
+                True,
+            )
+        ),
+    ),
+    "FILTER-002": TargetRecipe(
+        "classifier",
+        "derived-artifact-reanalysis",
+        "available",
+        CLASSIFIER_RECIPE_INPUTS,
+        _target_builder(
+            _computed_rule(
+                "Axiom allpodcc minus allpod mean AUROC",
+                lambda a: a["classifier"]["filter_effects"]["axiom"]["auroc"]["mean_difference"],
+                -0.124974386867459,
+                lambda observed, expected: abs(float(observed) - float(expected)) <= 1e-12,
+            ),
+            _computed_rule(
+                "Axiom allpodcc minus allpod mean PRAUC",
+                lambda a: a["classifier"]["filter_effects"]["axiom"]["prauc"]["mean_difference"],
+                -0.372361412793057,
+                lambda observed, expected: abs(float(observed) - float(expected)) <= 1e-12,
+            ),
+            _computed_rule(
+                "allpodcc minus allpod mean AUROC",
+                lambda a: {
+                    category: a["classifier"]["filter_effects"][category]["auroc"]["mean_difference"]
+                    for category in ("toxcast_cellbased", "toxcast_cellfree", "toxcast_cytotox")
+                },
+                {
+                    "toxcast_cellbased": -0.0079701890,
+                    "toxcast_cellfree": 0.0134291664,
+                    "toxcast_cytotox": -0.0885859687,
+                },
+                lambda observed, expected: all(abs(observed[key] - expected[key]) <= 1e-10 for key in expected),
+            ),
+            _computed_rule(
+                "allpodcc minus allpod mean PRAUC",
+                lambda a: {
+                    category: a["classifier"]["filter_effects"][category]["prauc"]["mean_difference"]
+                    for category in ("toxcast_cellbased", "toxcast_cellfree", "toxcast_cytotox")
+                },
+                {
+                    "toxcast_cellbased": -0.0065967963,
+                    "toxcast_cellfree": 0.0051519574,
+                    "toxcast_cytotox": -0.1671635603,
+                },
+                lambda observed, expected: all(abs(observed[key] - expected[key]) <= 1e-10 for key in expected),
+            ),
+            _rule(
+                "Axiom and cytotoxic effects are negative while cell-based and cell-free effects remain below 0.02",
+                ("classifier", "conclusion_gates", "allpodcc_filter_direction"),
+                True,
+            ),
+        ),
+    ),
+    "FIG-4A": TargetRecipe(
+        "classifier",
+        "derived-artifact-reanalysis",
+        "available",
+        CLASSIFIER_RECIPE_INPUTS,
+        _target_builder(
+            _rule(
+                "all-concentration strategy conclusion",
+                ("classifier", "conclusion_gates", "all_concentration_not_worse"),
+                True,
+            )
+        ),
+    ),
+    "REPRESENTATION-001": TargetRecipe(
+        "classifier",
+        "derived-artifact-reanalysis",
+        "available",
+        CLASSIFIER_RECIPE_INPUTS,
+        _target_builder(
+            _computed_rule(
+                "DINO versus CP-CNN cell-based AUROC effects",
+                lambda a: a["classifier"]["target_effects"]["dino_vs_cpcnn_cellbased_auroc"],
+                {"mean_difference": 0.01079046, "median_difference": 0.01587302},
+                lambda observed, expected: all(abs(observed[key] - expected[key]) <= 5e-8 for key in expected),
+            ),
+            _computed_rule(
+                "DINO versus CellProfiler median cell-based AUROC",
+                lambda a: a["classifier"]["target_effects"]["dino_vs_cellprofiler_cellbased_auroc"][
+                    "median_difference"
+                ],
+                0.02209021,
+                lambda observed, expected: abs(float(observed) - float(expected)) <= 5e-8,
+            ),
+        ),
+    ),
+    "FIG-4B": TargetRecipe(
+        "classifier",
+        "derived-artifact-reanalysis",
+        "available",
+        CLASSIFIER_RECIPE_INPUTS,
+        _target_builder(
+            _rule(
+                "representation effects remain practically small",
+                ("classifier", "conclusion_gates", "representation_small_effects"),
+                True,
+            )
+        ),
+    ),
+    "SFIG-4": TargetRecipe(
+        "classifier",
+        "derived-artifact-reanalysis",
+        "available",
+        CLASSIFIER_RECIPE_INPUTS,
+        _target_builder(
+            _rule(
+                "PRAUC filtering and representation practical conclusion",
+                ("classifier", "conclusion_gates", "prauc_no_material_improvement"),
+                True,
+            )
+        ),
+    ),
+    "METHOD-CLASSIFIER": TargetRecipe(
+        "classifier",
+        "documentary-trace",
+        "documentary-only",
+        (
+            "1_snakemake/classifier/classify.py",
+            "1_snakemake/classifier/aggregate_profiles.py",
+            "1_snakemake/classifier/hitcalls.py",
+            "1_snakemake/rules/classifier.smk",
+        ),
+        _target_builder(_rule("classifier implementation trace", ("classifier", "method_trace"), True, _all_true)),
+    ),
+    "CONCLUSION-002": TargetRecipe(
+        "classifier",
+        "derived-artifact-reanalysis",
+        "available",
+        CLASSIFIER_RECIPE_INPUTS,
+        _target_builder(
+            _rule(
+                "cell-based but not cell-free inequality gate",
+                ("classifier", "conclusion_gates", "cellbased_not_cellfree"),
+                True,
+            )
+        ),
+    ),
+    "CONCLUSION-003": TargetRecipe(
+        "classifier",
+        "derived-artifact-reanalysis",
+        "available",
+        CLASSIFIER_RECIPE_INPUTS,
+        _target_builder(
+            _rule(
+                "representation and filtering practical-equivalence gates",
+                ("classifier", "conclusion_gates", "conclusion_003"),
+                True,
+            )
+        ),
+    ),
+    "SFIG-1": TargetRecipe(
+        "external_image",
+        "unavailable",
+        "out-of-scope",
+        ("paper/figures/figure-s1.jpg", "paper/paper.md"),
+        _target_builder(
+            _rule("tracked navigation image identity trace", ("external_image", "identity_trace"), True),
+            _rule("external source image available", ("external_image", "source_image_available"), False),
+        ),
+    ),
+}
+
+
+def _execution_outcome(recipe: TargetRecipe, checks_passed: bool) -> str:
+    if not checks_passed:
+        raise ScientificContradictionError("one or more target-specific checks failed")
+    outcomes = {
+        "available": "checked",
+        "documentary-only": "documentary-only",
+        "blocked": "blocked",
+        "out-of-scope": "out-of-scope",
+    }
+    if recipe.availability not in outcomes:
+        raise InputValidationError(f"invalid recipe availability: {recipe.availability}")
+    return outcomes[recipe.availability]
+
+
+def _artifact_names(group: str) -> list[str]:
+    names = ["evidence-coverage.svg"]
+    if group == "activity_pods":
+        names.append("pod-summary.svg")
+    elif group == "regression_enrichment":
+        names.append("enrichment-summary.svg")
+    elif group == "toxcast":
+        names.append("toxcast-summary.svg")
+    elif group == "classifier":
+        names.append("classifier-summary.svg")
+    return names
+
+
+def _count_field(rows: Sequence[Mapping[str, object]], field: str) -> dict[str, int]:
+    return dict(sorted(Counter(str(row[field]) for row in rows).items()))
+
+
+def build_report(root: Path, selected_ids: set[str] | None = None) -> dict[str, object]:
+    """Build a deterministic report from the explicit tracked-input allowlist."""
+    root = root.resolve()
+    validated_inputs: set[str] = set()
+    tracker_token = _VALIDATED_INPUTS.set(validated_inputs)
+    try:
+        targets = load_targets(root)
+        ledger_ids = [row["id"] for row in targets]
+        grouped_ids = [target_id for group in TARGET_GROUPS.values() for target_id in group]
+        _require(len(grouped_ids) == len(set(grouped_ids)), "TARGET_GROUPS contains duplicate target assignments")
+        _require(set(grouped_ids) == set(ledger_ids), "TARGET_GROUPS does not cover the target ledger exactly")
+        _require(set(TARGET_RECIPES) == set(ledger_ids), "TARGET_RECIPES does not cover the target ledger exactly")
+        _require(len(TARGET_RECIPES) == 53, f"TARGET_RECIPES has {len(TARGET_RECIPES)} entries; expected 53")
+        _require(len(ledger_ids) == 53, f"target ledger has {len(ledger_ids)} rows; expected 53")
+        for target_id, recipe in TARGET_RECIPES.items():
+            _require(target_id in TARGET_GROUPS[recipe.group], f"{target_id}: recipe group assignment differs")
+            _require(recipe.evidence_strength in EVIDENCE_STRENGTHS, f"{target_id}: invalid evidence strength")
+            _require(bool(recipe.inputs), f"{target_id}: recipe has no concrete inputs")
+            _require(set(recipe.inputs) <= ALLOWED_INPUTS, f"{target_id}: recipe contains a non-allowlisted input")
+
+        if selected_ids is not None:
+            unknown = sorted(selected_ids - set(ledger_ids))
+            _require(not unknown, f"unknown selected target IDs: {', '.join(unknown)}")
+            selected = set(selected_ids)
+            _require(bool(selected), "no targets selected")
+        else:
+            selected = set(ledger_ids)
+
+        executed_groups = [
+            group for group, group_ids in TARGET_GROUPS.items() if any(target_id in selected for target_id in group_ids)
+        ]
+        analysis_builders: dict[str, Callable[[Path], dict[str, object]]] = {
+            "sources_design": _analyze_sources_design,
+            "activity_pods": _analyze_activity_pods,
+            "regression_enrichment": _analyze_regression_enrichment,
+            "toxcast": _analyze_toxcast,
+            "classifier": _analyze_classifier,
+            "external_image": _analyze_external_image,
+        }
+        analyses: dict[str, object] = {group: analysis_builders[group](root) for group in executed_groups}
+
+        result_targets: list[dict[str, object]] = []
+        check_ids: set[str] = set()
+        for ledger_row in targets:
+            target_id = ledger_row["id"]
+            if target_id not in selected:
+                continue
+            recipe = TARGET_RECIPES[target_id]
+            raw_checks = recipe.check_builder(analyses)
+            _require(bool(raw_checks), f"{target_id}: recipe built no target-specific checks")
+            checks: list[dict[str, object]] = []
+            for index, raw_check in enumerate(raw_checks, start=1):
+                check_id = f"{target_id}:{index:02d}"
+                _require(check_id not in check_ids, f"duplicate target check ID {check_id}")
+                check_ids.add(check_id)
+                checks.append({"id": check_id, "target_id": target_id, **raw_check})
+            checks_passed = all(bool(check["passed"]) for check in checks)
+            _confirm(checks_passed, f"{target_id}: one or more target-specific checks failed")
+            execution_outcome = _execution_outcome(recipe, checks_passed)
+            limitations = [] if ledger_row["deviation"] == "-" else [ledger_row["deviation"]]
+            if recipe.availability == "documentary-only":
+                limitations.append(
+                    "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+                )
+            elif recipe.evidence_strength == "derived-artifact-reanalysis":
+                limitations.append(
+                    "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+                )
+            elif recipe.availability == "out-of-scope":
+                limitations.append("The raw source image is external and excluded from tracked-only execution.")
+            result_targets.append(
+                {
+                    "id": target_id,
+                    "source": ledger_row["source"],
+                    "kind": ledger_row["kind"],
+                    "description": ledger_row["description"],
+                    "expected": ledger_row["expected"],
+                    "acceptance": ledger_row["acceptance"],
+                    "producer": ledger_row["producer"],
+                    "evidence": ledger_row["evidence"],
+                    "deviation": ledger_row["deviation"],
+                    "group": recipe.group,
+                    "ledger_status": ledger_row["status"],
+                    "execution_outcome": execution_outcome,
+                    "evidence_strength": recipe.evidence_strength,
+                    "availability": recipe.availability,
+                    "acceptance_class": ledger_row["acceptance"].partition(":")[0],
+                    "summary": f"{ledger_row['description']}: target-specific tracked-only checks completed with execution outcome {execution_outcome}.",
+                    "checks": checks,
+                    "inputs": list(recipe.inputs),
+                    "limitations": limitations,
+                    "artifacts": _artifact_names(recipe.group),
+                }
+            )
+
+        ledger_bytes = _input_path(root, "paper/targets.tsv").read_bytes()
+        for target in result_targets:
+            missing_validations = sorted(set(target["inputs"]) - validated_inputs)
+            _require(
+                not missing_validations,
+                f"{target['id']}: reported inputs were not opened and validated: {', '.join(missing_validations)}",
+            )
+
+        group_reports: dict[str, object] = {}
+        for group in executed_groups:
+            rows = [row for row in result_targets if row["group"] == group]
+            group_reports[group] = {
+                "target_ids": [row["id"] for row in rows],
+                "target_count": len(rows),
+                "execution_outcome_counts": _count_field(rows, "execution_outcome"),
+                "evidence_strength_counts": _count_field(rows, "evidence_strength"),
+                "checks": [check for row in rows for check in row["checks"]],
+            }
+
+        summary = {
+            "total": len(result_targets),
+            "ledger_status_counts": _count_field(result_targets, "ledger_status"),
+            "execution_outcome_counts": _count_field(result_targets, "execution_outcome"),
+            "evidence_strength_counts": _count_field(result_targets, "evidence_strength"),
+            "acceptance_class_counts": _count_field(result_targets, "acceptance_class"),
+        }
+        report: dict[str, object] = {
+            "schema_version": SCHEMA_VERSION,
+            "mode": "tracked",
+            "ledger_sha256": hashlib.sha256(ledger_bytes).hexdigest(),
+            "executed_groups": executed_groups,
+            "validated_inputs": sorted(validated_inputs),
+            "summary": summary,
+            "analyses": analyses,
+            "groups": group_reports,
+            "targets": result_targets,
+        }
+    finally:
+        _VALIDATED_INPUTS.reset(tracker_token)
+    # This is both a finiteness gate and an early guarantee that no unsupported
+    # object type entered the public report schema.
+    try:
+        report = json.loads(json.dumps(report, sort_keys=True, allow_nan=False, ensure_ascii=True))
+    except (TypeError, ValueError) as exc:
+        raise InputValidationError(f"report is not strict JSON: {exc}") from exc
+    return report
+
+
+def _output_is_protected(output_dir: Path) -> bool:
+    resolved_parts = output_dir.resolve().parts
+    for relative in (*PROTECTED_INPUT_TREES, *FORBIDDEN_OUTPUT_TREES):
+        protected_parts = Path(relative).parts
+        width = len(protected_parts)
+        if any(
+            tuple(resolved_parts[index : index + width]) == protected_parts
+            for index in range(len(resolved_parts) - width + 1)
+        ):
+            return True
+    return False
+
+
+def _atomic_bytes(path: Path, content: bytes) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except Exception:
+        # A failed temporary file remains recoverable and clearly named.
+        raise
+
+
+def _markdown_cell(value: object) -> str:
+    if isinstance(value, (dict, list)):
+        text = json.dumps(value, sort_keys=True, ensure_ascii=True, allow_nan=False)
+    elif value is None:
+        text = "null"
+    else:
+        text = str(value)
+    return text.replace("|", "\\|").replace("\n", " ")
+
+
+def _render_markdown(report: Mapping[str, Any]) -> str:
+    summary = report["summary"]
+    analyses = report["analyses"]
+    lines = [
+        "# Tracked paper audit",
+        "",
+        "This report is an archive-safe reanalysis of tracked sources, annotations, and compiled artifacts.",
+        "It is not a rerun of ignored scientific workflows and its figures are not publisher reproductions.",
+        "An execution outcome of `checked` means the declared checks passed against tracked inputs; it does not mean upstream workflows were regenerated.",
+        "Historical ledger status is retained for provenance and does not determine the execution outcome.",
+        "",
+        f"Mode: `{report['mode']}`.",
+        f"Targets covered: {summary['total']}.",
+        f"Executed groups: {', '.join(report['executed_groups'])}.",
+        f"Validated tracked inputs: {len(report['validated_inputs'])}.",
+        f"Ledger SHA-256: `{report['ledger_sha256']}`.",
+        "",
+        "## Execution outcome counts",
+        "",
+        "| Execution outcome | Count |",
+        "| --- | ---: |",
+    ]
+    lines.extend(f"| {name} | {count} |" for name, count in summary["execution_outcome_counts"].items())
+    lines.extend(
+        [
+            "",
+            "## Historical ledger status counts",
+            "",
+            "| Ledger status | Count |",
+            "| --- | ---: |",
+        ]
+    )
+    lines.extend(f"| {name} | {count} |" for name, count in summary["ledger_status_counts"].items())
+    lines.extend(
+        [
+            "",
+            "## Evidence coverage",
+            "",
+            "| Evidence strength | Targets |",
+            "| --- | ---: |",
+        ]
+    )
+    lines.extend(f"| {name} | {count} |" for name, count in summary["evidence_strength_counts"].items())
+    lines.extend(["", "[Open the evidence-coverage figure](evidence-coverage.svg)."])
+
+    if "sources_design" in analyses:
+        sources = analyses["sources_design"]
+        table_s1 = sources["table_s1"]
+        lines.extend(
+            [
+                "",
+                "## Sources, design, and Table S1",
+                "",
+                f"All {sources['source_count']} manifest sources passed SHA-256 and byte-count checks.",
+                f"All {sources['office_archive_count']} Office archives passed ZIP CRC checks.",
+                f"Table S1 has {table_s1['rows']} rows, {table_s1['stable_id_count']} stable IDs, and {table_s1['blank_id_count']} blank IDs.",
+            ]
+        )
+
+    if "activity_pods" in analyses:
+        activity = analyses["activity_pods"]
+        figure_2c = activity["figure_2c_three_general"]
+        figure_2d = activity["figure_2d"]
+        lines.extend(
+            [
+                "",
+                "## Activity and PODs",
+                "",
+                f"The direction-aware cytotoxicity trace records {activity['direction_aware_cytotoxicity']['count']} compounds and explicitly records that direction is absent from hit_summary.csv.",
+                "",
+                "| Figure 2A compound | Published Table S2 POD (uM) |",
+                "| --- | ---: |",
+            ]
+        )
+        lines.extend(f"| {row['compound']} | {row['pod_um']:.6g} |" for row in activity["figure_2a"]["rows"])
+        lines.extend(
+            [
+                "",
+                f"Figure 2C has {activity['figure_2c_complete_case']['count']} published-SI five-series cases and {figure_2c['count']} three-general cases.",
+                f"The three-general CP-CNN ratios are {figure_2c['geometric_fold_ratios']['cpcnn_over_cellprofiler']:.6g} over CellProfiler and {figure_2c['geometric_fold_ratios']['cpcnn_over_dino']:.6g} over DINO.",
+                f"The three-general CellProfiler-DINO paired-log10 p-value is {figure_2c['cellprofiler_vs_dino_paired_log10']['paired_t_p_value']:.6g}.",
+                f"Figure 2D has {figure_2d['complete_case_count']} published-SI complete cases and preserves the morphology, MT, cell-count, LDH median ordering.",
+                "",
+                "[Open the POD-summary figure](pod-summary.svg).",
+            ]
+        )
+
+    if "regression_enrichment" in analyses:
+        regression = analyses["regression_enrichment"]
+        lines.extend(
+            [
+                "",
+                "## Regression and enrichment",
+                "",
+                "Regression and Figure S2 numerical acceptance was not rerun because the required prediction and metric Parquets are not tracked.",
+                "Their recipes validate the paper, producer notebook, implementation, and evidence trace explicitly.",
+                "The four tracked enrichment tables were directly recomputed with upper-tail hypergeometric tests and BH FDR.",
+                "",
+                "| Enrichment artifact | Hit list | Significant sets | Maximum p error | Maximum FDR error |",
+                "| --- | ---: | ---: | ---: | ---: |",
+            ]
+        )
+        for name, values in regression["files"].items():
+            lines.append(
+                f"| {name} | {values['hit_list_size']} | {values['significant_count']} | "
+                f"{values['maximum_p_value_recomputation_error']:.3g} | "
+                f"{values['maximum_fdr_recomputation_error']:.3g} |"
+            )
+        lines.extend(
+            [
+                "",
+                f"MT-higher significant classes: {_markdown_cell(regression['significant_classes']['mtt_higher'])}.",
+                f"MT-lower significant classes: {_markdown_cell(regression['significant_classes']['mtt_lower'])}.",
+                "",
+                "[Open the enrichment-summary figure](enrichment-summary.svg).",
+            ]
+        )
+
+    if "toxcast" in analyses:
+        toxcast = analyses["toxcast"]
+        lines.extend(
+            [
+                "",
+                "## ToxCast and Table S5",
+                "",
+                f"The pinned binary annotation union contains {toxcast['union_ids']} OASIS IDs; it is not a tested-library join.",
+                f"Tracked evidence documents an actual tested-library intersection of {toxcast['documented_tested_intersection']['ids']} IDs ({toxcast['documented_tested_intersection']['percent_of_published_library']:.6f}%).",
+                f"Cell-based tissue composition: {_markdown_cell(toxcast['composition']['cellbased_tissues'])}.",
+                f"Cell-free assay composition: {_markdown_cell(toxcast['composition']['cellfree_assay_types'])}.",
+                f"Cell-free target-family composition: {_markdown_cell(toxcast['composition']['cellfree_target_families'])}.",
+                f"Median compounds observed per endpoint: {_markdown_cell(toxcast['endpoint_medians']['observed_compounds'])}.",
+                f"Median endpoint active fractions: {_markdown_cell(toxcast['endpoint_medians']['active_fraction'])}.",
+                f"The heatmap substrate has {toxcast['heatmap_summary']['cell_categories']} cell categories, {toxcast['heatmap_summary']['tissue_categories']} tissue categories, and {toxcast['heatmap_summary']['complete_compounds']} complete compounds.",
+                f"Table S5 has {toxcast['table_s5']['nuclear_receptor_assays']} nuclear-receptor assays and {toxcast['table_s5']['cytotoxicity_source_hits']} source cytotoxicity hits.",
+                "",
+                "[Open the ToxCast-summary figure](toxcast-summary.svg).",
+            ]
+        )
+
+    if "classifier" in analyses:
+        classifier = analyses["classifier"]
+        lines.extend(
+            [
+                "",
+                "## Classifier metrics",
+                "",
+                f"Modeled endpoint counts: {_markdown_cell(classifier['modeled_endpoint_counts'])}.",
+                f"All-concentration CellProfiler median AUROC and PRAUC: {_markdown_cell(classifier['all_cellprofiler_medians'])}.",
+                f"DINO cell-based target effects: {_markdown_cell(classifier['target_effects'])}.",
+                "",
+                "| Family | Metric | allpodcc minus allpod mean | Median | Matched endpoints |",
+                "| --- | --- | ---: | ---: | ---: |",
+            ]
+        )
+        for category, metric_rows in classifier["filter_effects"].items():
+            for metric, effect in metric_rows.items():
+                lines.append(
+                    f"| {category} | {metric} | {effect['mean_difference']:.6g} | "
+                    f"{effect['median_difference']:.6g} | {effect['matched_endpoints']} |"
+                )
+        lines.extend(["", "[Open the classifier-summary figure](classifier-summary.svg)."])
+
+    if "external_image" in analyses:
+        lines.extend(
+            [
+                "",
+                "## External image boundary",
+                "",
+                analyses["external_image"]["limitation"],
+            ]
+        )
+
+    figure_links = ["- [Evidence coverage](evidence-coverage.svg)"]
+    if "activity_pods" in analyses:
+        figure_links.append("- [POD summary](pod-summary.svg)")
+    if "regression_enrichment" in analyses:
+        figure_links.append("- [Enrichment summary](enrichment-summary.svg)")
+    if "toxcast" in analyses:
+        figure_links.append("- [ToxCast summary](toxcast-summary.svg)")
+    if "classifier" in analyses:
+        figure_links.append("- [Classifier summary](classifier-summary.svg)")
+    lines.extend(
+        [
+            "",
+            "## Generated figures",
+            "",
+            "Each SVG is generated from this report and labeled as tracked-artifact reanalysis.",
+            "",
+            *figure_links,
+            "",
+            "## Targets",
+        ]
+    )
+    for target in report["targets"]:
+        lines.extend(
+            [
+                "",
+                f"### {target['id']} - {target['description']}",
+                "",
+                f"Source: {_markdown_cell(target['source'])}.",
+                f"Kind: {_markdown_cell(target['kind'])}.",
+                f"Expected: {_markdown_cell(target['expected'])}.",
+                f"Full acceptance: {_markdown_cell(target['acceptance'])}.",
+                f"Producer: {_markdown_cell(target['producer'])}.",
+                f"Ledger evidence: {_markdown_cell(target['evidence'])}.",
+                f"Historical ledger status: `{target['ledger_status']}`.",
+                f"Execution outcome: `{target['execution_outcome']}`; availability: `{target['availability']}`; evidence strength: `{target['evidence_strength']}`.",
+                f"Declared deviation: {_markdown_cell(target['deviation'])}.",
+                "",
+                "| Target-specific check | Observed | Expected | Passed |",
+                "| --- | --- | --- | --- |",
+            ]
+        )
+        for check in target["checks"]:
+            lines.append(
+                f"| {check['id']} - {_markdown_cell(check['name'])} | {_markdown_cell(check['observed'])} | "
+                f"{_markdown_cell(check['expected'])} | {str(check['passed']).lower()} |"
+            )
+        lines.extend(["", "Validated inputs:"])
+        lines.extend(f"- `{path}`" for path in target["inputs"])
+        lines.extend(["", "Limitations and deviations:"])
+        if target["limitations"]:
+            lines.extend(f"- {_markdown_cell(limitation)}" for limitation in target["limitations"])
+        else:
+            lines.append("- None declared.")
+    lines.append("")
+    text = "\n".join(lines)
+    try:
+        text.encode("ascii")
+    except UnicodeEncodeError as exc:
+        raise InputValidationError("rendered Markdown is not ASCII") from exc
+    return text
+
+
+def _plot_style() -> None:
+    matplotlib.rcParams.update(
+        {
+            "axes.unicode_minus": False,
+            "font.family": "DejaVu Sans",
+            "font.size": 9,
+            "svg.fonttype": "path",
+            "svg.hashsalt": "oasis-paper-tracked-v1",
+            "figure.facecolor": "white",
+            "axes.facecolor": "white",
+            "axes.edgecolor": "#333333",
+            "axes.titleweight": "bold",
+        }
+    )
+
+
+def _save_svg(fig: Any, path: Path) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.stem}.", suffix=".svg", dir=path.parent)
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    fig.savefig(temporary, format="svg", metadata={"Date": None}, bbox_inches="tight")
+    plt.close(fig)
+    svg_text = temporary.read_text(encoding="utf-8")
+    normalized_svg = "\n".join(line.rstrip(" \t") for line in svg_text.splitlines()) + "\n"
+    temporary.write_text(normalized_svg, encoding="utf-8", newline="\n")
+    os.replace(temporary, path)
+
+
+def _bar_figure(labels: Sequence[str], values: Sequence[float], title: str, ylabel: str, color: str) -> Any:
+    fig, axis = plt.subplots(figsize=(7.2, 4.2), dpi=100)
+    positions = np.arange(len(labels))
+    axis.bar(positions, values, color=color, width=0.68)
+    axis.set_xticks(positions, labels, rotation=20, ha="right")
+    axis.set_ylabel(ylabel)
+    axis.set_title(title)
+    axis.spines[["top", "right"]].set_visible(False)
+    axis.grid(axis="y", color="#dddddd", linewidth=0.6)
+    axis.set_axisbelow(True)
+    return fig
+
+
+def render_outputs(report: dict[str, object], output_dir: Path) -> list[Path]:
+    """Render current outputs, then prune stale files from the known inventory."""
+    required = {
+        "schema_version",
+        "mode",
+        "ledger_sha256",
+        "executed_groups",
+        "validated_inputs",
+        "summary",
+        "analyses",
+        "groups",
+        "targets",
+    }
+    _require(set(report) == required, "report has an unexpected top-level schema")
+    output_dir = output_dir.resolve()
+    _require(not _output_is_protected(output_dir), f"output path is inside a protected input tree: {output_dir}")
+    if output_dir.exists():
+        _require(output_dir.is_dir(), f"output path is not a directory: {output_dir}")
+    else:
+        output_dir.mkdir(parents=True, exist_ok=False)
+
+    expected_filenames = {"report.json", "report.md", "evidence-coverage.svg"}
+    expected_filenames.update(
+        filename for group, filename in ANALYSIS_FIGURE_FILENAMES.items() if group in report["analyses"]
+    )
+    _require(expected_filenames <= KNOWN_OUTPUT_FILENAMES, "computed an unknown generated output filename")
+
+    json_bytes = (json.dumps(report, indent=2, sort_keys=True, ensure_ascii=True, allow_nan=False) + "\n").encode(
+        "ascii"
+    )
+    markdown_bytes = _render_markdown(report).encode("ascii")
+    report_json = output_dir / "report.json"
+    report_markdown = output_dir / "report.md"
+    _atomic_bytes(report_json, json_bytes)
+    _atomic_bytes(report_markdown, markdown_bytes)
+
+    _plot_style()
+    summary = report["summary"]
+    evidence_counts = summary["evidence_strength_counts"]
+    evidence_labels = list(evidence_counts)
+    evidence_figure = _bar_figure(
+        evidence_labels,
+        [evidence_counts[label] for label in evidence_labels],
+        "Evidence coverage - tracked-artifact audit",
+        "Targets",
+        "#4c78a8",
+    )
+    evidence_path = output_dir / "evidence-coverage.svg"
+    _save_svg(evidence_figure, evidence_path)
+    written = [report_json, report_markdown, evidence_path]
+
+    if "activity_pods" in report["analyses"]:
+        medians = report["analyses"]["activity_pods"]["figure_2d"]["median_pod_um"]
+        pod_labels = ["Morphology", "MT", "Cell count", "LDH"]
+        pod_figure = _bar_figure(
+            pod_labels,
+            [medians[label] for label in pod_labels],
+            "POD summary - tracked-artifact reanalysis",
+            "Median POD (uM)",
+            "#59a14f",
+        )
+        pod_path = output_dir / "pod-summary.svg"
+        _save_svg(pod_figure, pod_path)
+        written.append(pod_path)
+
+    if "classifier" in report["analyses"]:
+        modeled = report["analyses"]["classifier"]["modeled_endpoint_counts"]
+        classifier_labels = list(modeled)
+        classifier_figure = _bar_figure(
+            classifier_labels,
+            [modeled[label] for label in classifier_labels],
+            "Classifier denominators - tracked-artifact reanalysis",
+            "Modeled endpoints",
+            "#f28e2b",
+        )
+        classifier_path = output_dir / "classifier-summary.svg"
+        _save_svg(classifier_figure, classifier_path)
+        written.append(classifier_path)
+
+    if "regression_enrichment" in report["analyses"]:
+        enrichment_files = report["analyses"]["regression_enrichment"]["files"]
+        enrichment_labels = [name.removesuffix("_targets.csv") for name in enrichment_files]
+        enrichment_figure = _bar_figure(
+            enrichment_labels,
+            [item["significant_count"] for item in enrichment_files.values()],
+            "Enrichment summary - tracked-artifact reanalysis",
+            "Target sets with FDR < 0.05",
+            "#e15759",
+        )
+        enrichment_path = output_dir / "enrichment-summary.svg"
+        _save_svg(enrichment_figure, enrichment_path)
+        written.append(enrichment_path)
+
+    if "toxcast" in report["analyses"]:
+        toxcast = report["analyses"]["toxcast"]
+        categories = ["cellbased", "cellfree", "cytotox"]
+        positions = np.arange(len(categories))
+        width = 0.36
+        toxcast_figure, axis = plt.subplots(figsize=(7.2, 4.2), dpi=100)
+        axis.bar(
+            positions - width / 2,
+            [toxcast["source_endpoint_counts"][name] for name in categories],
+            width,
+            label="Source",
+            color="#4c78a8",
+        )
+        axis.bar(
+            positions + width / 2,
+            [toxcast["binary_endpoint_counts"][name] for name in categories],
+            width,
+            label="Binary",
+            color="#b279a2",
+        )
+        axis.set_xticks(positions, categories)
+        axis.set_ylabel("Endpoints")
+        axis.set_title("ToxCast endpoints - tracked-artifact reanalysis")
+        axis.legend(frameon=False)
+        axis.spines[["top", "right"]].set_visible(False)
+        axis.grid(axis="y", color="#dddddd", linewidth=0.6)
+        axis.set_axisbelow(True)
+        toxcast_path = output_dir / "toxcast-summary.svg"
+        _save_svg(toxcast_figure, toxcast_path)
+        written.append(toxcast_path)
+
+    _require({path.name for path in written} == expected_filenames, "rendered output inventory is incomplete")
+    # Prune only obsolete artifacts from the fixed generated-output inventory,
+    # and only after every output expected for this report rendered successfully.
+    # Unknown files in the destination are deliberately preserved.
+    for filename in sorted(KNOWN_OUTPUT_FILENAMES - expected_filenames):
+        stale_path = output_dir / filename
+        if stale_path.exists() or stale_path.is_symlink():
+            stale_path.unlink()
+
+    return written
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, help="output directory (default: paper/reproduction)")
+    parser.add_argument("--target", action="append", default=[], help="target ID to include; repeat as needed")
+    parser.add_argument("--list", action="store_true", dest="list_targets", help="list target IDs and exit")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the CLI and return 0, 1, or 2 according to the paper contract."""
+    arguments = _parser().parse_args(argv)
+    try:
+        targets = load_targets(REPOSITORY_ROOT)
+        if arguments.list_targets:
+            for row in targets:
+                print(row["id"])
+            return 0
+        selected = set(arguments.target) if arguments.target else None
+        if arguments.target and len(arguments.target) != len(selected or ()):
+            raise InputValidationError("--target values must not be repeated")
+        report = build_report(REPOSITORY_ROOT, selected)
+        output = arguments.output or REPOSITORY_ROOT / "paper/reproduction"
+        paths = render_outputs(report, output)
+        print(f"Wrote tracked paper audit for {report['summary']['total']} targets to {paths[0].parent}")
+        return 0
+    except ScientificContradictionError as exc:
+        print(f"scientific or ledger contradiction: {exc}", file=sys.stderr)
+        return 1
+    except (InputValidationError, OSError) as exc:
+        print(f"malformed input, incomplete coverage, or unsafe output: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/paper/reproduce.py.lock
+++ b/paper/reproduce.py.lock
@@ -1,0 +1,298 @@
+version = 1
+revision = 3
+requires-python = "==3.11.*"
+
+[manifest]
+requirements = [
+    { name = "matplotlib", specifier = "==3.9.2" },
+    { name = "numpy", specifier = "==1.24.3" },
+    { name = "pandas", specifier = "==2.2.2" },
+    { name = "pyarrow", specifier = "==14.0.1" },
+    { name = "scipy", specifier = "==1.13.1" },
+    { name = "statsmodels", specifier = "==0.14.3" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/b9/ede788a0b56fc5b071639d06c33cb893f68b1178938f3425debebe2dab78/contourpy-1.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6a37a2fb93d4df3fc4c0e363ea4d16f83195fc09c891bc8ce072b9d084853445", size = 269636, upload-time = "2025-04-15T17:35:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/75/3469f011d64b8bbfa04f709bfc23e1dd71be54d05b1b083be9f5b22750d1/contourpy-1.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b7cd50c38f500bbcc9b6a46643a40e0913673f869315d8e70de0438817cb7773", size = 254636, upload-time = "2025-04-15T17:35:58.283Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2f/95adb8dae08ce0ebca4fd8e7ad653159565d9739128b2d5977806656fcd2/contourpy-1.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6658ccc7251a4433eebd89ed2672c2ed96fba367fd25ca9512aa92a4b46c4f1", size = 313053, upload-time = "2025-04-15T17:36:03.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a6/8ccf97a50f31adfa36917707fe39c9a0cbc24b3bbb58185577f119736cc9/contourpy-1.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:70771a461aaeb335df14deb6c97439973d253ae70660ca085eec25241137ef43", size = 352985, upload-time = "2025-04-15T17:36:08.275Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b6/7925ab9b77386143f39d9c3243fdd101621b4532eb126743201160ffa7e6/contourpy-1.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65a887a6e8c4cd0897507d814b14c54a8c2e2aa4ac9f7686292f9769fcf9a6ab", size = 323750, upload-time = "2025-04-15T17:36:13.29Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f3/20c5d1ef4f4748e52d60771b8560cf00b69d5c6368b5c2e9311bcfa2a08b/contourpy-1.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3859783aefa2b8355697f16642695a5b9792e7a46ab86da1118a4a23a51a33d7", size = 326246, upload-time = "2025-04-15T17:36:18.329Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e5/9dae809e7e0b2d9d70c52b3d24cba134dd3dad979eb3e5e71f5df22ed1f5/contourpy-1.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eab0f6db315fa4d70f1d8ab514e527f0366ec021ff853d7ed6a2d33605cf4b83", size = 1308728, upload-time = "2025-04-15T17:36:33.878Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/0058ba34aeea35c0b442ae61a4f4d4ca84d6df8f91309bc2d43bb8dd248f/contourpy-1.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d91a3ccc7fea94ca0acab82ceb77f396d50a1f67412efe4c526f5d20264e6ecd", size = 1375762, upload-time = "2025-04-15T17:36:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/09/33/7174bdfc8b7767ef2c08ed81244762d93d5c579336fc0b51ca57b33d1b80/contourpy-1.3.2-cp311-cp311-win32.whl", hash = "sha256:1c48188778d4d2f3d48e4643fb15d8608b1d01e4b4d6b0548d9b336c28fc9b6f", size = 178196, upload-time = "2025-04-15T17:36:55.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/fe/4029038b4e1c4485cef18e480b0e2cd2d755448bb071eb9977caac80b77b/contourpy-1.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:5ebac872ba09cb8f2131c46b8739a7ff71de28a24c869bcad554477eb089a878", size = 222017, upload-time = "2025-04-15T17:36:58.576Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c0/91f1215d0d9f9f343e4773ba6c9b89e8c0cc7a64a6263f21139da639d848/contourpy-1.3.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:5f5964cdad279256c084b69c3f412b7801e15356b16efa9d78aa974041903da0", size = 266807, upload-time = "2025-04-15T17:45:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/79/6be7e90c955c0487e7712660d6cead01fa17bff98e0ea275737cc2bc8e71/contourpy-1.3.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49b65a95d642d4efa8f64ba12558fcb83407e58a2dfba9d796d77b63ccfcaff5", size = 318729, upload-time = "2025-04-15T17:45:20.166Z" },
+    { url = "https://files.pythonhosted.org/packages/87/68/7f46fb537958e87427d98a4074bcde4b67a70b04900cfc5ce29bc2f556c1/contourpy-1.3.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8c5acb8dddb0752bf252e01a3035b21443158910ac16a3b0d20e7fed7d534ce5", size = 221791, upload-time = "2025-04-15T17:45:24.794Z" },
+]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.63.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/2b/a7f1545bdf5da69c4bda0cea2a5781f0ad2a6623e0277267672db43c5fe6/fonttools-4.63.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2b8ae05d9eacf6081414d759c0a352769ac28ce31280d6bb8e77b03f9e3c449f", size = 2881793, upload-time = "2026-05-14T12:02:56.645Z" },
+    { url = "https://files.pythonhosted.org/packages/49/50/965308c703f085f225db2886813b27e015b8b3438c350b22dd65b52c2a2c/fonttools-4.63.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:79cdc9f567aec74a72918fd060283911406750cbc9fd28c1316023deb6ce31a9", size = 2428130, upload-time = "2026-05-14T12:02:58.891Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/38/6937fbd7f2dc3a6b48725851bc2c15ec949b9af14d9bbcb5fe83cdf9bdf9/fonttools-4.63.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c14b4fd138c4bafcca294765c547914e1aa431ae1ca94ab99d8db08c958bd3b", size = 5111952, upload-time = "2026-05-14T12:03:01.263Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/a81f20050a3115b57d62c8e781446949512eac36690dc384ccea65ff4cc1/fonttools-4.63.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76ac49f929aecaf82d83250b8347e099d7aecba0f4726c1d9b6df3b8bb5fe18", size = 5082308, upload-time = "2026-05-14T12:03:03.211Z" },
+    { url = "https://files.pythonhosted.org/packages/67/00/cdd9d4944ca6ae280d01e69cc37bde3bf663630b837a6fc6d2cd65d80e0e/fonttools-4.63.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dcf076a4474fe0d7367e5bbf5b052c7284fa1feca729c04176ce513521afd8a0", size = 5087932, upload-time = "2026-05-14T12:03:05.147Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f1/0aa0dbea778c75adbef223c42019fd47d22262b905974d62d829545d485f/fonttools-4.63.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7dd683fef0663e9f0f45cf541d788d24caa3ec9db50796b588e1757d8b3bc007", size = 5213271, upload-time = "2026-05-14T12:03:07.238Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/253e4056e1f0e67b9390125a154b73b5eb73ad521bece95c004858fdeec2/fonttools-4.63.0-cp311-cp311-win32.whl", hash = "sha256:afefc1ed0a59785a7fb06ea7e1678e849c193e1e387db783579bc7b3056fcfcb", size = 2304473, upload-time = "2026-05-14T12:03:09.271Z" },
+    { url = "https://files.pythonhosted.org/packages/08/60/defa5e69641db890a63be281f41345f4c33b157824eaf0b9fad3e08b0dcb/fonttools-4.63.0-cp311-cp311-win_amd64.whl", hash = "sha256:063e08bd17bd5a90127a14123de0d6a952dbc847695fd98b63c043d58057f90c", size = 2356389, upload-time = "2026-05-14T12:03:11.53Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/dd/a495a9c104be1c476f0386e714252caf2b7eca883915422a64c50b88c6f5/kiwisolver-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9eed0f7edbb274413b6ee781cca50541c8c0facd3d6fd289779e494340a2b85c", size = 122798, upload-time = "2026-03-09T13:12:58.963Z" },
+    { url = "https://files.pythonhosted.org/packages/11/60/37b4047a2af0cf5ef6d8b4b26e91829ae6fc6a2d1f74524bcb0e7cd28a32/kiwisolver-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c4923e404d6bcd91b6779c009542e5647fef32e4a5d75e115e3bbac6f2335eb", size = 66216, upload-time = "2026-03-09T13:13:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/aa/510dc933d87767584abfe03efa445889996c70c2990f6f87c3ebaa0a18c5/kiwisolver-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0df54df7e686afa55e6f21fb86195224a6d9beb71d637e8d7920c95cf0f89aac", size = 63911, upload-time = "2026-03-09T13:13:01.671Z" },
+    { url = "https://files.pythonhosted.org/packages/80/46/bddc13df6c2a40741e0cc7865bb1c9ed4796b6760bd04ce5fae3928ef917/kiwisolver-1.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2517e24d7315eb51c10664cdb865195df38ab74456c677df67bb47f12d088a27", size = 1438209, upload-time = "2026-03-09T13:13:03.385Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d6/76621246f5165e5372f02f5e6f3f48ea336a8f9e96e43997d45b240ed8cd/kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff710414307fefa903e0d9bdf300972f892c23477829f49504e59834f4195398", size = 1248888, upload-time = "2026-03-09T13:13:05.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c1/31559ec6fb39a5b48035ce29bb63ade628f321785f38c384dee3e2c08bc1/kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6176c1811d9d5a04fa391c490cc44f451e240697a16977f11c6f722efb9041db", size = 1266304, upload-time = "2026-03-09T13:13:06.743Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ef/1cb8276f2d29cc6a41e0a042f27946ca347d3a4a75acf85d0a16aa6dcc82/kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50847dca5d197fcbd389c805aa1a1cf32f25d2e7273dc47ab181a517666b68cc", size = 1319650, upload-time = "2026-03-09T13:13:08.607Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/e4/5ba3cecd7ce6236ae4a80f67e5d5531287337d0e1f076ca87a5abe4cd5d0/kiwisolver-1.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:01808c6d15f4c3e8559595d6d1fe6411c68e4a3822b4b9972b44473b24f4e679", size = 970949, upload-time = "2026-03-09T13:13:10.299Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/69/dc61f7ae9a2f071f26004ced87f078235b5507ab6e5acd78f40365655034/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f1f9f4121ec58628c96baa3de1a55a4e3a333c5102c8e94b64e23bf7b2083309", size = 2199125, upload-time = "2026-03-09T13:13:11.841Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7b/abbe0f1b5afa85f8d084b73e90e5f801c0939eba16ac2e49af7c61a6c28d/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b7d335370ae48a780c6e6a6bbfa97342f563744c39c35562f3f367665f5c1de2", size = 2293783, upload-time = "2026-03-09T13:13:14.399Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/80/5908ae149d96d81580d604c7f8aefd0e98f4fd728cf172f477e9f2a81744/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:800ee55980c18545af444d93fdd60c56b580db5cc54867d8cbf8a1dc0829938c", size = 1960726, upload-time = "2026-03-09T13:13:16.047Z" },
+    { url = "https://files.pythonhosted.org/packages/84/08/a78cb776f8c085b7143142ce479859cfec086bd09ee638a317040b6ef420/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:c438f6ca858697c9ab67eb28246c92508af972e114cac34e57a6d4ba17a3ac08", size = 2464738, upload-time = "2026-03-09T13:13:17.897Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e1/65584da5356ed6cb12c63791a10b208860ac40a83de165cb6a6751a686e3/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8c63c91f95173f9c2a67c7c526b2cea976828a0e7fced9cdcead2802dc10f8a4", size = 2270718, upload-time = "2026-03-09T13:13:19.421Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6c/28f17390b62b8f2f520e2915095b3c94d88681ecf0041e75389d9667f202/kiwisolver-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:beb7f344487cdcb9e1efe4b7a29681b74d34c08f0043a327a74da852a6749e7b", size = 73480, upload-time = "2026-03-09T13:13:20.818Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/0e/2ee5debc4f77a625778fec5501ff3e8036fe361b7ee28ae402a485bb9694/kiwisolver-1.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:ad4ae4ffd1ee9cd11357b4c66b612da9888f4f4daf2f36995eda64bd45370cac", size = 64930, upload-time = "2026-03-09T13:13:21.997Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/eb/5fcbbbf9a0e2c3a35effb88831a483345326bbc3a030a3b5b69aee647f84/kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ec4c85dc4b687c7f7f15f553ff26a98bfe8c58f5f7f0ac8905f0ba4c7be60232", size = 59532, upload-time = "2026-03-09T13:15:47.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9b/e17104555bb4db148fd52327feea1e96be4b88e8e008b029002c281a21ab/kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:12e91c215a96e39f57989c8912ae761286ac5a9584d04030ceb3368a357f017a", size = 57420, upload-time = "2026-03-09T13:15:48.199Z" },
+    { url = "https://files.pythonhosted.org/packages/48/44/2b5b95b7aa39fb2d8d9d956e0f3d5d45aef2ae1d942d4c3ffac2f9cfed1a/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be4a51a55833dc29ab5d7503e7bcb3b3af3402d266018137127450005cdfe737", size = 79892, upload-time = "2026-03-09T13:15:49.694Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7d/7157f9bba6b455cfb4632ed411e199fc8b8977642c2b12082e1bd9e6d173/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daae526907e262de627d8f70058a0f64acc9e2641c164c99c8f594b34a799a16", size = 77603, upload-time = "2026-03-09T13:15:50.945Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/dd/8050c947d435c8d4bc94e3252f4d8bb8a76cfb424f043a8680be637a57f1/kiwisolver-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:59cd8683f575d96df5bb48f6add94afc055012c29e28124fcae2b63661b9efb1", size = 73558, upload-time = "2026-03-09T13:15:52.112Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/d8/3d7f706c69e024d4287c1110d74f7dabac91d9843b99eadc90de9efc8869/matplotlib-3.9.2.tar.gz", hash = "sha256:96ab43906269ca64a6366934106fa01534454a69e471b7bf3d79083981aaab92", size = 36088381, upload-time = "2024-08-13T01:45:36.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c2/f9d7fe80a8fcce9bb128d1381c6fe41a8d286d7e18395e273002e8e0fa34/matplotlib-3.9.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d8dd059447824eec055e829258ab092b56bb0579fc3164fa09c64f3acd478772", size = 7902925, upload-time = "2024-08-13T01:44:35.27Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ba/8be09886eb56ac04a218a1dc3fa728a5c4cac60b019b4f1687885166da00/matplotlib-3.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c797dac8bb9c7a3fd3382b16fe8f215b4cf0f22adccea36f1545a6d7be310b41", size = 7773193, upload-time = "2024-08-13T01:44:36.78Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9a/5991972a560db3ab621312a7ca5efec339ae2122f25901c0846865c4b72f/matplotlib-3.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d719465db13267bcef19ea8954a971db03b9f48b4647e3860e4bc8e6ed86610f", size = 8202378, upload-time = "2024-08-13T01:44:38.772Z" },
+    { url = "https://files.pythonhosted.org/packages/01/75/6c7ce560e95714a10fcbb3367d1304975a1a3e620f72af28921b796403f3/matplotlib-3.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8912ef7c2362f7193b5819d17dae8629b34a95c58603d781329712ada83f9447", size = 8314361, upload-time = "2024-08-13T01:44:40.994Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/49/dc7384c6c092958e0b75e754efbd9e52500154939c3d715789cee9fb8a53/matplotlib-3.9.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7741f26a58a240f43bee74965c4882b6c93df3e7eb3de160126d8c8f53a6ae6e", size = 9091428, upload-time = "2024-08-13T01:44:42.904Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ce/15b0bb2fb29b3d46211d8ca740b96b5232499fc49200b58b8d571292c9a6/matplotlib-3.9.2-cp311-cp311-win_amd64.whl", hash = "sha256:ae82a14dab96fbfad7965403c643cafe6515e386de723e498cf3eeb1e0b70cc7", size = 7829377, upload-time = "2024-08-13T01:44:44.843Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "1.24.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/d4/590ae7df5044465cc9fa2db152ae12468694d62d952b1528ecff328ef7fc/numpy-1.24.3.tar.gz", hash = "sha256:ab344f1bf21f140adab8e47fdbc7c35a477dc01408791f8ba00d018dd0bc5155", size = 10909904, upload-time = "2023-04-22T21:44:47.789Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/7d/f69c47ea3db0cd8ca444aec241a80b538eb176ae756820489a9d2946ec8c/numpy-1.24.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9a7721ec204d3a237225db3e194c25268faf92e19338a35f3a224469cb6039a3", size = 19775092, upload-time = "2023-04-22T21:31:57.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/6c/7217a8844dfe22e349bccbecd35571fa72c5d7fe8b33d8c5540e8cc2535c/numpy-1.24.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d6cc757de514c00b24ae8cf5c876af2a7c3df189028d68c0cb4eaa9cd5afc2bf", size = 13839692, upload-time = "2023-04-22T21:32:18.71Z" },
+    { url = "https://files.pythonhosted.org/packages/72/eb/9c77bbc4d2b4ca17ef253621794a2d42897d896f86cd493db3eabe1a7d25/numpy-1.24.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76e3f4e85fc5d4fd311f6e9b794d0c00e7002ec122be271f2019d63376f1d385", size = 13991538, upload-time = "2023-04-22T21:32:40.184Z" },
+    { url = "https://files.pythonhosted.org/packages/82/19/321d369ede7458500f59151101470129d14f3b6768bb9b99bb7156f526b5/numpy-1.24.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1d3c026f57ceaad42f8231305d4653d5f05dc6332a730ae5c0bea3513de0950", size = 17278482, upload-time = "2023-04-22T21:33:05.897Z" },
+    { url = "https://files.pythonhosted.org/packages/94/84/ed45416c8319c02348a5812d5647796a0833e3fb5576d01758f2a72e9200/numpy-1.24.3-cp311-cp311-win32.whl", hash = "sha256:c91c4afd8abc3908e00a44b2672718905b8611503f7ff87390cc0ac3423fb096", size = 12422096, upload-time = "2023-04-22T21:33:24.783Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e8/1ea9adebdccaadfc208c7517e09f5145ed5a73069779ff436393085d47a2/numpy-1.24.3-cp311-cp311-win_amd64.whl", hash = "sha256:5342cf6aad47943286afa6f1609cad9b4266a05e7f2ec408e2cf7aea7ff69d80", size = 14833773, upload-time = "2023-04-22T21:33:47.309Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/d9/ecf715f34c73ccb1d8ceb82fc01cd1028a65a5f6dbc57bfa6ea155119058/pandas-2.2.2.tar.gz", hash = "sha256:9e79019aba43cb4fda9e4d983f8e88ca0373adbb697ae9c6c43093218de28b54", size = 4398391, upload-time = "2024-04-10T19:45:48.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/70/61704497903d43043e288017cb2b82155c0d41e15f5c17807920877b45c2/pandas-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:696039430f7a562b74fa45f540aca068ea85fa34c244d0deee539cb6d70aa288", size = 12574808, upload-time = "2024-04-10T19:44:35.516Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c6/75231fd47afd6b3f89011e7077f1a3958441264aca7ae9ff596e3276a5d0/pandas-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8e90497254aacacbc4ea6ae5e7a8cd75629d6ad2b30025a4a8b09aa4faf55151", size = 11304876, upload-time = "2024-04-10T19:44:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2d/7b54f80b93379ff94afb3bd9b0cd1d17b48183a0d6f98045bc01ce1e06a7/pandas-2.2.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58b84b91b0b9f4bafac2a0ac55002280c094dfc6402402332c0913a59654ab2b", size = 15602548, upload-time = "2024-04-10T19:44:42.902Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a5/4d82be566f069d7a9a702dcdf6f9106df0e0b042e738043c0cc7ddd7e3f6/pandas-2.2.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2123dc9ad6a814bcdea0f099885276b31b24f7edf40f6cdbc0912672e22eee", size = 13031332, upload-time = "2024-04-10T19:44:46.98Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a2/b79c48f530673567805e607712b29814b47dcaf0d167e87145eb4b0118c6/pandas-2.2.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:2925720037f06e89af896c70bca73459d7e6a4be96f9de79e2d440bd499fe0db", size = 16286054, upload-time = "2024-04-10T19:44:50.51Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c7/47e94907f1d8fdb4868d61bd6c93d57b3784a964d52691b77ebfdb062842/pandas-2.2.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0cace394b6ea70c01ca1595f839cf193df35d1575986e484ad35c4aeae7266c1", size = 13879507, upload-time = "2024-04-10T19:44:54.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/63/966db1321a0ad55df1d1fe51505d2cdae191b84c907974873817b0a6e849/pandas-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:873d13d177501a28b2756375d59816c365e42ed8417b41665f346289adc68d24", size = 11634249, upload-time = "2024-04-10T19:44:58.183Z" },
+]
+
+[[package]]
+name = "patsy"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/44/ed13eccdd0519eff265f44b670d46fbb0ec813e2274932dc1c0e48520f7d/patsy-1.0.2.tar.gz", hash = "sha256:cdc995455f6233e90e22de72c37fcadb344e7586fb83f06696f54d92f8ce74c0", size = 399942, upload-time = "2025-10-20T16:17:37.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/70/ba4b949bdc0490ab78d545459acd7702b211dfccf7eb89bbc1060f52818d/patsy-1.0.2-py2.py3-none-any.whl", hash = "sha256:37bfddbc58fcf0362febb5f54f10743f8b21dd2aa73dec7e7ef59d1b02ae668a", size = 233301, upload-time = "2025-10-20T16:17:36.563Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/c8/0a78b0e02d7ac54bc03e5321c9220da52f0c2ea83b21f7c40e7f3169c502/pillow-12.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:00808c5e14ef63ac5161091d242999076604ff74b883423a11e5d7bbb38bf756", size = 5392415, upload-time = "2026-07-01T11:53:47.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/5b/a02d30018abd97ced9f5a6c63d28597694a00d066516b9c1c6de45859fc9/pillow-12.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37d6d0a00072fd2948eb22bce7e1475f34569d90c87c59f7a2ec59541b77f7a6", size = 4785266, upload-time = "2026-07-01T11:53:49.079Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/98/766667a4be768150a202836acd9fad19c06824ca86c4286d3cf6b274964e/pillow-12.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bcb46e2f9feff8d06323983bd83ed00c201fdcab3d74973e7072a889b3979fcd", size = 6263814, upload-time = "2026-07-01T11:53:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2d/ede717bc1144f63886c21fd349bb95860b0d1a21149ff16f2bb362b612b6/pillow-12.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23d27a3e0307ec2244cc51e7287b919aa68d097504ebe19df4e76a98a3eea5bd", size = 6934408, upload-time = "2026-07-01T11:53:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/48/9c58b685e69d49c31af6c8eb9012055fab7e665785165c84796e2c73ce72/pillow-12.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4f883547d4b7f0495ebe7056b0cc2aea76094e7a4abc8e933540f3271df27d9c", size = 6337160, upload-time = "2026-07-01T11:53:55.457Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/fa/dc2a5c0ba6df93f67c31d34b808b7ce440b40cdbf96f0b81cde1d1e6fa93/pillow-12.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:236ff70b9312fb68943c703aa842ca6a758abfa45ac187a5e7c1452e96ef72b5", size = 7045172, upload-time = "2026-07-01T11:53:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a5/444817a4d4c4c2417df00513086ca196f388d8f9ef40c2e4ccd1ad1af54b/pillow-12.3.0-cp311-cp311-win32.whl", hash = "sha256:10e41f0fbf1eec8cfd234b8fe17a4caac7c9d0db4c204d3c173a8f9f6ef3232b", size = 6472232, upload-time = "2026-07-01T11:53:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c6/4bad1b18d132a50b27e1365e1ab163616f7a5bb56d330f66f9d1d9d4f9d4/pillow-12.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:8e95e1385e4998ae9694eeaa4730ba5457ff61185b3a55e2e7bea0880aef452a", size = 7233653, upload-time = "2026-07-01T11:54:02.066Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/16/00f91ab7760dc842f5aad55217e80fc4a7067a0604535249bc8a2d6d9870/pillow-12.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:ebaea975e03d3141d9d3a507df75c9b3ec90fa9d2ffd07567b3a978d9d790b26", size = 2568195, upload-time = "2026-07-01T11:54:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/75/18/2e8b40223153ccbc60df07f9e8928dc0c76202aa4e55ae9f53962b6510d6/pillow-12.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b3c777e849237620b022f7f297dd67705f9f5cf1685f09f02e46f93e92725468", size = 5302510, upload-time = "2026-07-01T11:56:25.736Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3e/51fabf59d5ab801ceab709453d3ab6b180083496579549de4c45ced6528a/pillow-12.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b343699e8308bdc51978310e1c959c584e7869cc8c40780058c87da7781a1e94", size = 4736058, upload-time = "2026-07-01T11:56:28.041Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/20/22fe9384b7949e25fb1293bcfc84fb82590ff4ea6b37c95b24d26d793d86/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbd139c8447d25dd750ab79ee274cc5e1fe80fc56340ab10b18a195e1b6eca3e", size = 5237776, upload-time = "2026-07-01T11:56:30.263Z" },
+    { url = "https://files.pythonhosted.org/packages/08/14/f6ba68107680ffa74b39985f3f30884e41318fbc4250caa423c79b4788bb/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7e480451b9fa137494bccd3a7d69adbe8ac65a87d97be61e11f1b1050a5bac3", size = 5860358, upload-time = "2026-07-01T11:56:32.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0169bc772ec491108b62f644f8ecf1fe5d8ae5ebafde2ee2142210166903/pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a", size = 7231786, upload-time = "2026-07-01T11:56:35.046Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "14.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/c3/48602ef0a293af9297c0c65cdef8a2339256e485c54a4ff375d3e95d3415/pyarrow-14.0.1.tar.gz", hash = "sha256:b8b3f4fe8d4ec15e1ef9b599b94683c5216adaed78d5cb4c606180546d1e2ee1", size = 1062511, upload-time = "2023-11-08T17:19:58.15Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/a6/b333f35d513dd16294d5fa1535ddb26ec5877f800f3c71c903cc8c7c2656/pyarrow-14.0.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:c7331b4ed3401b7ee56f22c980608cf273f0380f77d0f73dd3c185f78f5a6220", size = 26892386, upload-time = "2023-11-08T17:04:35.111Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4e/bd9bf0aaead74ba46996cf11a608894e1867e8e5f850fd7679018a117c60/pyarrow-14.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:922e8b49b88da8633d6cac0e1b5a690311b6758d6f5d7c2be71acb0f1e14cd61", size = 23986729, upload-time = "2023-11-08T17:05:05.514Z" },
+    { url = "https://files.pythonhosted.org/packages/39/50/f7b0a7142a8f5cf627dda896451f8dea2ecf4e08f452e4b688df0aa1ece4/pyarrow-14.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58c889851ca33f992ea916b48b8540735055201b177cb0dcf0596a495a667b00", size = 35940020, upload-time = "2023-11-08T17:05:41.48Z" },
+    { url = "https://files.pythonhosted.org/packages/02/35/132fcd8439b295e11094a27a9a9ef3fbc907db4f58388bd346446e82e316/pyarrow-14.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30d8494870d9916bb53b2a4384948491444741cb9a38253c590e21f836b01222", size = 38069780, upload-time = "2023-11-08T17:06:20.308Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/98/a75075869ff88b409df2e38bcfc27933f5cf24e84fb3a84d311410d112d3/pyarrow-14.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:be28e1a07f20391bb0b15ea03dcac3aade29fc773c5eb4bee2838e9b2cdde0cb", size = 35421474, upload-time = "2023-11-08T17:07:01.443Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2b/72ca700c2ecc82a05a8e2742a04853f9ebf0feab06aa4d61f37a4d5bb279/pyarrow-14.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:981670b4ce0110d8dcb3246410a4aabf5714db5d8ea63b15686bce1c914b1f83", size = 37993198, upload-time = "2023-11-08T17:07:42.796Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/f0/607f50ec87ac4775d6124855ae6be2c48bab58aa0a660ccd46e9af52bcd9/pyarrow-14.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:4756a2b373a28f6166c42711240643fb8bd6322467e9aacabd26b488fa41ec23", size = 24564125, upload-time = "2023-11-08T17:08:08.898Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.3.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/48/fb042503b6ca6cd271261dc559fd6432f7d8c713153e9ec5c591af4dfc1c/pytz-2026.3.post1.tar.gz", hash = "sha256:2211d3fcf9a797d3405cac96ac7f61d80e6a644f72a3309607282fe8a2010c5d", size = 319745, upload-time = "2026-07-25T15:12:07.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/7b/39c34ca613b0b198cb866466651b26b045e2009864c5183c979a3b83f383/pytz-2026.3.post1-py2.py3-none-any.whl", hash = "sha256:dd95840dd199baea12d9cc096a1d452caa6596a1c1e4b5f3dbd1541855d5e815", size = 508283, upload-time = "2026-07-25T15:12:05.782Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/00/48c2f661e2816ccf2ecd77982f6605b2950afe60f60a52b4cbbc2504aa8f/scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c", size = 57210720, upload-time = "2024-05-23T03:29:26.079Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/15/4a4bb1b15bbd2cd2786c4f46e76b871b28799b67891f23f455323a0cdcfb/scipy-1.13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:27e52b09c0d3a1d5b63e1105f24177e544a222b43611aaf5bc44d4a0979e32f9", size = 39333805, upload-time = "2024-05-23T03:19:43.081Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/92/42476de1af309c27710004f5cdebc27bec62c204db42e05b23a302cb0c9a/scipy-1.13.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:54f430b00f0133e2224c3ba42b805bfd0086fe488835effa33fa291561932326", size = 30317687, upload-time = "2024-05-23T03:19:48.799Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ba/8be64fe225360a4beb6840f3cbee494c107c0887f33350d0a47d55400b01/scipy-1.13.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e89369d27f9e7b0884ae559a3a956e77c02114cc60a6058b4e5011572eea9299", size = 33694638, upload-time = "2024-05-23T03:19:55.104Z" },
+    { url = "https://files.pythonhosted.org/packages/36/07/035d22ff9795129c5a847c64cb43c1fa9188826b59344fee28a3ab02e283/scipy-1.13.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a78b4b3345f1b6f68a763c6e25c0c9a23a9fd0f39f5f3d200efe8feda560a5fa", size = 38569931, upload-time = "2024-05-23T03:20:01.82Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/10/f9b43de37e5ed91facc0cfff31d45ed0104f359e4f9a68416cbf4e790241/scipy-1.13.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:45484bee6d65633752c490404513b9ef02475b4284c4cfab0ef946def50b3f59", size = 38838145, upload-time = "2024-05-23T03:20:09.173Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/48/4513a1a5623a23e95f94abd675ed91cfb19989c58e9f6f7d03990f6caf3d/scipy-1.13.1-cp311-cp311-win_amd64.whl", hash = "sha256:5713f62f781eebd8d597eb3f88b8bf9274e79eeabf63afb4a737abc6c84ad37b", size = 46196227, upload-time = "2024-05-23T03:20:16.433Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "statsmodels"
+version = "0.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "patsy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/d0/cf49ceca73f459b9b848ca2ce2a884ac8823284bc8b78aec161417d7bd78/statsmodels-0.14.3.tar.gz", hash = "sha256:ecf3502643fa93aabe5f0bdf238efb59609517c4d60a811632d31fcdce86c2d2", size = 20354488, upload-time = "2024-09-16T10:07:30.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/15/6e4a7d4b245d858b69ef3c6442912936e5520e6f5c2ab3fb5e5c68af1e0d/statsmodels-0.14.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e49a63757e12269ef02841f05906e91bdb70f5bc358cbaca97f171f4a4de09c4", size = 10219695, upload-time = "2024-09-16T09:56:04.221Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/24/16f9ea64dcbbed15fa1c3eb6122fdf2be250503f3d950809b3fa6f6a1c4e/statsmodels-0.14.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:de4b989f0fea684f89bdf5ff641f9acb7acddfd712459f28365904a974afaeff", size = 9910887, upload-time = "2024-09-16T09:56:14.476Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b7/9c48b08b9f3dda940eb863ff093f0edcb3122a6c4b0ad98e79736c4b6afa/statsmodels-0.14.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45a5ae177e92348532bf2522f27feecd0589b88b243709b28e2b068631c9c181", size = 10422907, upload-time = "2024-09-16T12:41:41.618Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/80/137dae43adbdfb8ae6a084063e79ab8012727b696d6fe9d1c8893c2899b6/statsmodels-0.14.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a736ac24da1388e444bb2b0d381a7307b29074b237acef040a793cfdd508e160", size = 10751368, upload-time = "2024-09-16T12:41:52.147Z" },
+    { url = "https://files.pythonhosted.org/packages/82/08/177ada7b055070f487c171cb42d142a0ead6c03f7015368c97f75f07f303/statsmodels-0.14.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ea8491b6a36fca738403037709e9469412a9d3e8a8e54db482c20e8dd70efa1f", size = 10957834, upload-time = "2024-09-16T12:42:03.402Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/fd9356fe3827621e3b0b579c1a34c803596fe6a98032d30ff584da1af6cf/statsmodels-0.14.3-cp311-cp311-win_amd64.whl", hash = "sha256:efb946ced8243923eb78909834699be55442172cea3dc37158e3e1c5370e4189", size = 9851931, upload-time = "2024-09-16T09:56:24.277Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]

--- a/paper/reproduction/classifier-summary.svg
+++ b/paper/reproduction/classifier-summary.svg
@@ -1,0 +1,1247 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="453.049062pt" height="304.153965pt" viewBox="0 0 453.049062 304.153965" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 304.153965
+L 453.049062 304.153965
+L 453.049062 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 44.089063 254.254312
+L 445.849063 254.254312
+L 445.849063 21.406312
+L 44.089063 21.406312
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="md36de533ea" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md36de533ea" x="96.095545" y="254.254312" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- axiom -->
+      <g transform="translate(69.504887 277.125695) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-61" d="M 2194 1759
+Q 1497 1759 1228 1600
+Q 959 1441 959 1056
+Q 959 750 1161 570
+Q 1363 391 1709 391
+Q 2188 391 2477 730
+Q 2766 1069 2766 1631
+L 2766 1759
+L 2194 1759
+z
+M 3341 1997
+L 3341 0
+L 2766 0
+L 2766 531
+Q 2569 213 2275 61
+Q 1981 -91 1556 -91
+Q 1019 -91 701 211
+Q 384 513 384 1019
+Q 384 1609 779 1909
+Q 1175 2209 1959 2209
+L 2766 2209
+L 2766 2266
+Q 2766 2663 2505 2880
+Q 2244 3097 1772 3097
+Q 1472 3097 1187 3025
+Q 903 2953 641 2809
+L 641 3341
+Q 956 3463 1253 3523
+Q 1550 3584 1831 3584
+Q 2591 3584 2966 3190
+Q 3341 2797 3341 1997
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-78" d="M 3513 3500
+L 2247 1797
+L 3578 0
+L 2900 0
+L 1881 1375
+L 863 0
+L 184 0
+L 1544 1831
+L 300 3500
+L 978 3500
+L 1906 2253
+L 2834 3500
+L 3513 3500
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500
+L 1178 3500
+L 1178 0
+L 603 0
+L 603 3500
+z
+M 603 4863
+L 1178 4863
+L 1178 4134
+L 603 4134
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6f" d="M 1959 3097
+Q 1497 3097 1228 2736
+Q 959 2375 959 1747
+Q 959 1119 1226 758
+Q 1494 397 1959 397
+Q 2419 397 2687 759
+Q 2956 1122 2956 1747
+Q 2956 2369 2687 2733
+Q 2419 3097 1959 3097
+z
+M 1959 3584
+Q 2709 3584 3137 3096
+Q 3566 2609 3566 1747
+Q 3566 888 3137 398
+Q 2709 -91 1959 -91
+Q 1206 -91 779 398
+Q 353 888 353 1747
+Q 353 2609 779 3096
+Q 1206 3584 1959 3584
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6d" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-61"/>
+       <use xlink:href="#DejaVuSans-78" x="61.279297"/>
+       <use xlink:href="#DejaVuSans-69" x="120.458984"/>
+       <use xlink:href="#DejaVuSans-6f" x="148.242188"/>
+       <use xlink:href="#DejaVuSans-6d" x="209.423828"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#md36de533ea" x="195.344557" y="254.254312" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- toxcast_cellbased -->
+      <g transform="translate(119.669189 294.959908) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-74" d="M 1172 4494
+L 1172 3500
+L 2356 3500
+L 2356 3053
+L 1172 3053
+L 1172 1153
+Q 1172 725 1289 603
+Q 1406 481 1766 481
+L 2356 481
+L 2356 0
+L 1766 0
+Q 1100 0 847 248
+Q 594 497 594 1153
+L 594 3053
+L 172 3053
+L 172 3500
+L 594 3500
+L 594 4494
+L 1172 4494
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-63" d="M 3122 3366
+L 3122 2828
+Q 2878 2963 2633 3030
+Q 2388 3097 2138 3097
+Q 1578 3097 1268 2742
+Q 959 2388 959 1747
+Q 959 1106 1268 751
+Q 1578 397 2138 397
+Q 2388 397 2633 464
+Q 2878 531 3122 666
+L 3122 134
+Q 2881 22 2623 -34
+Q 2366 -91 2075 -91
+Q 1284 -91 818 406
+Q 353 903 353 1747
+Q 353 2603 823 3093
+Q 1294 3584 2113 3584
+Q 2378 3584 2631 3529
+Q 2884 3475 3122 3366
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397
+L 2834 2853
+Q 2591 2978 2328 3040
+Q 2066 3103 1784 3103
+Q 1356 3103 1142 2972
+Q 928 2841 928 2578
+Q 928 2378 1081 2264
+Q 1234 2150 1697 2047
+L 1894 2003
+Q 2506 1872 2764 1633
+Q 3022 1394 3022 966
+Q 3022 478 2636 193
+Q 2250 -91 1575 -91
+Q 1294 -91 989 -36
+Q 684 19 347 128
+L 347 722
+Q 666 556 975 473
+Q 1284 391 1588 391
+Q 1994 391 2212 530
+Q 2431 669 2431 922
+Q 2431 1156 2273 1281
+Q 2116 1406 1581 1522
+L 1381 1569
+Q 847 1681 609 1914
+Q 372 2147 372 2553
+Q 372 3047 722 3315
+Q 1072 3584 1716 3584
+Q 2034 3584 2315 3537
+Q 2597 3491 2834 3397
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-5f" d="M 3263 -1063
+L 3263 -1509
+L -63 -1509
+L -63 -1063
+L 3263 -1063
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-65" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6c" d="M 603 4863
+L 1178 4863
+L 1178 0
+L 603 0
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-62" d="M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+M 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2969
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-64" d="M 2906 2969
+L 2906 4863
+L 3481 4863
+L 3481 0
+L 2906 0
+L 2906 525
+Q 2725 213 2448 61
+Q 2172 -91 1784 -91
+Q 1150 -91 751 415
+Q 353 922 353 1747
+Q 353 2572 751 3078
+Q 1150 3584 1784 3584
+Q 2172 3584 2448 3432
+Q 2725 3281 2906 2969
+z
+M 947 1747
+Q 947 1113 1208 752
+Q 1469 391 1925 391
+Q 2381 391 2643 752
+Q 2906 1113 2906 1747
+Q 2906 2381 2643 2742
+Q 2381 3103 1925 3103
+Q 1469 3103 1208 2742
+Q 947 2381 947 1747
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-74"/>
+       <use xlink:href="#DejaVuSans-6f" x="39.208984"/>
+       <use xlink:href="#DejaVuSans-78" x="97.265625"/>
+       <use xlink:href="#DejaVuSans-63" x="154.695312"/>
+       <use xlink:href="#DejaVuSans-61" x="209.675781"/>
+       <use xlink:href="#DejaVuSans-73" x="270.955078"/>
+       <use xlink:href="#DejaVuSans-74" x="323.054688"/>
+       <use xlink:href="#DejaVuSans-5f" x="362.263672"/>
+       <use xlink:href="#DejaVuSans-63" x="412.263672"/>
+       <use xlink:href="#DejaVuSans-65" x="467.244141"/>
+       <use xlink:href="#DejaVuSans-6c" x="528.767578"/>
+       <use xlink:href="#DejaVuSans-6c" x="556.550781"/>
+       <use xlink:href="#DejaVuSans-62" x="584.333984"/>
+       <use xlink:href="#DejaVuSans-61" x="647.810547"/>
+       <use xlink:href="#DejaVuSans-73" x="709.089844"/>
+       <use xlink:href="#DejaVuSans-65" x="761.189453"/>
+       <use xlink:href="#DejaVuSans-64" x="822.712891"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#md36de533ea" x="294.593568" y="254.254312" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- toxcast_cellfree -->
+      <g transform="translate(227.777153 291.735513) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-66" d="M 2375 4863
+L 2375 4384
+L 1825 4384
+Q 1516 4384 1395 4259
+Q 1275 4134 1275 3809
+L 1275 3500
+L 2222 3500
+L 2222 3053
+L 1275 3053
+L 1275 0
+L 697 0
+L 697 3053
+L 147 3053
+L 147 3500
+L 697 3500
+L 697 3744
+Q 697 4328 969 4595
+Q 1241 4863 1831 4863
+L 2375 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963
+Q 2534 3019 2420 3045
+Q 2306 3072 2169 3072
+Q 1681 3072 1420 2755
+Q 1159 2438 1159 1844
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1341 3275 1631 3429
+Q 1922 3584 2338 3584
+Q 2397 3584 2469 3576
+Q 2541 3569 2628 3553
+L 2631 2963
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-74"/>
+       <use xlink:href="#DejaVuSans-6f" x="39.208984"/>
+       <use xlink:href="#DejaVuSans-78" x="97.265625"/>
+       <use xlink:href="#DejaVuSans-63" x="154.695312"/>
+       <use xlink:href="#DejaVuSans-61" x="209.675781"/>
+       <use xlink:href="#DejaVuSans-73" x="270.955078"/>
+       <use xlink:href="#DejaVuSans-74" x="323.054688"/>
+       <use xlink:href="#DejaVuSans-5f" x="362.263672"/>
+       <use xlink:href="#DejaVuSans-63" x="412.263672"/>
+       <use xlink:href="#DejaVuSans-65" x="467.244141"/>
+       <use xlink:href="#DejaVuSans-6c" x="528.767578"/>
+       <use xlink:href="#DejaVuSans-6c" x="556.550781"/>
+       <use xlink:href="#DejaVuSans-66" x="584.333984"/>
+       <use xlink:href="#DejaVuSans-72" x="619.539062"/>
+       <use xlink:href="#DejaVuSans-65" x="658.402344"/>
+       <use xlink:href="#DejaVuSans-65" x="719.925781"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#md36de533ea" x="393.84258" y="254.254312" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- toxcast_cytotox -->
+      <g transform="translate(326.872878 291.556089) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-79" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-74"/>
+       <use xlink:href="#DejaVuSans-6f" x="39.208984"/>
+       <use xlink:href="#DejaVuSans-78" x="97.265625"/>
+       <use xlink:href="#DejaVuSans-63" x="154.695312"/>
+       <use xlink:href="#DejaVuSans-61" x="209.675781"/>
+       <use xlink:href="#DejaVuSans-73" x="270.955078"/>
+       <use xlink:href="#DejaVuSans-74" x="323.054688"/>
+       <use xlink:href="#DejaVuSans-5f" x="362.263672"/>
+       <use xlink:href="#DejaVuSans-63" x="412.263672"/>
+       <use xlink:href="#DejaVuSans-79" x="467.244141"/>
+       <use xlink:href="#DejaVuSans-74" x="526.423828"/>
+       <use xlink:href="#DejaVuSans-6f" x="565.632812"/>
+       <use xlink:href="#DejaVuSans-74" x="626.814453"/>
+       <use xlink:href="#DejaVuSans-6f" x="666.023438"/>
+       <use xlink:href="#DejaVuSans-78" x="724.080078"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_5">
+      <path d="M 44.089063 254.254312
+L 445.849063 254.254312
+" clip-path="url(#p529f11c130)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <defs>
+       <path id="m77db5bb38e" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="254.254312" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0 -->
+      <g transform="translate(31.362813 257.673609) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_7">
+      <path d="M 44.089063 212.726223
+L 445.849063 212.726223
+" clip-path="url(#p529f11c130)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="212.726223" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 50 -->
+      <g transform="translate(25.636563 216.145519) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_9">
+      <path d="M 44.089063 171.198133
+L 445.849063 171.198133
+" clip-path="url(#p529f11c130)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="171.198133" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 100 -->
+      <g transform="translate(19.910313 174.61743) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_11">
+      <path d="M 44.089063 129.670043
+L 445.849063 129.670043
+" clip-path="url(#p529f11c130)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="129.670043" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 150 -->
+      <g transform="translate(19.910313 133.08934) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_13">
+      <path d="M 44.089063 88.141953
+L 445.849063 88.141953
+" clip-path="url(#p529f11c130)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="88.141953" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 200 -->
+      <g transform="translate(19.910313 91.56125) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <path d="M 44.089063 46.613863
+L 445.849063 46.613863
+" clip-path="url(#p529f11c130)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="46.613863" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 250 -->
+      <g transform="translate(19.910313 50.03316) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_11">
+     <!-- Modeled endpoints -->
+     <g transform="translate(14.038594 180.696328) rotate(-90) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-4d" d="M 628 4666
+L 1569 4666
+L 2759 1491
+L 3956 4666
+L 4897 4666
+L 4897 0
+L 4281 0
+L 4281 4097
+L 3078 897
+L 2444 897
+L 1241 4097
+L 1241 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525
+L 1159 -1331
+L 581 -1331
+L 581 3500
+L 1159 3500
+L 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+z
+M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" x="86.279297"/>
+      <use xlink:href="#DejaVuSans-64" x="147.460938"/>
+      <use xlink:href="#DejaVuSans-65" x="210.9375"/>
+      <use xlink:href="#DejaVuSans-6c" x="272.460938"/>
+      <use xlink:href="#DejaVuSans-65" x="300.244141"/>
+      <use xlink:href="#DejaVuSans-64" x="361.767578"/>
+      <use xlink:href="#DejaVuSans-20" x="425.244141"/>
+      <use xlink:href="#DejaVuSans-65" x="457.03125"/>
+      <use xlink:href="#DejaVuSans-6e" x="518.554688"/>
+      <use xlink:href="#DejaVuSans-64" x="581.933594"/>
+      <use xlink:href="#DejaVuSans-70" x="645.410156"/>
+      <use xlink:href="#DejaVuSans-6f" x="708.886719"/>
+      <use xlink:href="#DejaVuSans-69" x="770.068359"/>
+      <use xlink:href="#DejaVuSans-6e" x="797.851562"/>
+      <use xlink:href="#DejaVuSans-74" x="861.230469"/>
+      <use xlink:href="#DejaVuSans-73" x="900.439453"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 62.350881 254.254312
+L 129.840209 254.254312
+L 129.840209 252.593189
+L 62.350881 252.593189
+z
+" clip-path="url(#p529f11c130)" style="fill: #f28e2b"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 161.599893 254.254312
+L 229.089221 254.254312
+L 229.089221 32.494312
+L 161.599893 32.494312
+z
+" clip-path="url(#p529f11c130)" style="fill: #f28e2b"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 260.848904 254.254312
+L 328.338232 254.254312
+L 328.338232 210.234537
+L 260.848904 210.234537
+z
+" clip-path="url(#p529f11c130)" style="fill: #f28e2b"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 360.097916 254.254312
+L 427.587244 254.254312
+L 427.587244 226.015211
+L 360.097916 226.015211
+z
+" clip-path="url(#p529f11c130)" style="fill: #f28e2b"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 44.089063 254.254312
+L 44.089063 21.406312
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 44.089063 254.254312
+L 445.849063 254.254312
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_12">
+    <!-- Classifier denominators - tracked-artifact reanalysis -->
+    <g transform="translate(85.799 15.406312) scale(0.108 -0.108)">
+     <defs>
+      <path id="DejaVuSans-Bold-43" d="M 4288 256
+Q 3956 84 3597 -3
+Q 3238 -91 2847 -91
+Q 1681 -91 1000 561
+Q 319 1213 319 2328
+Q 319 3447 1000 4098
+Q 1681 4750 2847 4750
+Q 3238 4750 3597 4662
+Q 3956 4575 4288 4403
+L 4288 3438
+Q 3953 3666 3628 3772
+Q 3303 3878 2944 3878
+Q 2300 3878 1931 3465
+Q 1563 3053 1563 2328
+Q 1563 1606 1931 1193
+Q 2300 781 2944 781
+Q 3303 781 3628 887
+Q 3953 994 4288 1222
+L 4288 256
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863
+L 1656 4863
+L 1656 0
+L 538 0
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575
+Q 1756 1575 1579 1456
+Q 1403 1338 1403 1106
+Q 1403 894 1545 773
+Q 1688 653 1941 653
+Q 2256 653 2472 879
+Q 2688 1106 2688 1447
+L 2688 1575
+L 2106 1575
+z
+M 3816 1997
+L 3816 0
+L 2688 0
+L 2688 519
+Q 2463 200 2181 54
+Q 1900 -91 1497 -91
+Q 953 -91 614 226
+Q 275 544 275 1050
+Q 275 1666 698 1953
+Q 1122 2241 2028 2241
+L 2688 2241
+L 2688 2328
+Q 2688 2594 2478 2717
+Q 2269 2841 1825 2841
+Q 1466 2841 1156 2769
+Q 847 2697 581 2553
+L 581 3406
+Q 941 3494 1303 3539
+Q 1666 3584 2028 3584
+Q 2975 3584 3395 3211
+Q 3816 2838 3816 1997
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391
+L 3272 2541
+Q 2913 2691 2578 2766
+Q 2244 2841 1947 2841
+Q 1628 2841 1473 2761
+Q 1319 2681 1319 2516
+Q 1319 2381 1436 2309
+Q 1553 2238 1856 2203
+L 2053 2175
+Q 2913 2066 3209 1816
+Q 3506 1566 3506 1031
+Q 3506 472 3093 190
+Q 2681 -91 1863 -91
+Q 1516 -91 1145 -36
+Q 775 19 384 128
+L 384 978
+Q 719 816 1070 734
+Q 1422 653 1784 653
+Q 2113 653 2278 743
+Q 2444 834 2444 1013
+Q 2444 1163 2330 1236
+Q 2216 1309 1875 1350
+L 1678 1375
+Q 931 1469 631 1722
+Q 331 1975 331 2491
+Q 331 3047 712 3315
+Q 1094 3584 1881 3584
+Q 2191 3584 2531 3537
+Q 2872 3491 3272 3391
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-69" d="M 538 3500
+L 1656 3500
+L 1656 0
+L 538 0
+L 538 3500
+z
+M 538 4863
+L 1656 4863
+L 1656 3950
+L 538 3950
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-66" d="M 2841 4863
+L 2841 4128
+L 2222 4128
+Q 1984 4128 1890 4042
+Q 1797 3956 1797 3744
+L 1797 3500
+L 2753 3500
+L 2753 2700
+L 1797 2700
+L 1797 0
+L 678 0
+L 678 2700
+L 122 2700
+L 122 3500
+L 678 3500
+L 678 3744
+Q 678 4316 997 4589
+Q 1316 4863 1984 4863
+L 2841 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759
+L 4031 1441
+L 1416 1441
+Q 1456 1047 1700 850
+Q 1944 653 2381 653
+Q 2734 653 3104 758
+Q 3475 863 3866 1075
+L 3866 213
+Q 3469 63 3072 -14
+Q 2675 -91 2278 -91
+Q 1328 -91 801 392
+Q 275 875 275 1747
+Q 275 2603 792 3093
+Q 1309 3584 2216 3584
+Q 3041 3584 3536 3087
+Q 4031 2591 4031 1759
+z
+M 2881 2131
+Q 2881 2450 2695 2645
+Q 2509 2841 2209 2841
+Q 1884 2841 1681 2658
+Q 1478 2475 1428 2131
+L 2881 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-72" d="M 3138 2547
+Q 2991 2616 2845 2648
+Q 2700 2681 2553 2681
+Q 2122 2681 1889 2404
+Q 1656 2128 1656 1613
+L 1656 0
+L 538 0
+L 538 3500
+L 1656 3500
+L 1656 2925
+Q 1872 3269 2151 3426
+Q 2431 3584 2822 3584
+Q 2878 3584 2943 3579
+Q 3009 3575 3134 3559
+L 3138 2547
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-64" d="M 2919 2988
+L 2919 4863
+L 4044 4863
+L 4044 0
+L 2919 0
+L 2919 506
+Q 2688 197 2409 53
+Q 2131 -91 1766 -91
+Q 1119 -91 703 423
+Q 288 938 288 1747
+Q 288 2556 703 3070
+Q 1119 3584 1766 3584
+Q 2128 3584 2408 3439
+Q 2688 3294 2919 2988
+z
+M 2181 722
+Q 2541 722 2730 984
+Q 2919 1247 2919 1747
+Q 2919 2247 2730 2509
+Q 2541 2772 2181 2772
+Q 1825 2772 1636 2509
+Q 1447 2247 1447 1747
+Q 1447 1247 1636 984
+Q 1825 722 2181 722
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131
+L 4056 0
+L 2931 0
+L 2931 347
+L 2931 1631
+Q 2931 2084 2911 2256
+Q 2891 2428 2841 2509
+Q 2775 2619 2662 2680
+Q 2550 2741 2406 2741
+Q 2056 2741 1856 2470
+Q 1656 2200 1656 1722
+L 1656 0
+L 538 0
+L 538 3500
+L 1656 3500
+L 1656 2988
+Q 1909 3294 2193 3439
+Q 2478 3584 2822 3584
+Q 3428 3584 3742 3212
+Q 4056 2841 4056 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6f" d="M 2203 2784
+Q 1831 2784 1636 2517
+Q 1441 2250 1441 1747
+Q 1441 1244 1636 976
+Q 1831 709 2203 709
+Q 2569 709 2762 976
+Q 2956 1244 2956 1747
+Q 2956 2250 2762 2517
+Q 2569 2784 2203 2784
+z
+M 2203 3584
+Q 3106 3584 3614 3096
+Q 4122 2609 4122 1747
+Q 4122 884 3614 396
+Q 3106 -91 2203 -91
+Q 1297 -91 786 396
+Q 275 884 275 1747
+Q 275 2609 786 3096
+Q 1297 3584 2203 3584
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6d" d="M 3781 2919
+Q 3994 3244 4286 3414
+Q 4578 3584 4928 3584
+Q 5531 3584 5847 3212
+Q 6163 2841 6163 2131
+L 6163 0
+L 5038 0
+L 5038 1825
+Q 5041 1866 5042 1909
+Q 5044 1953 5044 2034
+Q 5044 2406 4934 2573
+Q 4825 2741 4581 2741
+Q 4263 2741 4089 2478
+Q 3916 2216 3909 1719
+L 3909 0
+L 2784 0
+L 2784 1825
+Q 2784 2406 2684 2573
+Q 2584 2741 2328 2741
+Q 2006 2741 1831 2477
+Q 1656 2213 1656 1722
+L 1656 0
+L 531 0
+L 531 3500
+L 1656 3500
+L 1656 2988
+Q 1863 3284 2130 3434
+Q 2397 3584 2719 3584
+Q 3081 3584 3359 3409
+Q 3638 3234 3781 2919
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494
+L 1759 3500
+L 2913 3500
+L 2913 2700
+L 1759 2700
+L 1759 1216
+Q 1759 972 1856 886
+Q 1953 800 2241 800
+L 2816 800
+L 2816 0
+L 1856 0
+Q 1194 0 917 276
+Q 641 553 641 1216
+L 641 2700
+L 84 2700
+L 84 3500
+L 641 3500
+L 641 4494
+L 1759 4494
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2d" d="M 347 2297
+L 2309 2297
+L 2309 1388
+L 347 1388
+L 347 2297
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391
+L 3366 2478
+Q 3138 2634 2908 2709
+Q 2678 2784 2431 2784
+Q 1963 2784 1702 2511
+Q 1441 2238 1441 1747
+Q 1441 1256 1702 982
+Q 1963 709 2431 709
+Q 2694 709 2930 787
+Q 3166 866 3366 1019
+L 3366 103
+Q 3103 6 2833 -42
+Q 2563 -91 2291 -91
+Q 1344 -91 809 395
+Q 275 881 275 1747
+Q 275 2613 809 3098
+Q 1344 3584 2291 3584
+Q 2566 3584 2833 3536
+Q 3100 3488 3366 3391
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6b" d="M 538 4863
+L 1656 4863
+L 1656 2216
+L 2944 3500
+L 4244 3500
+L 2534 1894
+L 4378 0
+L 3022 0
+L 1656 1459
+L 1656 0
+L 538 0
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-79" d="M 78 3500
+L 1197 3500
+L 2138 1125
+L 2938 3500
+L 4056 3500
+L 2584 -331
+Q 2363 -916 2067 -1148
+Q 1772 -1381 1288 -1381
+L 641 -1381
+L 641 -647
+L 991 -647
+Q 1275 -647 1404 -556
+Q 1534 -466 1606 -231
+L 1638 -134
+L 78 3500
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-43"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" x="73.388672"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="107.666016"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="175.146484"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="234.667969"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="294.189453"/>
+     <use xlink:href="#DejaVuSans-Bold-66" x="328.466797"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="371.972656"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="406.25"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="474.072266"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="523.388672"/>
+     <use xlink:href="#DejaVuSans-Bold-64" x="558.203125"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="629.785156"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="697.607422"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" x="768.798828"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="837.5"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="941.699219"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="975.976562"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1047.167969"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1114.648438"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" x="1162.451172"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1231.152344"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="1280.46875"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1339.990234"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" x="1374.804688"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1416.308594"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1451.123047"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1498.925781"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1548.242188"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1615.722656"/>
+     <use xlink:href="#DejaVuSans-Bold-6b" x="1675"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="1738.878906"/>
+     <use xlink:href="#DejaVuSans-Bold-64" x="1806.701172"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" x="1878.283203"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1919.787109"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1987.267578"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="2036.583984"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="2084.386719"/>
+     <use xlink:href="#DejaVuSans-Bold-66" x="2118.664062"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="2162.169922"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="2229.650391"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="2288.927734"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="2336.730469"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="2371.544922"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="2420.861328"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="2488.683594"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="2556.164062"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="2627.355469"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" x="2694.835938"/>
+     <use xlink:href="#DejaVuSans-Bold-79" x="2729.113281"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="2794.298828"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="2853.820312"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="2888.097656"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p529f11c130">
+   <rect x="44.089063" y="21.406312" width="401.76" height="232.848"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/paper/reproduction/enrichment-summary.svg
+++ b/paper/reproduction/enrichment-summary.svg
@@ -1,0 +1,1271 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="453.049062pt" height="293.695845pt" viewBox="0 0 453.049062 293.695845" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 293.695845
+L 453.049062 293.695845
+L 453.049062 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 44.089063 254.254313
+L 445.849063 254.254313
+L 445.849063 21.406313
+L 44.089063 21.406313
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="md36de533ea" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md36de533ea" x="96.095545" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- err_higher -->
+      <g transform="translate(52.013231 283.460977) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-65" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963
+Q 2534 3019 2420 3045
+Q 2306 3072 2169 3072
+Q 1681 3072 1420 2755
+Q 1159 2438 1159 1844
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1341 3275 1631 3429
+Q 1922 3584 2338 3584
+Q 2397 3584 2469 3576
+Q 2541 3569 2628 3553
+L 2631 2963
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-5f" d="M 3263 -1063
+L 3263 -1509
+L -63 -1509
+L -63 -1063
+L 3263 -1063
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-68" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500
+L 1178 3500
+L 1178 0
+L 603 0
+L 603 3500
+z
+M 603 4863
+L 1178 4863
+L 1178 4134
+L 603 4134
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-67" d="M 2906 1791
+Q 2906 2416 2648 2759
+Q 2391 3103 1925 3103
+Q 1463 3103 1205 2759
+Q 947 2416 947 1791
+Q 947 1169 1205 825
+Q 1463 481 1925 481
+Q 2391 481 2648 825
+Q 2906 1169 2906 1791
+z
+M 3481 434
+Q 3481 -459 3084 -895
+Q 2688 -1331 1869 -1331
+Q 1566 -1331 1297 -1286
+Q 1028 -1241 775 -1147
+L 775 -588
+Q 1028 -725 1275 -790
+Q 1522 -856 1778 -856
+Q 2344 -856 2625 -561
+Q 2906 -266 2906 331
+L 2906 616
+Q 2728 306 2450 153
+Q 2172 0 1784 0
+Q 1141 0 747 490
+Q 353 981 353 1791
+Q 353 2603 747 3093
+Q 1141 3584 1784 3584
+Q 2172 3584 2450 3431
+Q 2728 3278 2906 2969
+L 2906 3500
+L 3481 3500
+L 3481 434
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-65"/>
+       <use xlink:href="#DejaVuSans-72" x="61.523438"/>
+       <use xlink:href="#DejaVuSans-72" x="100.886719"/>
+       <use xlink:href="#DejaVuSans-5f" x="142"/>
+       <use xlink:href="#DejaVuSans-68" x="192"/>
+       <use xlink:href="#DejaVuSans-69" x="255.378906"/>
+       <use xlink:href="#DejaVuSans-67" x="283.162109"/>
+       <use xlink:href="#DejaVuSans-68" x="346.638672"/>
+       <use xlink:href="#DejaVuSans-65" x="410.017578"/>
+       <use xlink:href="#DejaVuSans-72" x="471.541016"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#md36de533ea" x="195.344557" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- err_lower -->
+      <g transform="translate(155.259607 282.006056) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-6c" d="M 603 4863
+L 1178 4863
+L 1178 0
+L 603 0
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6f" d="M 1959 3097
+Q 1497 3097 1228 2736
+Q 959 2375 959 1747
+Q 959 1119 1226 758
+Q 1494 397 1959 397
+Q 2419 397 2687 759
+Q 2956 1122 2956 1747
+Q 2956 2369 2687 2733
+Q 2419 3097 1959 3097
+z
+M 1959 3584
+Q 2709 3584 3137 3096
+Q 3566 2609 3566 1747
+Q 3566 888 3137 398
+Q 2709 -91 1959 -91
+Q 1206 -91 779 398
+Q 353 888 353 1747
+Q 353 2609 779 3096
+Q 1206 3584 1959 3584
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-77" d="M 269 3500
+L 844 3500
+L 1563 769
+L 2278 3500
+L 2956 3500
+L 3675 769
+L 4391 3500
+L 4966 3500
+L 4050 0
+L 3372 0
+L 2619 2869
+L 1863 0
+L 1184 0
+L 269 3500
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-65"/>
+       <use xlink:href="#DejaVuSans-72" x="61.523438"/>
+       <use xlink:href="#DejaVuSans-72" x="100.886719"/>
+       <use xlink:href="#DejaVuSans-5f" x="142"/>
+       <use xlink:href="#DejaVuSans-6c" x="192"/>
+       <use xlink:href="#DejaVuSans-6f" x="219.783203"/>
+       <use xlink:href="#DejaVuSans-77" x="280.964844"/>
+       <use xlink:href="#DejaVuSans-65" x="362.751953"/>
+       <use xlink:href="#DejaVuSans-72" x="424.275391"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#md36de533ea" x="294.593568" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- mtt_higher -->
+      <g transform="translate(247.651652 284.501787) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-6d" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494
+L 1172 3500
+L 2356 3500
+L 2356 3053
+L 1172 3053
+L 1172 1153
+Q 1172 725 1289 603
+Q 1406 481 1766 481
+L 2356 481
+L 2356 0
+L 1766 0
+Q 1100 0 847 248
+Q 594 497 594 1153
+L 594 3053
+L 172 3053
+L 172 3500
+L 594 3500
+L 594 4494
+L 1172 4494
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-6d"/>
+       <use xlink:href="#DejaVuSans-74" x="97.412109"/>
+       <use xlink:href="#DejaVuSans-74" x="136.621094"/>
+       <use xlink:href="#DejaVuSans-5f" x="175.830078"/>
+       <use xlink:href="#DejaVuSans-68" x="225.830078"/>
+       <use xlink:href="#DejaVuSans-69" x="289.208984"/>
+       <use xlink:href="#DejaVuSans-67" x="316.992188"/>
+       <use xlink:href="#DejaVuSans-68" x="380.46875"/>
+       <use xlink:href="#DejaVuSans-65" x="443.847656"/>
+       <use xlink:href="#DejaVuSans-72" x="505.371094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#md36de533ea" x="393.84258" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- mtt_lower -->
+      <g transform="translate(350.898028 283.046866) rotate(-20) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-6d"/>
+       <use xlink:href="#DejaVuSans-74" x="97.412109"/>
+       <use xlink:href="#DejaVuSans-74" x="136.621094"/>
+       <use xlink:href="#DejaVuSans-5f" x="175.830078"/>
+       <use xlink:href="#DejaVuSans-6c" x="225.830078"/>
+       <use xlink:href="#DejaVuSans-6f" x="253.613281"/>
+       <use xlink:href="#DejaVuSans-77" x="314.794922"/>
+       <use xlink:href="#DejaVuSans-65" x="396.582031"/>
+       <use xlink:href="#DejaVuSans-72" x="458.105469"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_5">
+      <path d="M 44.089063 254.254313
+L 445.849063 254.254313
+" clip-path="url(#p157208b24c)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <defs>
+       <path id="m77db5bb38e" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0 -->
+      <g transform="translate(31.362813 257.673609) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_7">
+      <path d="M 44.089063 223.108245
+L 445.849063 223.108245
+" clip-path="url(#p157208b24c)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="223.108245" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 25 -->
+      <g transform="translate(25.636563 226.527542) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_9">
+      <path d="M 44.089063 191.962178
+L 445.849063 191.962178
+" clip-path="url(#p157208b24c)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="191.962178" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 50 -->
+      <g transform="translate(25.636563 195.381475) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_11">
+      <path d="M 44.089063 160.81611
+L 445.849063 160.81611
+" clip-path="url(#p157208b24c)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="160.81611" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 75 -->
+      <g transform="translate(25.636563 164.235407) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666
+L 3525 4666
+L 3525 4397
+L 1831 0
+L 1172 0
+L 2766 4134
+L 525 4134
+L 525 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-37"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_13">
+      <path d="M 44.089063 129.670043
+L 445.849063 129.670043
+" clip-path="url(#p157208b24c)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="129.670043" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 100 -->
+      <g transform="translate(19.910313 133.08934) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <path d="M 44.089063 98.523975
+L 445.849063 98.523975
+" clip-path="url(#p157208b24c)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="98.523975" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 125 -->
+      <g transform="translate(19.910313 101.943272) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_17">
+      <path d="M 44.089063 67.377908
+L 445.849063 67.377908
+" clip-path="url(#p157208b24c)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="67.377908" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 150 -->
+      <g transform="translate(19.910313 70.797205) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_19">
+      <path d="M 44.089063 36.231841
+L 445.849063 36.231841
+" clip-path="url(#p157208b24c)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="36.231841" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 175 -->
+      <g transform="translate(19.910313 39.651137) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_13">
+     <!-- Target sets with FDR &lt; 0.05 -->
+     <g transform="translate(14.038594 200.643984) rotate(-90) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666
+L 3928 4666
+L 3928 4134
+L 2272 4134
+L 2272 0
+L 1638 0
+L 1638 4134
+L -19 4134
+L -19 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759
+Q 1497 1759 1228 1600
+Q 959 1441 959 1056
+Q 959 750 1161 570
+Q 1363 391 1709 391
+Q 2188 391 2477 730
+Q 2766 1069 2766 1631
+L 2766 1759
+L 2194 1759
+z
+M 3341 1997
+L 3341 0
+L 2766 0
+L 2766 531
+Q 2569 213 2275 61
+Q 1981 -91 1556 -91
+Q 1019 -91 701 211
+Q 384 513 384 1019
+Q 384 1609 779 1909
+Q 1175 2209 1959 2209
+L 2766 2209
+L 2766 2266
+Q 2766 2663 2505 2880
+Q 2244 3097 1772 3097
+Q 1472 3097 1187 3025
+Q 903 2953 641 2809
+L 641 3341
+Q 956 3463 1253 3523
+Q 1550 3584 1831 3584
+Q 2591 3584 2966 3190
+Q 3341 2797 3341 1997
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397
+L 2834 2853
+Q 2591 2978 2328 3040
+Q 2066 3103 1784 3103
+Q 1356 3103 1142 2972
+Q 928 2841 928 2578
+Q 928 2378 1081 2264
+Q 1234 2150 1697 2047
+L 1894 2003
+Q 2506 1872 2764 1633
+Q 3022 1394 3022 966
+Q 3022 478 2636 193
+Q 2250 -91 1575 -91
+Q 1294 -91 989 -36
+Q 684 19 347 128
+L 347 722
+Q 666 556 975 473
+Q 1284 391 1588 391
+Q 1994 391 2212 530
+Q 2431 669 2431 922
+Q 2431 1156 2273 1281
+Q 2116 1406 1581 1522
+L 1381 1569
+Q 847 1681 609 1914
+Q 372 2147 372 2553
+Q 372 3047 722 3315
+Q 1072 3584 1716 3584
+Q 2034 3584 2315 3537
+Q 2597 3491 2834 3397
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-46" d="M 628 4666
+L 3309 4666
+L 3309 4134
+L 1259 4134
+L 1259 2759
+L 3109 2759
+L 3109 2228
+L 1259 2228
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147
+L 1259 519
+L 2022 519
+Q 2988 519 3436 956
+Q 3884 1394 3884 2338
+Q 3884 3275 3436 3711
+Q 2988 4147 2022 4147
+L 1259 4147
+z
+M 628 4666
+L 1925 4666
+Q 3281 4666 3915 4102
+Q 4550 3538 4550 2338
+Q 4550 1131 3912 565
+Q 3275 0 1925 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 2841 2188
+Q 3044 2119 3236 1894
+Q 3428 1669 3622 1275
+L 4263 0
+L 3584 0
+L 2988 1197
+Q 2756 1666 2539 1819
+Q 2322 1972 1947 1972
+L 1259 1972
+L 1259 0
+L 628 0
+L 628 4666
+L 2053 4666
+Q 2853 4666 3247 4331
+Q 3641 3997 3641 3322
+Q 3641 2881 3436 2590
+Q 3231 2300 2841 2188
+z
+M 1259 4147
+L 1259 2491
+L 2053 2491
+Q 2509 2491 2742 2702
+Q 2975 2913 2975 3322
+Q 2975 3731 2742 3939
+Q 2509 4147 2053 4147
+L 1259 4147
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3c" d="M 4684 3150
+L 1459 2003
+L 4684 863
+L 4684 294
+L 678 1747
+L 678 2266
+L 4684 3719
+L 4684 3150
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2e" d="M 684 794
+L 1344 794
+L 1344 0
+L 684 0
+L 684 794
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-54"/>
+      <use xlink:href="#DejaVuSans-61" x="44.583984"/>
+      <use xlink:href="#DejaVuSans-72" x="105.863281"/>
+      <use xlink:href="#DejaVuSans-67" x="145.226562"/>
+      <use xlink:href="#DejaVuSans-65" x="208.703125"/>
+      <use xlink:href="#DejaVuSans-74" x="270.226562"/>
+      <use xlink:href="#DejaVuSans-20" x="309.435547"/>
+      <use xlink:href="#DejaVuSans-73" x="341.222656"/>
+      <use xlink:href="#DejaVuSans-65" x="393.322266"/>
+      <use xlink:href="#DejaVuSans-74" x="454.845703"/>
+      <use xlink:href="#DejaVuSans-73" x="494.054688"/>
+      <use xlink:href="#DejaVuSans-20" x="546.154297"/>
+      <use xlink:href="#DejaVuSans-77" x="577.941406"/>
+      <use xlink:href="#DejaVuSans-69" x="659.728516"/>
+      <use xlink:href="#DejaVuSans-74" x="687.511719"/>
+      <use xlink:href="#DejaVuSans-68" x="726.720703"/>
+      <use xlink:href="#DejaVuSans-20" x="790.099609"/>
+      <use xlink:href="#DejaVuSans-46" x="821.886719"/>
+      <use xlink:href="#DejaVuSans-44" x="879.40625"/>
+      <use xlink:href="#DejaVuSans-52" x="956.408203"/>
+      <use xlink:href="#DejaVuSans-20" x="1025.890625"/>
+      <use xlink:href="#DejaVuSans-3c" x="1057.677734"/>
+      <use xlink:href="#DejaVuSans-20" x="1141.466797"/>
+      <use xlink:href="#DejaVuSans-30" x="1173.253906"/>
+      <use xlink:href="#DejaVuSans-2e" x="1236.876953"/>
+      <use xlink:href="#DejaVuSans-30" x="1268.664062"/>
+      <use xlink:href="#DejaVuSans-35" x="1332.287109"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 62.350881 254.254313
+L 129.840209 254.254313
+L 129.840209 32.494313
+L 62.350881 32.494313
+z
+" clip-path="url(#p157208b24c)" style="fill: #e15759"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 161.599893 254.254313
+L 229.089221 254.254313
+L 229.089221 254.254313
+L 161.599893 254.254313
+z
+" clip-path="url(#p157208b24c)" style="fill: #e15759"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 260.848904 254.254313
+L 328.338232 254.254313
+L 328.338232 71.115436
+L 260.848904 71.115436
+z
+" clip-path="url(#p157208b24c)" style="fill: #e15759"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 360.097916 254.254313
+L 427.587244 254.254313
+L 427.587244 120.949144
+L 360.097916 120.949144
+z
+" clip-path="url(#p157208b24c)" style="fill: #e15759"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 44.089063 254.254313
+L 44.089063 21.406313
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 44.089063 254.254313
+L 445.849063 254.254313
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_14">
+    <!-- Enrichment summary - tracked-artifact reanalysis -->
+    <g transform="translate(93.332 15.406313) scale(0.108 -0.108)">
+     <defs>
+      <path id="DejaVuSans-Bold-45" d="M 588 4666
+L 3834 4666
+L 3834 3756
+L 1791 3756
+L 1791 2888
+L 3713 2888
+L 3713 1978
+L 1791 1978
+L 1791 909
+L 3903 909
+L 3903 0
+L 588 0
+L 588 4666
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131
+L 4056 0
+L 2931 0
+L 2931 347
+L 2931 1631
+Q 2931 2084 2911 2256
+Q 2891 2428 2841 2509
+Q 2775 2619 2662 2680
+Q 2550 2741 2406 2741
+Q 2056 2741 1856 2470
+Q 1656 2200 1656 1722
+L 1656 0
+L 538 0
+L 538 3500
+L 1656 3500
+L 1656 2988
+Q 1909 3294 2193 3439
+Q 2478 3584 2822 3584
+Q 3428 3584 3742 3212
+Q 4056 2841 4056 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-72" d="M 3138 2547
+Q 2991 2616 2845 2648
+Q 2700 2681 2553 2681
+Q 2122 2681 1889 2404
+Q 1656 2128 1656 1613
+L 1656 0
+L 538 0
+L 538 3500
+L 1656 3500
+L 1656 2925
+Q 1872 3269 2151 3426
+Q 2431 3584 2822 3584
+Q 2878 3584 2943 3579
+Q 3009 3575 3134 3559
+L 3138 2547
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-69" d="M 538 3500
+L 1656 3500
+L 1656 0
+L 538 0
+L 538 3500
+z
+M 538 4863
+L 1656 4863
+L 1656 3950
+L 538 3950
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391
+L 3366 2478
+Q 3138 2634 2908 2709
+Q 2678 2784 2431 2784
+Q 1963 2784 1702 2511
+Q 1441 2238 1441 1747
+Q 1441 1256 1702 982
+Q 1963 709 2431 709
+Q 2694 709 2930 787
+Q 3166 866 3366 1019
+L 3366 103
+Q 3103 6 2833 -42
+Q 2563 -91 2291 -91
+Q 1344 -91 809 395
+Q 275 881 275 1747
+Q 275 2613 809 3098
+Q 1344 3584 2291 3584
+Q 2566 3584 2833 3536
+Q 3100 3488 3366 3391
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-68" d="M 4056 2131
+L 4056 0
+L 2931 0
+L 2931 347
+L 2931 1625
+Q 2931 2084 2911 2256
+Q 2891 2428 2841 2509
+Q 2775 2619 2662 2680
+Q 2550 2741 2406 2741
+Q 2056 2741 1856 2470
+Q 1656 2200 1656 1722
+L 1656 0
+L 538 0
+L 538 4863
+L 1656 4863
+L 1656 2988
+Q 1909 3294 2193 3439
+Q 2478 3584 2822 3584
+Q 3428 3584 3742 3212
+Q 4056 2841 4056 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6d" d="M 3781 2919
+Q 3994 3244 4286 3414
+Q 4578 3584 4928 3584
+Q 5531 3584 5847 3212
+Q 6163 2841 6163 2131
+L 6163 0
+L 5038 0
+L 5038 1825
+Q 5041 1866 5042 1909
+Q 5044 1953 5044 2034
+Q 5044 2406 4934 2573
+Q 4825 2741 4581 2741
+Q 4263 2741 4089 2478
+Q 3916 2216 3909 1719
+L 3909 0
+L 2784 0
+L 2784 1825
+Q 2784 2406 2684 2573
+Q 2584 2741 2328 2741
+Q 2006 2741 1831 2477
+Q 1656 2213 1656 1722
+L 1656 0
+L 531 0
+L 531 3500
+L 1656 3500
+L 1656 2988
+Q 1863 3284 2130 3434
+Q 2397 3584 2719 3584
+Q 3081 3584 3359 3409
+Q 3638 3234 3781 2919
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759
+L 4031 1441
+L 1416 1441
+Q 1456 1047 1700 850
+Q 1944 653 2381 653
+Q 2734 653 3104 758
+Q 3475 863 3866 1075
+L 3866 213
+Q 3469 63 3072 -14
+Q 2675 -91 2278 -91
+Q 1328 -91 801 392
+Q 275 875 275 1747
+Q 275 2603 792 3093
+Q 1309 3584 2216 3584
+Q 3041 3584 3536 3087
+Q 4031 2591 4031 1759
+z
+M 2881 2131
+Q 2881 2450 2695 2645
+Q 2509 2841 2209 2841
+Q 1884 2841 1681 2658
+Q 1478 2475 1428 2131
+L 2881 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494
+L 1759 3500
+L 2913 3500
+L 2913 2700
+L 1759 2700
+L 1759 1216
+Q 1759 972 1856 886
+Q 1953 800 2241 800
+L 2816 800
+L 2816 0
+L 1856 0
+Q 1194 0 917 276
+Q 641 553 641 1216
+L 641 2700
+L 84 2700
+L 84 3500
+L 641 3500
+L 641 4494
+L 1759 4494
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391
+L 3272 2541
+Q 2913 2691 2578 2766
+Q 2244 2841 1947 2841
+Q 1628 2841 1473 2761
+Q 1319 2681 1319 2516
+Q 1319 2381 1436 2309
+Q 1553 2238 1856 2203
+L 2053 2175
+Q 2913 2066 3209 1816
+Q 3506 1566 3506 1031
+Q 3506 472 3093 190
+Q 2681 -91 1863 -91
+Q 1516 -91 1145 -36
+Q 775 19 384 128
+L 384 978
+Q 719 816 1070 734
+Q 1422 653 1784 653
+Q 2113 653 2278 743
+Q 2444 834 2444 1013
+Q 2444 1163 2330 1236
+Q 2216 1309 1875 1350
+L 1678 1375
+Q 931 1469 631 1722
+Q 331 1975 331 2491
+Q 331 3047 712 3315
+Q 1094 3584 1881 3584
+Q 2191 3584 2531 3537
+Q 2872 3491 3272 3391
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-75" d="M 500 1363
+L 500 3500
+L 1625 3500
+L 1625 3150
+Q 1625 2866 1622 2436
+Q 1619 2006 1619 1863
+Q 1619 1441 1641 1255
+Q 1663 1069 1716 984
+Q 1784 875 1895 815
+Q 2006 756 2150 756
+Q 2500 756 2700 1025
+Q 2900 1294 2900 1772
+L 2900 3500
+L 4019 3500
+L 4019 0
+L 2900 0
+L 2900 506
+Q 2647 200 2364 54
+Q 2081 -91 1741 -91
+Q 1134 -91 817 281
+Q 500 653 500 1363
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575
+Q 1756 1575 1579 1456
+Q 1403 1338 1403 1106
+Q 1403 894 1545 773
+Q 1688 653 1941 653
+Q 2256 653 2472 879
+Q 2688 1106 2688 1447
+L 2688 1575
+L 2106 1575
+z
+M 3816 1997
+L 3816 0
+L 2688 0
+L 2688 519
+Q 2463 200 2181 54
+Q 1900 -91 1497 -91
+Q 953 -91 614 226
+Q 275 544 275 1050
+Q 275 1666 698 1953
+Q 1122 2241 2028 2241
+L 2688 2241
+L 2688 2328
+Q 2688 2594 2478 2717
+Q 2269 2841 1825 2841
+Q 1466 2841 1156 2769
+Q 847 2697 581 2553
+L 581 3406
+Q 941 3494 1303 3539
+Q 1666 3584 2028 3584
+Q 2975 3584 3395 3211
+Q 3816 2838 3816 1997
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-79" d="M 78 3500
+L 1197 3500
+L 2138 1125
+L 2938 3500
+L 4056 3500
+L 2584 -331
+Q 2363 -916 2067 -1148
+Q 1772 -1381 1288 -1381
+L 641 -1381
+L 641 -647
+L 991 -647
+Q 1275 -647 1404 -556
+Q 1534 -466 1606 -231
+L 1638 -134
+L 78 3500
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2d" d="M 347 2297
+L 2309 2297
+L 2309 1388
+L 347 1388
+L 347 2297
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6b" d="M 538 4863
+L 1656 4863
+L 1656 2216
+L 2944 3500
+L 4244 3500
+L 2534 1894
+L 4378 0
+L 3022 0
+L 1656 1459
+L 1656 0
+L 538 0
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-64" d="M 2919 2988
+L 2919 4863
+L 4044 4863
+L 4044 0
+L 2919 0
+L 2919 506
+Q 2688 197 2409 53
+Q 2131 -91 1766 -91
+Q 1119 -91 703 423
+Q 288 938 288 1747
+Q 288 2556 703 3070
+Q 1119 3584 1766 3584
+Q 2128 3584 2408 3439
+Q 2688 3294 2919 2988
+z
+M 2181 722
+Q 2541 722 2730 984
+Q 2919 1247 2919 1747
+Q 2919 2247 2730 2509
+Q 2541 2772 2181 2772
+Q 1825 2772 1636 2509
+Q 1447 2247 1447 1747
+Q 1447 1247 1636 984
+Q 1825 722 2181 722
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-66" d="M 2841 4863
+L 2841 4128
+L 2222 4128
+Q 1984 4128 1890 4042
+Q 1797 3956 1797 3744
+L 1797 3500
+L 2753 3500
+L 2753 2700
+L 1797 2700
+L 1797 0
+L 678 0
+L 678 2700
+L 122 2700
+L 122 3500
+L 678 3500
+L 678 3744
+Q 678 4316 997 4589
+Q 1316 4863 1984 4863
+L 2841 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863
+L 1656 4863
+L 1656 0
+L 538 0
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-45"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="68.310547"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="139.501953"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="188.818359"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="223.095703"/>
+     <use xlink:href="#DejaVuSans-Bold-68" x="282.373047"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="353.564453"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="457.763672"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="525.585938"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="596.777344"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="644.580078"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="679.394531"/>
+     <use xlink:href="#DejaVuSans-Bold-75" x="738.916016"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="810.107422"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="914.306641"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1018.505859"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1085.986328"/>
+     <use xlink:href="#DejaVuSans-Bold-79" x="1135.302734"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1200.488281"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" x="1235.302734"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1276.806641"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1311.621094"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1359.423828"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1408.740234"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1476.220703"/>
+     <use xlink:href="#DejaVuSans-Bold-6b" x="1535.498047"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="1599.376953"/>
+     <use xlink:href="#DejaVuSans-Bold-64" x="1667.199219"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" x="1738.78125"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1780.285156"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1847.765625"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1897.082031"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="1944.884766"/>
+     <use xlink:href="#DejaVuSans-Bold-66" x="1979.162109"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="2022.667969"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="2090.148438"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="2149.425781"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="2197.228516"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="2232.042969"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="2281.359375"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="2349.181641"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="2416.662109"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="2487.853516"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" x="2555.333984"/>
+     <use xlink:href="#DejaVuSans-Bold-79" x="2589.611328"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="2654.796875"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="2714.318359"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="2748.595703"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p157208b24c">
+   <rect x="44.089063" y="21.406313" width="401.76" height="232.848"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/paper/reproduction/evidence-coverage.svg
+++ b/paper/reproduction/evidence-coverage.svg
@@ -1,0 +1,1331 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="478.394135pt" height="317.135209pt" viewBox="0 0 478.394135 317.135209" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 317.135209
+L 478.394135 317.135209
+L 478.394135 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 69.434135 254.254313
+L 471.194135 254.254313
+L 471.194135 21.406313
+L 69.434135 21.406313
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="md36de533ea" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md36de533ea" x="121.440617" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- derived-artifact-reanalysis -->
+      <g transform="translate(9.538937 308.176368) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-64" d="M 2906 2969
+L 2906 4863
+L 3481 4863
+L 3481 0
+L 2906 0
+L 2906 525
+Q 2725 213 2448 61
+Q 2172 -91 1784 -91
+Q 1150 -91 751 415
+Q 353 922 353 1747
+Q 353 2572 751 3078
+Q 1150 3584 1784 3584
+Q 2172 3584 2448 3432
+Q 2725 3281 2906 2969
+z
+M 947 1747
+Q 947 1113 1208 752
+Q 1469 391 1925 391
+Q 2381 391 2643 752
+Q 2906 1113 2906 1747
+Q 2906 2381 2643 2742
+Q 2381 3103 1925 3103
+Q 1469 3103 1208 2742
+Q 947 2381 947 1747
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-65" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963
+Q 2534 3019 2420 3045
+Q 2306 3072 2169 3072
+Q 1681 3072 1420 2755
+Q 1159 2438 1159 1844
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1341 3275 1631 3429
+Q 1922 3584 2338 3584
+Q 2397 3584 2469 3576
+Q 2541 3569 2628 3553
+L 2631 2963
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500
+L 1178 3500
+L 1178 0
+L 603 0
+L 603 3500
+z
+M 603 4863
+L 1178 4863
+L 1178 4134
+L 603 4134
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-76" d="M 191 3500
+L 800 3500
+L 1894 563
+L 2988 3500
+L 3597 3500
+L 2284 0
+L 1503 0
+L 191 3500
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2d" d="M 313 2009
+L 1997 2009
+L 1997 1497
+L 313 1497
+L 313 2009
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-61" d="M 2194 1759
+Q 1497 1759 1228 1600
+Q 959 1441 959 1056
+Q 959 750 1161 570
+Q 1363 391 1709 391
+Q 2188 391 2477 730
+Q 2766 1069 2766 1631
+L 2766 1759
+L 2194 1759
+z
+M 3341 1997
+L 3341 0
+L 2766 0
+L 2766 531
+Q 2569 213 2275 61
+Q 1981 -91 1556 -91
+Q 1019 -91 701 211
+Q 384 513 384 1019
+Q 384 1609 779 1909
+Q 1175 2209 1959 2209
+L 2766 2209
+L 2766 2266
+Q 2766 2663 2505 2880
+Q 2244 3097 1772 3097
+Q 1472 3097 1187 3025
+Q 903 2953 641 2809
+L 641 3341
+Q 956 3463 1253 3523
+Q 1550 3584 1831 3584
+Q 2591 3584 2966 3190
+Q 3341 2797 3341 1997
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494
+L 1172 3500
+L 2356 3500
+L 2356 3053
+L 1172 3053
+L 1172 1153
+Q 1172 725 1289 603
+Q 1406 481 1766 481
+L 2356 481
+L 2356 0
+L 1766 0
+Q 1100 0 847 248
+Q 594 497 594 1153
+L 594 3053
+L 172 3053
+L 172 3500
+L 594 3500
+L 594 4494
+L 1172 4494
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-66" d="M 2375 4863
+L 2375 4384
+L 1825 4384
+Q 1516 4384 1395 4259
+Q 1275 4134 1275 3809
+L 1275 3500
+L 2222 3500
+L 2222 3053
+L 1275 3053
+L 1275 0
+L 697 0
+L 697 3053
+L 147 3053
+L 147 3500
+L 697 3500
+L 697 3744
+Q 697 4328 969 4595
+Q 1241 4863 1831 4863
+L 2375 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-63" d="M 3122 3366
+L 3122 2828
+Q 2878 2963 2633 3030
+Q 2388 3097 2138 3097
+Q 1578 3097 1268 2742
+Q 959 2388 959 1747
+Q 959 1106 1268 751
+Q 1578 397 2138 397
+Q 2388 397 2633 464
+Q 2878 531 3122 666
+L 3122 134
+Q 2881 22 2623 -34
+Q 2366 -91 2075 -91
+Q 1284 -91 818 406
+Q 353 903 353 1747
+Q 353 2603 823 3093
+Q 1294 3584 2113 3584
+Q 2378 3584 2631 3529
+Q 2884 3475 3122 3366
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6e" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6c" d="M 603 4863
+L 1178 4863
+L 1178 0
+L 603 0
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-79" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397
+L 2834 2853
+Q 2591 2978 2328 3040
+Q 2066 3103 1784 3103
+Q 1356 3103 1142 2972
+Q 928 2841 928 2578
+Q 928 2378 1081 2264
+Q 1234 2150 1697 2047
+L 1894 2003
+Q 2506 1872 2764 1633
+Q 3022 1394 3022 966
+Q 3022 478 2636 193
+Q 2250 -91 1575 -91
+Q 1294 -91 989 -36
+Q 684 19 347 128
+L 347 722
+Q 666 556 975 473
+Q 1284 391 1588 391
+Q 1994 391 2212 530
+Q 2431 669 2431 922
+Q 2431 1156 2273 1281
+Q 2116 1406 1581 1522
+L 1381 1569
+Q 847 1681 609 1914
+Q 372 2147 372 2553
+Q 372 3047 722 3315
+Q 1072 3584 1716 3584
+Q 2034 3584 2315 3537
+Q 2597 3491 2834 3397
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-64"/>
+       <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+       <use xlink:href="#DejaVuSans-72" x="125"/>
+       <use xlink:href="#DejaVuSans-69" x="166.113281"/>
+       <use xlink:href="#DejaVuSans-76" x="193.896484"/>
+       <use xlink:href="#DejaVuSans-65" x="253.076172"/>
+       <use xlink:href="#DejaVuSans-64" x="314.599609"/>
+       <use xlink:href="#DejaVuSans-2d" x="378.076172"/>
+       <use xlink:href="#DejaVuSans-61" x="414.160156"/>
+       <use xlink:href="#DejaVuSans-72" x="475.439453"/>
+       <use xlink:href="#DejaVuSans-74" x="516.552734"/>
+       <use xlink:href="#DejaVuSans-69" x="555.761719"/>
+       <use xlink:href="#DejaVuSans-66" x="583.544922"/>
+       <use xlink:href="#DejaVuSans-61" x="618.75"/>
+       <use xlink:href="#DejaVuSans-63" x="680.029297"/>
+       <use xlink:href="#DejaVuSans-74" x="735.009766"/>
+       <use xlink:href="#DejaVuSans-2d" x="774.21875"/>
+       <use xlink:href="#DejaVuSans-72" x="810.302734"/>
+       <use xlink:href="#DejaVuSans-65" x="849.166016"/>
+       <use xlink:href="#DejaVuSans-61" x="910.689453"/>
+       <use xlink:href="#DejaVuSans-6e" x="971.96875"/>
+       <use xlink:href="#DejaVuSans-61" x="1035.347656"/>
+       <use xlink:href="#DejaVuSans-6c" x="1096.626953"/>
+       <use xlink:href="#DejaVuSans-79" x="1124.410156"/>
+       <use xlink:href="#DejaVuSans-73" x="1183.589844"/>
+       <use xlink:href="#DejaVuSans-69" x="1235.689453"/>
+       <use xlink:href="#DejaVuSans-73" x="1263.472656"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#md36de533ea" x="220.689629" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- documentary-trace -->
+      <g transform="translate(138.981594 297.18678) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-6f" d="M 1959 3097
+Q 1497 3097 1228 2736
+Q 959 2375 959 1747
+Q 959 1119 1226 758
+Q 1494 397 1959 397
+Q 2419 397 2687 759
+Q 2956 1122 2956 1747
+Q 2956 2369 2687 2733
+Q 2419 3097 1959 3097
+z
+M 1959 3584
+Q 2709 3584 3137 3096
+Q 3566 2609 3566 1747
+Q 3566 888 3137 398
+Q 2709 -91 1959 -91
+Q 1206 -91 779 398
+Q 353 888 353 1747
+Q 353 2609 779 3096
+Q 1206 3584 1959 3584
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-75" d="M 544 1381
+L 544 3500
+L 1119 3500
+L 1119 1403
+Q 1119 906 1312 657
+Q 1506 409 1894 409
+Q 2359 409 2629 706
+Q 2900 1003 2900 1516
+L 2900 3500
+L 3475 3500
+L 3475 0
+L 2900 0
+L 2900 538
+Q 2691 219 2414 64
+Q 2138 -91 1772 -91
+Q 1169 -91 856 284
+Q 544 659 544 1381
+z
+M 1991 3584
+L 1991 3584
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6d" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-64"/>
+       <use xlink:href="#DejaVuSans-6f" x="63.476562"/>
+       <use xlink:href="#DejaVuSans-63" x="124.658203"/>
+       <use xlink:href="#DejaVuSans-75" x="179.638672"/>
+       <use xlink:href="#DejaVuSans-6d" x="243.017578"/>
+       <use xlink:href="#DejaVuSans-65" x="340.429688"/>
+       <use xlink:href="#DejaVuSans-6e" x="401.953125"/>
+       <use xlink:href="#DejaVuSans-74" x="465.332031"/>
+       <use xlink:href="#DejaVuSans-61" x="504.541016"/>
+       <use xlink:href="#DejaVuSans-72" x="565.820312"/>
+       <use xlink:href="#DejaVuSans-79" x="606.933594"/>
+       <use xlink:href="#DejaVuSans-2d" x="664.363281"/>
+       <use xlink:href="#DejaVuSans-74" x="700.447266"/>
+       <use xlink:href="#DejaVuSans-72" x="739.65625"/>
+       <use xlink:href="#DejaVuSans-61" x="780.769531"/>
+       <use xlink:href="#DejaVuSans-63" x="842.048828"/>
+       <use xlink:href="#DejaVuSans-65" x="897.029297"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#md36de533ea" x="319.938641" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- source-recomputation -->
+      <g transform="translate(226.186977 301.570303) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-70" d="M 1159 525
+L 1159 -1331
+L 581 -1331
+L 581 3500
+L 1159 3500
+L 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+z
+M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-73"/>
+       <use xlink:href="#DejaVuSans-6f" x="52.099609"/>
+       <use xlink:href="#DejaVuSans-75" x="113.28125"/>
+       <use xlink:href="#DejaVuSans-72" x="176.660156"/>
+       <use xlink:href="#DejaVuSans-63" x="215.523438"/>
+       <use xlink:href="#DejaVuSans-65" x="270.503906"/>
+       <use xlink:href="#DejaVuSans-2d" x="332.027344"/>
+       <use xlink:href="#DejaVuSans-72" x="368.111328"/>
+       <use xlink:href="#DejaVuSans-65" x="406.974609"/>
+       <use xlink:href="#DejaVuSans-63" x="468.498047"/>
+       <use xlink:href="#DejaVuSans-6f" x="523.478516"/>
+       <use xlink:href="#DejaVuSans-6d" x="584.660156"/>
+       <use xlink:href="#DejaVuSans-70" x="682.072266"/>
+       <use xlink:href="#DejaVuSans-75" x="745.548828"/>
+       <use xlink:href="#DejaVuSans-74" x="808.927734"/>
+       <use xlink:href="#DejaVuSans-61" x="848.136719"/>
+       <use xlink:href="#DejaVuSans-74" x="909.416016"/>
+       <use xlink:href="#DejaVuSans-69" x="948.625"/>
+       <use xlink:href="#DejaVuSans-6f" x="976.408203"/>
+       <use xlink:href="#DejaVuSans-6e" x="1037.589844"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#md36de533ea" x="419.187653" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- unavailable -->
+      <g transform="translate(369.652784 285.476705) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-62" d="M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+M 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2969
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-75"/>
+       <use xlink:href="#DejaVuSans-6e" x="63.378906"/>
+       <use xlink:href="#DejaVuSans-61" x="126.757812"/>
+       <use xlink:href="#DejaVuSans-76" x="188.037109"/>
+       <use xlink:href="#DejaVuSans-61" x="247.216797"/>
+       <use xlink:href="#DejaVuSans-69" x="308.496094"/>
+       <use xlink:href="#DejaVuSans-6c" x="336.279297"/>
+       <use xlink:href="#DejaVuSans-61" x="364.0625"/>
+       <use xlink:href="#DejaVuSans-62" x="425.341797"/>
+       <use xlink:href="#DejaVuSans-6c" x="488.818359"/>
+       <use xlink:href="#DejaVuSans-65" x="516.601562"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_5">
+      <path d="M 69.434135 254.254313
+L 471.194135 254.254313
+" clip-path="url(#p1643c53492)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <defs>
+       <path id="m77db5bb38e" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m77db5bb38e" x="69.434135" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0.0 -->
+      <g transform="translate(48.121323 257.673609) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794
+L 1344 794
+L 1344 0
+L 684 0
+L 684 794
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_7">
+      <path d="M 69.434135 223.454313
+L 471.194135 223.454313
+" clip-path="url(#p1643c53492)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="69.434135" y="223.454313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 2.5 -->
+      <g transform="translate(48.121323 226.873609) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_9">
+      <path d="M 69.434135 192.654313
+L 471.194135 192.654313
+" clip-path="url(#p1643c53492)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="69.434135" y="192.654313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 5.0 -->
+      <g transform="translate(48.121323 196.073609) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_11">
+      <path d="M 69.434135 161.854312
+L 471.194135 161.854312
+" clip-path="url(#p1643c53492)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="69.434135" y="161.854312" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 7.5 -->
+      <g transform="translate(48.121323 165.273609) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666
+L 3525 4666
+L 3525 4397
+L 1831 0
+L 1172 0
+L 2766 4134
+L 525 4134
+L 525 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-37"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_13">
+      <path d="M 69.434135 131.054313
+L 471.194135 131.054313
+" clip-path="url(#p1643c53492)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="69.434135" y="131.054313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 10.0 -->
+      <g transform="translate(42.395073 134.473609) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <path d="M 69.434135 100.254312
+L 471.194135 100.254312
+" clip-path="url(#p1643c53492)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="69.434135" y="100.254312" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 12.5 -->
+      <g transform="translate(42.395073 103.673609) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_17">
+      <path d="M 69.434135 69.454312
+L 471.194135 69.454312
+" clip-path="url(#p1643c53492)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="69.434135" y="69.454312" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 15.0 -->
+      <g transform="translate(42.395073 72.873609) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_19">
+      <path d="M 69.434135 38.654313
+L 471.194135 38.654313
+" clip-path="url(#p1643c53492)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="69.434135" y="38.654313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 17.5 -->
+      <g transform="translate(42.395073 42.073609) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_13">
+     <!-- Targets -->
+     <g transform="translate(36.523354 154.099219) rotate(-90) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666
+L 3928 4666
+L 3928 4134
+L 2272 4134
+L 2272 0
+L 1638 0
+L 1638 4134
+L -19 4134
+L -19 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791
+Q 2906 2416 2648 2759
+Q 2391 3103 1925 3103
+Q 1463 3103 1205 2759
+Q 947 2416 947 1791
+Q 947 1169 1205 825
+Q 1463 481 1925 481
+Q 2391 481 2648 825
+Q 2906 1169 2906 1791
+z
+M 3481 434
+Q 3481 -459 3084 -895
+Q 2688 -1331 1869 -1331
+Q 1566 -1331 1297 -1286
+Q 1028 -1241 775 -1147
+L 775 -588
+Q 1028 -725 1275 -790
+Q 1522 -856 1778 -856
+Q 2344 -856 2625 -561
+Q 2906 -266 2906 331
+L 2906 616
+Q 2728 306 2450 153
+Q 2172 0 1784 0
+Q 1141 0 747 490
+Q 353 981 353 1791
+Q 353 2603 747 3093
+Q 1141 3584 1784 3584
+Q 2172 3584 2450 3431
+Q 2728 3278 2906 2969
+L 2906 3500
+L 3481 3500
+L 3481 434
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-54"/>
+      <use xlink:href="#DejaVuSans-61" x="44.583984"/>
+      <use xlink:href="#DejaVuSans-72" x="105.863281"/>
+      <use xlink:href="#DejaVuSans-67" x="145.226562"/>
+      <use xlink:href="#DejaVuSans-65" x="208.703125"/>
+      <use xlink:href="#DejaVuSans-74" x="270.226562"/>
+      <use xlink:href="#DejaVuSans-73" x="309.435547"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 87.695953 254.254313
+L 155.185281 254.254313
+L 155.185281 32.494312
+L 87.695953 32.494312
+z
+" clip-path="url(#p1643c53492)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 186.944965 254.254313
+L 254.434293 254.254313
+L 254.434293 44.814312
+L 186.944965 44.814312
+z
+" clip-path="url(#p1643c53492)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 286.193977 254.254313
+L 353.683305 254.254313
+L 353.683305 44.814312
+L 286.193977 44.814312
+z
+" clip-path="url(#p1643c53492)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 385.442989 254.254313
+L 452.932317 254.254313
+L 452.932317 241.934313
+L 385.442989 241.934313
+z
+" clip-path="url(#p1643c53492)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 69.434135 254.254313
+L 69.434135 21.406313
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 69.434135 254.254313
+L 471.194135 254.254313
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_14">
+    <!-- Evidence coverage - tracked-artifact audit -->
+    <g transform="translate(141.720729 15.406313) scale(0.108 -0.108)">
+     <defs>
+      <path id="DejaVuSans-Bold-45" d="M 588 4666
+L 3834 4666
+L 3834 3756
+L 1791 3756
+L 1791 2888
+L 3713 2888
+L 3713 1978
+L 1791 1978
+L 1791 909
+L 3903 909
+L 3903 0
+L 588 0
+L 588 4666
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-76" d="M 97 3500
+L 1216 3500
+L 2088 1081
+L 2956 3500
+L 4078 3500
+L 2700 0
+L 1472 0
+L 97 3500
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-69" d="M 538 3500
+L 1656 3500
+L 1656 0
+L 538 0
+L 538 3500
+z
+M 538 4863
+L 1656 4863
+L 1656 3950
+L 538 3950
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-64" d="M 2919 2988
+L 2919 4863
+L 4044 4863
+L 4044 0
+L 2919 0
+L 2919 506
+Q 2688 197 2409 53
+Q 2131 -91 1766 -91
+Q 1119 -91 703 423
+Q 288 938 288 1747
+Q 288 2556 703 3070
+Q 1119 3584 1766 3584
+Q 2128 3584 2408 3439
+Q 2688 3294 2919 2988
+z
+M 2181 722
+Q 2541 722 2730 984
+Q 2919 1247 2919 1747
+Q 2919 2247 2730 2509
+Q 2541 2772 2181 2772
+Q 1825 2772 1636 2509
+Q 1447 2247 1447 1747
+Q 1447 1247 1636 984
+Q 1825 722 2181 722
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759
+L 4031 1441
+L 1416 1441
+Q 1456 1047 1700 850
+Q 1944 653 2381 653
+Q 2734 653 3104 758
+Q 3475 863 3866 1075
+L 3866 213
+Q 3469 63 3072 -14
+Q 2675 -91 2278 -91
+Q 1328 -91 801 392
+Q 275 875 275 1747
+Q 275 2603 792 3093
+Q 1309 3584 2216 3584
+Q 3041 3584 3536 3087
+Q 4031 2591 4031 1759
+z
+M 2881 2131
+Q 2881 2450 2695 2645
+Q 2509 2841 2209 2841
+Q 1884 2841 1681 2658
+Q 1478 2475 1428 2131
+L 2881 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131
+L 4056 0
+L 2931 0
+L 2931 347
+L 2931 1631
+Q 2931 2084 2911 2256
+Q 2891 2428 2841 2509
+Q 2775 2619 2662 2680
+Q 2550 2741 2406 2741
+Q 2056 2741 1856 2470
+Q 1656 2200 1656 1722
+L 1656 0
+L 538 0
+L 538 3500
+L 1656 3500
+L 1656 2988
+Q 1909 3294 2193 3439
+Q 2478 3584 2822 3584
+Q 3428 3584 3742 3212
+Q 4056 2841 4056 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391
+L 3366 2478
+Q 3138 2634 2908 2709
+Q 2678 2784 2431 2784
+Q 1963 2784 1702 2511
+Q 1441 2238 1441 1747
+Q 1441 1256 1702 982
+Q 1963 709 2431 709
+Q 2694 709 2930 787
+Q 3166 866 3366 1019
+L 3366 103
+Q 3103 6 2833 -42
+Q 2563 -91 2291 -91
+Q 1344 -91 809 395
+Q 275 881 275 1747
+Q 275 2613 809 3098
+Q 1344 3584 2291 3584
+Q 2566 3584 2833 3536
+Q 3100 3488 3366 3391
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6f" d="M 2203 2784
+Q 1831 2784 1636 2517
+Q 1441 2250 1441 1747
+Q 1441 1244 1636 976
+Q 1831 709 2203 709
+Q 2569 709 2762 976
+Q 2956 1244 2956 1747
+Q 2956 2250 2762 2517
+Q 2569 2784 2203 2784
+z
+M 2203 3584
+Q 3106 3584 3614 3096
+Q 4122 2609 4122 1747
+Q 4122 884 3614 396
+Q 3106 -91 2203 -91
+Q 1297 -91 786 396
+Q 275 884 275 1747
+Q 275 2609 786 3096
+Q 1297 3584 2203 3584
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-72" d="M 3138 2547
+Q 2991 2616 2845 2648
+Q 2700 2681 2553 2681
+Q 2122 2681 1889 2404
+Q 1656 2128 1656 1613
+L 1656 0
+L 538 0
+L 538 3500
+L 1656 3500
+L 1656 2925
+Q 1872 3269 2151 3426
+Q 2431 3584 2822 3584
+Q 2878 3584 2943 3579
+Q 3009 3575 3134 3559
+L 3138 2547
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575
+Q 1756 1575 1579 1456
+Q 1403 1338 1403 1106
+Q 1403 894 1545 773
+Q 1688 653 1941 653
+Q 2256 653 2472 879
+Q 2688 1106 2688 1447
+L 2688 1575
+L 2106 1575
+z
+M 3816 1997
+L 3816 0
+L 2688 0
+L 2688 519
+Q 2463 200 2181 54
+Q 1900 -91 1497 -91
+Q 953 -91 614 226
+Q 275 544 275 1050
+Q 275 1666 698 1953
+Q 1122 2241 2028 2241
+L 2688 2241
+L 2688 2328
+Q 2688 2594 2478 2717
+Q 2269 2841 1825 2841
+Q 1466 2841 1156 2769
+Q 847 2697 581 2553
+L 581 3406
+Q 941 3494 1303 3539
+Q 1666 3584 2028 3584
+Q 2975 3584 3395 3211
+Q 3816 2838 3816 1997
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-67" d="M 2919 594
+Q 2688 288 2409 144
+Q 2131 0 1766 0
+Q 1125 0 706 504
+Q 288 1009 288 1791
+Q 288 2575 706 3076
+Q 1125 3578 1766 3578
+Q 2131 3578 2409 3434
+Q 2688 3291 2919 2981
+L 2919 3500
+L 4044 3500
+L 4044 353
+Q 4044 -491 3511 -936
+Q 2978 -1381 1966 -1381
+Q 1638 -1381 1331 -1331
+Q 1025 -1281 716 -1178
+L 716 -306
+Q 1009 -475 1290 -558
+Q 1572 -641 1856 -641
+Q 2406 -641 2662 -400
+Q 2919 -159 2919 353
+L 2919 594
+z
+M 2181 2772
+Q 1834 2772 1640 2515
+Q 1447 2259 1447 1791
+Q 1447 1309 1634 1061
+Q 1822 813 2181 813
+Q 2531 813 2725 1069
+Q 2919 1325 2919 1791
+Q 2919 2259 2725 2515
+Q 2531 2772 2181 2772
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2d" d="M 347 2297
+L 2309 2297
+L 2309 1388
+L 347 1388
+L 347 2297
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494
+L 1759 3500
+L 2913 3500
+L 2913 2700
+L 1759 2700
+L 1759 1216
+Q 1759 972 1856 886
+Q 1953 800 2241 800
+L 2816 800
+L 2816 0
+L 1856 0
+Q 1194 0 917 276
+Q 641 553 641 1216
+L 641 2700
+L 84 2700
+L 84 3500
+L 641 3500
+L 641 4494
+L 1759 4494
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6b" d="M 538 4863
+L 1656 4863
+L 1656 2216
+L 2944 3500
+L 4244 3500
+L 2534 1894
+L 4378 0
+L 3022 0
+L 1656 1459
+L 1656 0
+L 538 0
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-66" d="M 2841 4863
+L 2841 4128
+L 2222 4128
+Q 1984 4128 1890 4042
+Q 1797 3956 1797 3744
+L 1797 3500
+L 2753 3500
+L 2753 2700
+L 1797 2700
+L 1797 0
+L 678 0
+L 678 2700
+L 122 2700
+L 122 3500
+L 678 3500
+L 678 3744
+Q 678 4316 997 4589
+Q 1316 4863 1984 4863
+L 2841 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-75" d="M 500 1363
+L 500 3500
+L 1625 3500
+L 1625 3150
+Q 1625 2866 1622 2436
+Q 1619 2006 1619 1863
+Q 1619 1441 1641 1255
+Q 1663 1069 1716 984
+Q 1784 875 1895 815
+Q 2006 756 2150 756
+Q 2500 756 2700 1025
+Q 2900 1294 2900 1772
+L 2900 3500
+L 4019 3500
+L 4019 0
+L 2900 0
+L 2900 506
+Q 2647 200 2364 54
+Q 2081 -91 1741 -91
+Q 1134 -91 817 281
+Q 500 653 500 1363
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-45"/>
+     <use xlink:href="#DejaVuSans-Bold-76" x="68.310547"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="133.496094"/>
+     <use xlink:href="#DejaVuSans-Bold-64" x="167.773438"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="239.355469"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="307.177734"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="378.369141"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="437.646484"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="505.46875"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="540.283203"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" x="599.560547"/>
+     <use xlink:href="#DejaVuSans-Bold-76" x="668.261719"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="733.447266"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="801.269531"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="850.585938"/>
+     <use xlink:href="#DejaVuSans-Bold-67" x="918.066406"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="989.648438"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1057.470703"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" x="1092.285156"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1133.789062"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1168.603516"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1216.40625"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1265.722656"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1333.203125"/>
+     <use xlink:href="#DejaVuSans-Bold-6b" x="1392.480469"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="1456.359375"/>
+     <use xlink:href="#DejaVuSans-Bold-64" x="1524.181641"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" x="1595.763672"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1637.267578"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1704.748047"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1754.064453"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="1801.867188"/>
+     <use xlink:href="#DejaVuSans-Bold-66" x="1836.144531"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1879.650391"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1947.130859"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="2006.408203"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="2054.210938"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="2089.025391"/>
+     <use xlink:href="#DejaVuSans-Bold-75" x="2156.505859"/>
+     <use xlink:href="#DejaVuSans-Bold-64" x="2227.697266"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="2299.279297"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="2333.556641"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p1643c53492">
+   <rect x="69.434135" y="21.406313" width="401.76" height="232.848"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/paper/reproduction/pod-summary.svg
+++ b/paper/reproduction/pod-summary.svg
@@ -1,0 +1,1446 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="447.322813pt" height="294.747211pt" viewBox="0 0 447.322813 294.747211" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 294.747211
+L 447.322813 294.747211
+L 447.322813 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 38.362813 254.254312
+L 440.122813 254.254312
+L 440.122813 21.406313
+L 38.362813 21.406313
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="md36de533ea" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md36de533ea" x="90.369295" y="254.254312" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- Morphology -->
+      <g transform="translate(39.978131 285.788371) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666
+L 1569 4666
+L 2759 1491
+L 3956 4666
+L 4897 4666
+L 4897 0
+L 4281 0
+L 4281 4097
+L 3078 897
+L 2444 897
+L 1241 4097
+L 1241 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6f" d="M 1959 3097
+Q 1497 3097 1228 2736
+Q 959 2375 959 1747
+Q 959 1119 1226 758
+Q 1494 397 1959 397
+Q 2419 397 2687 759
+Q 2956 1122 2956 1747
+Q 2956 2369 2687 2733
+Q 2419 3097 1959 3097
+z
+M 1959 3584
+Q 2709 3584 3137 3096
+Q 3566 2609 3566 1747
+Q 3566 888 3137 398
+Q 2709 -91 1959 -91
+Q 1206 -91 779 398
+Q 353 888 353 1747
+Q 353 2609 779 3096
+Q 1206 3584 1959 3584
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963
+Q 2534 3019 2420 3045
+Q 2306 3072 2169 3072
+Q 1681 3072 1420 2755
+Q 1159 2438 1159 1844
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1341 3275 1631 3429
+Q 1922 3584 2338 3584
+Q 2397 3584 2469 3576
+Q 2541 3569 2628 3553
+L 2631 2963
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-70" d="M 1159 525
+L 1159 -1331
+L 581 -1331
+L 581 3500
+L 1159 3500
+L 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+z
+M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-68" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6c" d="M 603 4863
+L 1178 4863
+L 1178 0
+L 603 0
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-67" d="M 2906 1791
+Q 2906 2416 2648 2759
+Q 2391 3103 1925 3103
+Q 1463 3103 1205 2759
+Q 947 2416 947 1791
+Q 947 1169 1205 825
+Q 1463 481 1925 481
+Q 2391 481 2648 825
+Q 2906 1169 2906 1791
+z
+M 3481 434
+Q 3481 -459 3084 -895
+Q 2688 -1331 1869 -1331
+Q 1566 -1331 1297 -1286
+Q 1028 -1241 775 -1147
+L 775 -588
+Q 1028 -725 1275 -790
+Q 1522 -856 1778 -856
+Q 2344 -856 2625 -561
+Q 2906 -266 2906 331
+L 2906 616
+Q 2728 306 2450 153
+Q 2172 0 1784 0
+Q 1141 0 747 490
+Q 353 981 353 1791
+Q 353 2603 747 3093
+Q 1141 3584 1784 3584
+Q 2172 3584 2450 3431
+Q 2728 3278 2906 2969
+L 2906 3500
+L 3481 3500
+L 3481 434
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-79" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-4d"/>
+       <use xlink:href="#DejaVuSans-6f" x="86.279297"/>
+       <use xlink:href="#DejaVuSans-72" x="147.460938"/>
+       <use xlink:href="#DejaVuSans-70" x="188.574219"/>
+       <use xlink:href="#DejaVuSans-68" x="252.050781"/>
+       <use xlink:href="#DejaVuSans-6f" x="315.429688"/>
+       <use xlink:href="#DejaVuSans-6c" x="376.611328"/>
+       <use xlink:href="#DejaVuSans-6f" x="404.394531"/>
+       <use xlink:href="#DejaVuSans-67" x="465.576172"/>
+       <use xlink:href="#DejaVuSans-79" x="529.052734"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#md36de533ea" x="189.618307" y="254.254312" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- MT -->
+      <g transform="translate(176.515614 272.216477) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-54" d="M -19 4666
+L 3928 4666
+L 3928 4134
+L 2272 4134
+L 2272 0
+L 1638 0
+L 1638 4134
+L -19 4134
+L -19 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-4d"/>
+       <use xlink:href="#DejaVuSans-54" x="86.279297"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#md36de533ea" x="288.867318" y="254.254312" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- Cell count -->
+      <g transform="translate(245.870949 283.096886) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-43" d="M 4122 4306
+L 4122 3641
+Q 3803 3938 3442 4084
+Q 3081 4231 2675 4231
+Q 1875 4231 1450 3742
+Q 1025 3253 1025 2328
+Q 1025 1406 1450 917
+Q 1875 428 2675 428
+Q 3081 428 3442 575
+Q 3803 722 4122 1019
+L 4122 359
+Q 3791 134 3420 21
+Q 3050 -91 2638 -91
+Q 1578 -91 968 557
+Q 359 1206 359 2328
+Q 359 3453 968 4101
+Q 1578 4750 2638 4750
+Q 3056 4750 3426 4639
+Q 3797 4528 4122 4306
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-65" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-63" d="M 3122 3366
+L 3122 2828
+Q 2878 2963 2633 3030
+Q 2388 3097 2138 3097
+Q 1578 3097 1268 2742
+Q 959 2388 959 1747
+Q 959 1106 1268 751
+Q 1578 397 2138 397
+Q 2388 397 2633 464
+Q 2878 531 3122 666
+L 3122 134
+Q 2881 22 2623 -34
+Q 2366 -91 2075 -91
+Q 1284 -91 818 406
+Q 353 903 353 1747
+Q 353 2603 823 3093
+Q 1294 3584 2113 3584
+Q 2378 3584 2631 3529
+Q 2884 3475 3122 3366
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-75" d="M 544 1381
+L 544 3500
+L 1119 3500
+L 1119 1403
+Q 1119 906 1312 657
+Q 1506 409 1894 409
+Q 2359 409 2629 706
+Q 2900 1003 2900 1516
+L 2900 3500
+L 3475 3500
+L 3475 0
+L 2900 0
+L 2900 538
+Q 2691 219 2414 64
+Q 2138 -91 1772 -91
+Q 1169 -91 856 284
+Q 544 659 544 1381
+z
+M 1991 3584
+L 1991 3584
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6e" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494
+L 1172 3500
+L 2356 3500
+L 2356 3053
+L 1172 3053
+L 1172 1153
+Q 1172 725 1289 603
+Q 1406 481 1766 481
+L 2356 481
+L 2356 0
+L 1766 0
+Q 1100 0 847 248
+Q 594 497 594 1153
+L 594 3053
+L 172 3053
+L 172 3500
+L 594 3500
+L 594 4494
+L 1172 4494
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-43"/>
+       <use xlink:href="#DejaVuSans-65" x="69.824219"/>
+       <use xlink:href="#DejaVuSans-6c" x="131.347656"/>
+       <use xlink:href="#DejaVuSans-6c" x="159.130859"/>
+       <use xlink:href="#DejaVuSans-20" x="186.914062"/>
+       <use xlink:href="#DejaVuSans-63" x="218.701172"/>
+       <use xlink:href="#DejaVuSans-6f" x="273.681641"/>
+       <use xlink:href="#DejaVuSans-75" x="334.863281"/>
+       <use xlink:href="#DejaVuSans-6e" x="398.242188"/>
+       <use xlink:href="#DejaVuSans-74" x="461.621094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#md36de533ea" x="388.11633" y="254.254312" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- LDH -->
+      <g transform="translate(369.891726 274.080701) rotate(-20) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-4c" d="M 628 4666
+L 1259 4666
+L 1259 531
+L 3531 531
+L 3531 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-44" d="M 1259 4147
+L 1259 519
+L 2022 519
+Q 2988 519 3436 956
+Q 3884 1394 3884 2338
+Q 3884 3275 3436 3711
+Q 2988 4147 2022 4147
+L 1259 4147
+z
+M 628 4666
+L 1925 4666
+Q 3281 4666 3915 4102
+Q 4550 3538 4550 2338
+Q 4550 1131 3912 565
+Q 3275 0 1925 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-48" d="M 628 4666
+L 1259 4666
+L 1259 2753
+L 3553 2753
+L 3553 4666
+L 4184 4666
+L 4184 0
+L 3553 0
+L 3553 2222
+L 1259 2222
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-4c"/>
+       <use xlink:href="#DejaVuSans-44" x="55.712891"/>
+       <use xlink:href="#DejaVuSans-48" x="132.714844"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_5">
+      <path d="M 38.362813 254.254312
+L 440.122813 254.254312
+" clip-path="url(#p3144f8b9f2)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <defs>
+       <path id="m77db5bb38e" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m77db5bb38e" x="38.362813" y="254.254312" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0 -->
+      <g transform="translate(25.636563 257.673609) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_7">
+      <path d="M 38.362813 226.900485
+L 440.122813 226.900485
+" clip-path="url(#p3144f8b9f2)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="38.362813" y="226.900485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 5 -->
+      <g transform="translate(25.636563 230.319782) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_9">
+      <path d="M 38.362813 199.546658
+L 440.122813 199.546658
+" clip-path="url(#p3144f8b9f2)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="38.362813" y="199.546658" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 10 -->
+      <g transform="translate(19.910313 202.965955) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_11">
+      <path d="M 38.362813 172.19283
+L 440.122813 172.19283
+" clip-path="url(#p3144f8b9f2)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="38.362813" y="172.19283" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 15 -->
+      <g transform="translate(19.910313 175.612127) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_13">
+      <path d="M 38.362813 144.839003
+L 440.122813 144.839003
+" clip-path="url(#p3144f8b9f2)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="38.362813" y="144.839003" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 20 -->
+      <g transform="translate(19.910313 148.2583) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <path d="M 38.362813 117.485175
+L 440.122813 117.485175
+" clip-path="url(#p3144f8b9f2)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="38.362813" y="117.485175" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 25 -->
+      <g transform="translate(19.910313 120.904472) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_17">
+      <path d="M 38.362813 90.131348
+L 440.122813 90.131348
+" clip-path="url(#p3144f8b9f2)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="38.362813" y="90.131348" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 30 -->
+      <g transform="translate(19.910313 93.550645) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516
+Q 3050 2419 3304 2112
+Q 3559 1806 3559 1356
+Q 3559 666 3084 287
+Q 2609 -91 1734 -91
+Q 1441 -91 1130 -33
+Q 819 25 488 141
+L 488 750
+Q 750 597 1062 519
+Q 1375 441 1716 441
+Q 2309 441 2620 675
+Q 2931 909 2931 1356
+Q 2931 1769 2642 2001
+Q 2353 2234 1838 2234
+L 1294 2234
+L 1294 2753
+L 1863 2753
+Q 2328 2753 2575 2939
+Q 2822 3125 2822 3475
+Q 2822 3834 2567 4026
+Q 2313 4219 1838 4219
+Q 1578 4219 1281 4162
+Q 984 4106 628 3988
+L 628 4550
+Q 988 4650 1302 4700
+Q 1616 4750 1894 4750
+Q 2613 4750 3031 4423
+Q 3450 4097 3450 3541
+Q 3450 3153 3228 2886
+Q 3006 2619 2597 2516
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_19">
+      <path d="M 38.362813 62.777521
+L 440.122813 62.777521
+" clip-path="url(#p3144f8b9f2)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="38.362813" y="62.777521" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 35 -->
+      <g transform="translate(19.910313 66.196818) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_21">
+      <path d="M 38.362813 35.423693
+L 440.122813 35.423693
+" clip-path="url(#p3144f8b9f2)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="38.362813" y="35.423693" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 40 -->
+      <g transform="translate(19.910313 38.84299) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116
+L 825 1625
+L 2419 1625
+L 2419 4116
+z
+M 2253 4666
+L 3047 4666
+L 3047 1625
+L 3713 1625
+L 3713 1100
+L 3047 1100
+L 3047 0
+L 2419 0
+L 2419 1100
+L 313 1100
+L 313 1709
+L 2253 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- Median POD (uM) -->
+     <g transform="translate(14.038594 177.025313) rotate(-90) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-64" d="M 2906 2969
+L 2906 4863
+L 3481 4863
+L 3481 0
+L 2906 0
+L 2906 525
+Q 2725 213 2448 61
+Q 2172 -91 1784 -91
+Q 1150 -91 751 415
+Q 353 922 353 1747
+Q 353 2572 751 3078
+Q 1150 3584 1784 3584
+Q 2172 3584 2448 3432
+Q 2725 3281 2906 2969
+z
+M 947 1747
+Q 947 1113 1208 752
+Q 1469 391 1925 391
+Q 2381 391 2643 752
+Q 2906 1113 2906 1747
+Q 2906 2381 2643 2742
+Q 2381 3103 1925 3103
+Q 1469 3103 1208 2742
+Q 947 2381 947 1747
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500
+L 1178 3500
+L 1178 0
+L 603 0
+L 603 3500
+z
+M 603 4863
+L 1178 4863
+L 1178 4134
+L 603 4134
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759
+Q 1497 1759 1228 1600
+Q 959 1441 959 1056
+Q 959 750 1161 570
+Q 1363 391 1709 391
+Q 2188 391 2477 730
+Q 2766 1069 2766 1631
+L 2766 1759
+L 2194 1759
+z
+M 3341 1997
+L 3341 0
+L 2766 0
+L 2766 531
+Q 2569 213 2275 61
+Q 1981 -91 1556 -91
+Q 1019 -91 701 211
+Q 384 513 384 1019
+Q 384 1609 779 1909
+Q 1175 2209 1959 2209
+L 2766 2209
+L 2766 2266
+Q 2766 2663 2505 2880
+Q 2244 3097 1772 3097
+Q 1472 3097 1187 3025
+Q 903 2953 641 2809
+L 641 3341
+Q 956 3463 1253 3523
+Q 1550 3584 1831 3584
+Q 2591 3584 2966 3190
+Q 3341 2797 3341 1997
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-50" d="M 1259 4147
+L 1259 2394
+L 2053 2394
+Q 2494 2394 2734 2622
+Q 2975 2850 2975 3272
+Q 2975 3691 2734 3919
+Q 2494 4147 2053 4147
+L 1259 4147
+z
+M 628 4666
+L 2053 4666
+Q 2838 4666 3239 4311
+Q 3641 3956 3641 3272
+Q 3641 2581 3239 2228
+Q 2838 1875 2053 1875
+L 1259 1875
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238
+Q 1834 4238 1429 3725
+Q 1025 3213 1025 2328
+Q 1025 1447 1429 934
+Q 1834 422 2522 422
+Q 3209 422 3611 934
+Q 4013 1447 4013 2328
+Q 4013 3213 3611 3725
+Q 3209 4238 2522 4238
+z
+M 2522 4750
+Q 3503 4750 4090 4092
+Q 4678 3434 4678 2328
+Q 4678 1225 4090 567
+Q 3503 -91 2522 -91
+Q 1538 -91 948 565
+Q 359 1222 359 2328
+Q 359 3434 948 4092
+Q 1538 4750 2522 4750
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856
+Q 1566 4138 1362 3434
+Q 1159 2731 1159 2009
+Q 1159 1288 1364 580
+Q 1569 -128 1984 -844
+L 1484 -844
+Q 1016 -109 783 600
+Q 550 1309 550 2009
+Q 550 2706 781 3412
+Q 1013 4119 1484 4856
+L 1984 4856
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856
+L 1013 4856
+Q 1481 4119 1714 3412
+Q 1947 2706 1947 2009
+Q 1947 1309 1714 600
+Q 1481 -109 1013 -844
+L 513 -844
+Q 928 -128 1133 580
+Q 1338 1288 1338 2009
+Q 1338 2731 1133 3434
+Q 928 4138 513 4856
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-65" x="86.279297"/>
+      <use xlink:href="#DejaVuSans-64" x="147.802734"/>
+      <use xlink:href="#DejaVuSans-69" x="211.279297"/>
+      <use xlink:href="#DejaVuSans-61" x="239.0625"/>
+      <use xlink:href="#DejaVuSans-6e" x="300.341797"/>
+      <use xlink:href="#DejaVuSans-20" x="363.720703"/>
+      <use xlink:href="#DejaVuSans-50" x="395.507812"/>
+      <use xlink:href="#DejaVuSans-4f" x="455.810547"/>
+      <use xlink:href="#DejaVuSans-44" x="534.521484"/>
+      <use xlink:href="#DejaVuSans-20" x="611.523438"/>
+      <use xlink:href="#DejaVuSans-28" x="643.310547"/>
+      <use xlink:href="#DejaVuSans-75" x="682.324219"/>
+      <use xlink:href="#DejaVuSans-4d" x="745.703125"/>
+      <use xlink:href="#DejaVuSans-29" x="831.982422"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 56.624631 254.254312
+L 124.113959 254.254312
+L 124.113959 226.597218
+L 56.624631 226.597218
+z
+" clip-path="url(#p3144f8b9f2)" style="fill: #59a14f"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 155.873643 254.254312
+L 223.362971 254.254312
+L 223.362971 205.25234
+L 155.873643 205.25234
+z
+" clip-path="url(#p3144f8b9f2)" style="fill: #59a14f"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 255.122654 254.254312
+L 322.611982 254.254312
+L 322.611982 123.946944
+L 255.122654 123.946944
+z
+" clip-path="url(#p3144f8b9f2)" style="fill: #59a14f"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 354.371666 254.254312
+L 421.860994 254.254312
+L 421.860994 32.494312
+L 354.371666 32.494312
+z
+" clip-path="url(#p3144f8b9f2)" style="fill: #59a14f"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 38.362813 254.254312
+L 38.362813 21.406312
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 38.362813 254.254312
+L 440.122813 254.254312
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- POD summary - tracked-artifact reanalysis -->
+    <g transform="translate(109.38125 15.406313) scale(0.108 -0.108)">
+     <defs>
+      <path id="DejaVuSans-Bold-50" d="M 588 4666
+L 2584 4666
+Q 3475 4666 3951 4270
+Q 4428 3875 4428 3144
+Q 4428 2409 3951 2014
+Q 3475 1619 2584 1619
+L 1791 1619
+L 1791 0
+L 588 0
+L 588 4666
+z
+M 1791 3794
+L 1791 2491
+L 2456 2491
+Q 2806 2491 2997 2661
+Q 3188 2831 3188 3144
+Q 3188 3456 2997 3625
+Q 2806 3794 2456 3794
+L 1791 3794
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4f" d="M 2719 3878
+Q 2169 3878 1866 3472
+Q 1563 3066 1563 2328
+Q 1563 1594 1866 1187
+Q 2169 781 2719 781
+Q 3272 781 3575 1187
+Q 3878 1594 3878 2328
+Q 3878 3066 3575 3472
+Q 3272 3878 2719 3878
+z
+M 2719 4750
+Q 3844 4750 4481 4106
+Q 5119 3463 5119 2328
+Q 5119 1197 4481 553
+Q 3844 -91 2719 -91
+Q 1597 -91 958 553
+Q 319 1197 319 2328
+Q 319 3463 958 4106
+Q 1597 4750 2719 4750
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-44" d="M 1791 3756
+L 1791 909
+L 2222 909
+Q 2959 909 3348 1275
+Q 3738 1641 3738 2338
+Q 3738 3031 3350 3393
+Q 2963 3756 2222 3756
+L 1791 3756
+z
+M 588 4666
+L 1856 4666
+Q 2919 4666 3439 4514
+Q 3959 4363 4331 4000
+Q 4659 3684 4818 3271
+Q 4978 2859 4978 2338
+Q 4978 1809 4818 1395
+Q 4659 981 4331 666
+Q 3956 303 3431 151
+Q 2906 0 1856 0
+L 588 0
+L 588 4666
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391
+L 3272 2541
+Q 2913 2691 2578 2766
+Q 2244 2841 1947 2841
+Q 1628 2841 1473 2761
+Q 1319 2681 1319 2516
+Q 1319 2381 1436 2309
+Q 1553 2238 1856 2203
+L 2053 2175
+Q 2913 2066 3209 1816
+Q 3506 1566 3506 1031
+Q 3506 472 3093 190
+Q 2681 -91 1863 -91
+Q 1516 -91 1145 -36
+Q 775 19 384 128
+L 384 978
+Q 719 816 1070 734
+Q 1422 653 1784 653
+Q 2113 653 2278 743
+Q 2444 834 2444 1013
+Q 2444 1163 2330 1236
+Q 2216 1309 1875 1350
+L 1678 1375
+Q 931 1469 631 1722
+Q 331 1975 331 2491
+Q 331 3047 712 3315
+Q 1094 3584 1881 3584
+Q 2191 3584 2531 3537
+Q 2872 3491 3272 3391
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-75" d="M 500 1363
+L 500 3500
+L 1625 3500
+L 1625 3150
+Q 1625 2866 1622 2436
+Q 1619 2006 1619 1863
+Q 1619 1441 1641 1255
+Q 1663 1069 1716 984
+Q 1784 875 1895 815
+Q 2006 756 2150 756
+Q 2500 756 2700 1025
+Q 2900 1294 2900 1772
+L 2900 3500
+L 4019 3500
+L 4019 0
+L 2900 0
+L 2900 506
+Q 2647 200 2364 54
+Q 2081 -91 1741 -91
+Q 1134 -91 817 281
+Q 500 653 500 1363
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6d" d="M 3781 2919
+Q 3994 3244 4286 3414
+Q 4578 3584 4928 3584
+Q 5531 3584 5847 3212
+Q 6163 2841 6163 2131
+L 6163 0
+L 5038 0
+L 5038 1825
+Q 5041 1866 5042 1909
+Q 5044 1953 5044 2034
+Q 5044 2406 4934 2573
+Q 4825 2741 4581 2741
+Q 4263 2741 4089 2478
+Q 3916 2216 3909 1719
+L 3909 0
+L 2784 0
+L 2784 1825
+Q 2784 2406 2684 2573
+Q 2584 2741 2328 2741
+Q 2006 2741 1831 2477
+Q 1656 2213 1656 1722
+L 1656 0
+L 531 0
+L 531 3500
+L 1656 3500
+L 1656 2988
+Q 1863 3284 2130 3434
+Q 2397 3584 2719 3584
+Q 3081 3584 3359 3409
+Q 3638 3234 3781 2919
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575
+Q 1756 1575 1579 1456
+Q 1403 1338 1403 1106
+Q 1403 894 1545 773
+Q 1688 653 1941 653
+Q 2256 653 2472 879
+Q 2688 1106 2688 1447
+L 2688 1575
+L 2106 1575
+z
+M 3816 1997
+L 3816 0
+L 2688 0
+L 2688 519
+Q 2463 200 2181 54
+Q 1900 -91 1497 -91
+Q 953 -91 614 226
+Q 275 544 275 1050
+Q 275 1666 698 1953
+Q 1122 2241 2028 2241
+L 2688 2241
+L 2688 2328
+Q 2688 2594 2478 2717
+Q 2269 2841 1825 2841
+Q 1466 2841 1156 2769
+Q 847 2697 581 2553
+L 581 3406
+Q 941 3494 1303 3539
+Q 1666 3584 2028 3584
+Q 2975 3584 3395 3211
+Q 3816 2838 3816 1997
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-72" d="M 3138 2547
+Q 2991 2616 2845 2648
+Q 2700 2681 2553 2681
+Q 2122 2681 1889 2404
+Q 1656 2128 1656 1613
+L 1656 0
+L 538 0
+L 538 3500
+L 1656 3500
+L 1656 2925
+Q 1872 3269 2151 3426
+Q 2431 3584 2822 3584
+Q 2878 3584 2943 3579
+Q 3009 3575 3134 3559
+L 3138 2547
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-79" d="M 78 3500
+L 1197 3500
+L 2138 1125
+L 2938 3500
+L 4056 3500
+L 2584 -331
+Q 2363 -916 2067 -1148
+Q 1772 -1381 1288 -1381
+L 641 -1381
+L 641 -647
+L 991 -647
+Q 1275 -647 1404 -556
+Q 1534 -466 1606 -231
+L 1638 -134
+L 78 3500
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2d" d="M 347 2297
+L 2309 2297
+L 2309 1388
+L 347 1388
+L 347 2297
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494
+L 1759 3500
+L 2913 3500
+L 2913 2700
+L 1759 2700
+L 1759 1216
+Q 1759 972 1856 886
+Q 1953 800 2241 800
+L 2816 800
+L 2816 0
+L 1856 0
+Q 1194 0 917 276
+Q 641 553 641 1216
+L 641 2700
+L 84 2700
+L 84 3500
+L 641 3500
+L 641 4494
+L 1759 4494
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391
+L 3366 2478
+Q 3138 2634 2908 2709
+Q 2678 2784 2431 2784
+Q 1963 2784 1702 2511
+Q 1441 2238 1441 1747
+Q 1441 1256 1702 982
+Q 1963 709 2431 709
+Q 2694 709 2930 787
+Q 3166 866 3366 1019
+L 3366 103
+Q 3103 6 2833 -42
+Q 2563 -91 2291 -91
+Q 1344 -91 809 395
+Q 275 881 275 1747
+Q 275 2613 809 3098
+Q 1344 3584 2291 3584
+Q 2566 3584 2833 3536
+Q 3100 3488 3366 3391
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6b" d="M 538 4863
+L 1656 4863
+L 1656 2216
+L 2944 3500
+L 4244 3500
+L 2534 1894
+L 4378 0
+L 3022 0
+L 1656 1459
+L 1656 0
+L 538 0
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759
+L 4031 1441
+L 1416 1441
+Q 1456 1047 1700 850
+Q 1944 653 2381 653
+Q 2734 653 3104 758
+Q 3475 863 3866 1075
+L 3866 213
+Q 3469 63 3072 -14
+Q 2675 -91 2278 -91
+Q 1328 -91 801 392
+Q 275 875 275 1747
+Q 275 2603 792 3093
+Q 1309 3584 2216 3584
+Q 3041 3584 3536 3087
+Q 4031 2591 4031 1759
+z
+M 2881 2131
+Q 2881 2450 2695 2645
+Q 2509 2841 2209 2841
+Q 1884 2841 1681 2658
+Q 1478 2475 1428 2131
+L 2881 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-64" d="M 2919 2988
+L 2919 4863
+L 4044 4863
+L 4044 0
+L 2919 0
+L 2919 506
+Q 2688 197 2409 53
+Q 2131 -91 1766 -91
+Q 1119 -91 703 423
+Q 288 938 288 1747
+Q 288 2556 703 3070
+Q 1119 3584 1766 3584
+Q 2128 3584 2408 3439
+Q 2688 3294 2919 2988
+z
+M 2181 722
+Q 2541 722 2730 984
+Q 2919 1247 2919 1747
+Q 2919 2247 2730 2509
+Q 2541 2772 2181 2772
+Q 1825 2772 1636 2509
+Q 1447 2247 1447 1747
+Q 1447 1247 1636 984
+Q 1825 722 2181 722
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-69" d="M 538 3500
+L 1656 3500
+L 1656 0
+L 538 0
+L 538 3500
+z
+M 538 4863
+L 1656 4863
+L 1656 3950
+L 538 3950
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-66" d="M 2841 4863
+L 2841 4128
+L 2222 4128
+Q 1984 4128 1890 4042
+Q 1797 3956 1797 3744
+L 1797 3500
+L 2753 3500
+L 2753 2700
+L 1797 2700
+L 1797 0
+L 678 0
+L 678 2700
+L 122 2700
+L 122 3500
+L 678 3500
+L 678 3744
+Q 678 4316 997 4589
+Q 1316 4863 1984 4863
+L 2841 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131
+L 4056 0
+L 2931 0
+L 2931 347
+L 2931 1631
+Q 2931 2084 2911 2256
+Q 2891 2428 2841 2509
+Q 2775 2619 2662 2680
+Q 2550 2741 2406 2741
+Q 2056 2741 1856 2470
+Q 1656 2200 1656 1722
+L 1656 0
+L 538 0
+L 538 3500
+L 1656 3500
+L 1656 2988
+Q 1909 3294 2193 3439
+Q 2478 3584 2822 3584
+Q 3428 3584 3742 3212
+Q 4056 2841 4056 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863
+L 1656 4863
+L 1656 0
+L 538 0
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-50"/>
+     <use xlink:href="#DejaVuSans-Bold-4f" x="73.291016"/>
+     <use xlink:href="#DejaVuSans-Bold-44" x="158.300781"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="241.308594"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="276.123047"/>
+     <use xlink:href="#DejaVuSans-Bold-75" x="335.644531"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="406.835938"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="511.035156"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="615.234375"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="682.714844"/>
+     <use xlink:href="#DejaVuSans-Bold-79" x="732.03125"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="797.216797"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" x="832.03125"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="873.535156"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="908.349609"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="956.152344"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1005.46875"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1072.949219"/>
+     <use xlink:href="#DejaVuSans-Bold-6b" x="1132.226562"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="1196.105469"/>
+     <use xlink:href="#DejaVuSans-Bold-64" x="1263.927734"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" x="1335.509766"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1377.013672"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1444.494141"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1493.810547"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="1541.613281"/>
+     <use xlink:href="#DejaVuSans-Bold-66" x="1575.890625"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1619.396484"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1686.876953"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1746.154297"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1793.957031"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1828.771484"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="1878.087891"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1945.910156"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="2013.390625"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="2084.582031"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" x="2152.0625"/>
+     <use xlink:href="#DejaVuSans-Bold-79" x="2186.339844"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="2251.525391"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="2311.046875"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="2345.324219"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p3144f8b9f2">
+   <rect x="38.362813" y="21.406313" width="401.76" height="232.848"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/paper/reproduction/report.json
+++ b/paper/reproduction/report.json
@@ -1,0 +1,6001 @@
+{
+  "analyses": {
+    "activity_pods": {
+      "conclusion_gates": {
+        "complete_case_median_order": true,
+        "general_morphology_count_exceeds_mt": true
+      },
+      "direction_aware_cytotoxicity": {
+        "count": 429,
+        "definition": "decreased MT union decreased cell count union increased LDH",
+        "directly_encoded_in_hit_summary": false,
+        "documented_in_tracked_evidence": true,
+        "mt_increasing_count": 10,
+        "mt_increasing_count_documented": true
+      },
+      "figure_2a": {
+        "compound_names": [
+          "Benzarone",
+          "Tiratricol",
+          "Tolcapone",
+          "2-Ethylanthracene-9,10-dione"
+        ],
+        "direction": "increasing MT",
+        "rows": [
+          {
+            "compound": "Benzarone",
+            "expected_published_pod_um": 69.337144,
+            "pod_um": 69.3371438444262
+          },
+          {
+            "compound": "Tiratricol",
+            "expected_published_pod_um": 25.860426,
+            "pod_um": 25.8604260795536
+          },
+          {
+            "compound": "Tolcapone",
+            "expected_published_pod_um": 23.606292,
+            "pod_um": 23.606292193515
+          },
+          {
+            "compound": "2-Ethylanthracene-9,10-dione",
+            "expected_published_pod_um": 8.660848,
+            "pod_um": 8.66084844072792
+          }
+        ]
+      },
+      "figure_2c_complete_case": {
+        "camera_ready_count_trace": 342,
+        "camera_ready_order_trace": [
+          "cellprofiler_categorical",
+          "dino_categorical",
+          "dino_global",
+          "cpcnn_global",
+          "cellprofiler_global"
+        ],
+        "count": 156,
+        "finite_nonempty_pod_summaries": true,
+        "median_order": [
+          "cellprofiler_categorical",
+          "dino_categorical",
+          "dino_global",
+          "cpcnn_global",
+          "cellprofiler_global"
+        ],
+        "median_pod_um": {
+          "cellprofiler_categorical": 5.85551144918407,
+          "cellprofiler_global": 46.2055798650723,
+          "cpcnn_global": 18.0560280127798,
+          "dino_categorical": 11.3589668035708,
+          "dino_global": 17.7760972171524
+        },
+        "ordering_preserved": true,
+        "paired_log10_tests": {
+          "cellprofiler_categorical_vs_dino_categorical": {
+            "matched_rows": 156,
+            "mean_difference": 5.52761919634595,
+            "median_difference": 1.48602766716567,
+            "paired_t_p_value": 3.55462442344319e-09,
+            "paired_t_statistic": -6.26271054693791
+          },
+          "cellprofiler_global_vs_dino_global": {
+            "matched_rows": 156,
+            "mean_difference": -29.6652341191191,
+            "median_difference": -29.5433183663327,
+            "paired_t_p_value": 1.37980468558783e-22,
+            "paired_t_statistic": 11.5246989969438
+          },
+          "dino_global_vs_cpcnn_global": {
+            "matched_rows": 156,
+            "mean_difference": 1.39265462475451,
+            "median_difference": 0.16687843773693,
+            "paired_t_p_value": 0.406438080847463,
+            "paired_t_statistic": -0.832445861310611
+          }
+        },
+        "source_si_count_deviation": 186
+      },
+      "figure_2c_three_general": {
+        "cellprofiler_vs_dino_paired_log10": {
+          "matched_rows": 488,
+          "mean_difference": -3.26385155986129,
+          "median_difference": -0.115190084410055,
+          "paired_t_p_value": 0.261389384315177,
+          "paired_t_statistic": -1.12441861620229
+        },
+        "count": 488,
+        "geometric_fold_ratios": {
+          "cpcnn_over_cellprofiler": 1.81811349465688,
+          "cpcnn_over_dino": 1.68648633246714
+        }
+      },
+      "figure_2d": {
+        "complete_case_count": 121,
+        "geometric_fold_ratio_vs_morphology": {
+          "cellcount": 4.28127228016061,
+          "ldh": 8.15371968189112,
+          "mt": 1.78550470485347
+        },
+        "median_pod_um": {
+          "Cell count": 23.8188547870137,
+          "LDH": 40.5354608552776,
+          "MT": 8.95705965699234,
+          "Morphology": 5.05543414478975
+        },
+        "paired_log10_t_tests": {
+          "cellcount": {
+            "matched_rows": 121,
+            "mean_difference": 18.2880922078987,
+            "median_difference": 15.085231052446,
+            "paired_t_p_value": 2.03399100992163e-28,
+            "paired_t_statistic": -14.6173464821414
+          },
+          "ldh": {
+            "matched_rows": 121,
+            "mean_difference": 36.1028319744029,
+            "median_difference": 30.3731720175229,
+            "paired_t_p_value": 2.12673813597151e-33,
+            "paired_t_statistic": -16.8416487979573
+          },
+          "mt": {
+            "matched_rows": 121,
+            "mean_difference": 7.39855207172027,
+            "median_difference": 2.11396480286384,
+            "paired_t_p_value": 3.17409814489868e-06,
+            "paired_t_statistic": -4.88905274492215
+          }
+        }
+      },
+      "hit_summary_counts": {
+        "Cell_Painting_hit": 572,
+        "Cell_count_hit": 198,
+        "Hit_in_all_assays": 121,
+        "LDH_hit": 130,
+        "MT_hit": 377
+      },
+      "morphology_activity_summary": {
+        "cellprofiler": {
+          "categorical": {
+            "count": 598,
+            "fraction_of_1085": 0.551152073732719
+          },
+          "general": {
+            "count": 607,
+            "fraction_of_1085": 0.559447004608295
+          },
+          "global": {
+            "count": 169,
+            "fraction_of_1085": 0.155760368663594
+          }
+        },
+        "cpcnn": {
+          "categorical": {
+            "count": 0,
+            "fraction_of_1085": 0.0
+          },
+          "general": {
+            "count": 539,
+            "fraction_of_1085": 0.496774193548387
+          },
+          "global": {
+            "count": 539,
+            "fraction_of_1085": 0.496774193548387
+          }
+        },
+        "dino": {
+          "categorical": {
+            "count": 626,
+            "fraction_of_1085": 0.576958525345622
+          },
+          "general": {
+            "count": 644,
+            "fraction_of_1085": 0.593548387096774
+          },
+          "global": {
+            "count": 545,
+            "fraction_of_1085": 0.502304147465438
+          }
+        }
+      },
+      "morphology_counts": {
+        "cellprofiler": {
+          "categorical": {
+            "count": 598,
+            "median_pod_um": 11.4513778482377
+          },
+          "general": {
+            "count": 607,
+            "median_pod_um": 11.6049260296356
+          },
+          "global": {
+            "count": 169,
+            "median_pod_um": 52.756880220123
+          }
+        },
+        "cpcnn": {
+          "categorical": {
+            "count": 0,
+            "median_pod_um": null
+          },
+          "general": {
+            "count": 539,
+            "median_pod_um": 25.526139704154
+          },
+          "global": {
+            "count": 539,
+            "median_pod_um": 25.526139704154
+          }
+        },
+        "dino": {
+          "categorical": {
+            "count": 626,
+            "median_pod_um": 19.9912750866602
+          },
+          "general": {
+            "count": 644,
+            "median_pod_um": 15.9895697594189
+          },
+          "global": {
+            "count": 545,
+            "median_pod_um": 14.9345112533045
+          }
+        }
+      },
+      "pod_method_trace": {
+        "compound_minimum_pod": true,
+        "dmso_control": true,
+        "documented_ci_ratio_threshold_40": true,
+        "documented_dmso_95th_percentile_benchmark": true,
+        "documented_eight_model_names": true,
+        "documented_highest_tested_concentration_filter": true,
+        "known_selection_deviation_traced": true,
+        "morphology_residual_sd_selection": true,
+        "paired_assay_scorespod_default": true
+      },
+      "published_si_count_order": [
+        "cpcnn_categorical",
+        "cellprofiler_global",
+        "cpcnn_global",
+        "cpcnn_general",
+        "dino_global",
+        "cellprofiler_categorical",
+        "cellprofiler_general",
+        "dino_categorical",
+        "dino_general"
+      ],
+      "supplemental_tables": {
+        "table_s2": {
+          "compiled_rows": 796,
+          "matched_semantic_keys": 796,
+          "maximum_absolute_pod_difference": 4.40536496171262e-13,
+          "workbook_rows": 796
+        },
+        "table_s3": {
+          "bioactivity_flag_exact_rows": 10935,
+          "compiled_rows": 10935,
+          "matched_semantic_keys": 10935,
+          "maximum_absolute_pod_difference": 5.11590769747272e-13,
+          "workbook_rows": 10935
+        },
+        "table_s4": {
+          "all_hit_calls_exact_rows": 1086,
+          "compiled_rows": 1086,
+          "matched_semantic_keys": 1086,
+          "workbook_rows": 1086
+        }
+      },
+      "table_s2_counts": {
+        "Cell count": 220,
+        "LDH": 147,
+        "MT": 429,
+        "unique_compounds": 437
+      }
+    },
+    "classifier": {
+      "all_cellprofiler_medians": {
+        "axiom": {
+          "auroc": 0.90154710075502,
+          "prauc": 0.805566469136103
+        },
+        "toxcast_cellbased": {
+          "auroc": 0.607226107226107,
+          "prauc": 0.144839974879456
+        },
+        "toxcast_cellfree": {
+          "auroc": 0.532085561497326,
+          "prauc": 0.454015201822219
+        },
+        "toxcast_cytotox": {
+          "auroc": 0.737210441587034,
+          "prauc": 0.477454853975985
+        }
+      },
+      "baseline_effects": {
+        "axiom": {
+          "auroc": {
+            "cell_count": {
+              "contrast": "Actual - Cellcount_baseline",
+              "matched_endpoints": 2,
+              "mean_difference": 0.191848343164801,
+              "median_difference": 0.191848343164801,
+              "paired_t_p_value": 0.0334890898966074,
+              "paired_t_statistic": 18.9922282128338
+            },
+            "random": {
+              "contrast": "Actual - Random_baseline",
+              "matched_endpoints": 2,
+              "mean_difference": 0.398578104661083,
+              "median_difference": 0.398578104661083,
+              "paired_t_p_value": 0.0530234478195209,
+              "paired_t_statistic": 11.9786061940612
+            }
+          },
+          "prauc": {
+            "cell_count": {
+              "contrast": "Actual - Cellcount_baseline",
+              "matched_endpoints": 2,
+              "mean_difference": 0.276758072962196,
+              "median_difference": 0.276758072962196,
+              "paired_t_p_value": 0.164204926372078,
+              "paired_t_statistic": 3.79062212675162
+            },
+            "random": {
+              "contrast": "Actual - Random_baseline",
+              "matched_endpoints": 2,
+              "mean_difference": 0.538687287816479,
+              "median_difference": 0.538687287816479,
+              "paired_t_p_value": 0.108174281792913,
+              "paired_t_statistic": 5.82838132180947
+            }
+          }
+        },
+        "toxcast_cellbased": {
+          "auroc": {
+            "cell_count": {
+              "contrast": "Actual - Cellcount_baseline",
+              "matched_endpoints": 267,
+              "mean_difference": 0.0943561078878174,
+              "median_difference": 0.0972972972972973,
+              "paired_t_p_value": 1.73663667991645e-19,
+              "paired_t_statistic": 9.77712801468256
+            },
+            "random": {
+              "contrast": "Actual - Random_baseline",
+              "matched_endpoints": 267,
+              "mean_difference": 0.107903336619662,
+              "median_difference": 0.0959876543209878,
+              "paired_t_p_value": 1.22730034879639e-21,
+              "paired_t_statistic": 10.4488328204023
+            }
+          },
+          "prauc": {
+            "cell_count": {
+              "contrast": "Actual - Cellcount_baseline",
+              "matched_endpoints": 267,
+              "mean_difference": 0.0497951144036619,
+              "median_difference": 0.0324276634836125,
+              "paired_t_p_value": 1.30300206819287e-15,
+              "paired_t_statistic": 8.50822392960011
+            },
+            "random": {
+              "contrast": "Actual - Random_baseline",
+              "matched_endpoints": 267,
+              "mean_difference": 0.0533209897339242,
+              "median_difference": 0.0338534460485173,
+              "paired_t_p_value": 1.96666356518498e-15,
+              "paired_t_statistic": 8.44736396559601
+            }
+          }
+        },
+        "toxcast_cellfree": {
+          "auroc": {
+            "cell_count": {
+              "contrast": "Actual - Cellcount_baseline",
+              "matched_endpoints": 53,
+              "mean_difference": 0.0596215838741412,
+              "median_difference": 0.0476190476190476,
+              "paired_t_p_value": 0.0268667399634751,
+              "paired_t_statistic": 2.27798083251681
+            },
+            "random": {
+              "contrast": "Actual - Random_baseline",
+              "matched_endpoints": 53,
+              "mean_difference": 0.0210205807188119,
+              "median_difference": 0.00624999999999998,
+              "paired_t_p_value": 0.523405188467189,
+              "paired_t_statistic": 0.642447551010717
+            }
+          },
+          "prauc": {
+            "cell_count": {
+              "contrast": "Actual - Cellcount_baseline",
+              "matched_endpoints": 53,
+              "mean_difference": 0.0485140044799443,
+              "median_difference": 0.0275466456979061,
+              "paired_t_p_value": 0.0696031955676325,
+              "paired_t_statistic": 1.85270862931842
+            },
+            "random": {
+              "contrast": "Actual - Random_baseline",
+              "matched_endpoints": 53,
+              "mean_difference": -0.00123258056106282,
+              "median_difference": 0.0121437549378726,
+              "paired_t_p_value": 0.964618157845972,
+              "paired_t_statistic": -0.0445732967458701
+            }
+          }
+        },
+        "toxcast_cytotox": {
+          "auroc": {
+            "cell_count": {
+              "contrast": "Actual - Cellcount_baseline",
+              "matched_endpoints": 34,
+              "mean_difference": 0.151719468464938,
+              "median_difference": 0.164486577836035,
+              "paired_t_p_value": 6.02180361521194e-10,
+              "paired_t_statistic": 8.60662329735231
+            },
+            "random": {
+              "contrast": "Actual - Random_baseline",
+              "matched_endpoints": 34,
+              "mean_difference": 0.240707625917434,
+              "median_difference": 0.26613781553083,
+              "paired_t_p_value": 4.02207484983548e-11,
+              "paired_t_statistic": 9.63999544092536
+            }
+          },
+          "prauc": {
+            "cell_count": {
+              "contrast": "Actual - Cellcount_baseline",
+              "matched_endpoints": 34,
+              "mean_difference": 0.16026401976451,
+              "median_difference": 0.179279476698888,
+              "paired_t_p_value": 8.95712238843293e-11,
+              "paired_t_statistic": 9.32866945886684
+            },
+            "random": {
+              "contrast": "Actual - Random_baseline",
+              "matched_endpoints": 34,
+              "mean_difference": 0.239111001528769,
+              "median_difference": 0.24965494465908,
+              "paired_t_p_value": 1.57662828301766e-11,
+              "paired_t_statistic": 10.0105861043993
+            }
+          }
+        }
+      },
+      "classifier_001": {
+        "all_representations_above_both_baselines": true,
+        "endpoint": "LDH",
+        "morphology_mean_auroc": 0.932625056254142,
+        "morphology_mean_prauc": 0.753212139721954
+      },
+      "conclusion_gates": {
+        "all_concentration_not_worse": true,
+        "allpod_small_effects": true,
+        "allpodcc_filter_direction": true,
+        "axiom_above_baselines": true,
+        "cellbased_not_cellfree": true,
+        "conclusion_003": true,
+        "prauc_no_material_improvement": true,
+        "representation_small_effects": true,
+        "table2": true
+      },
+      "distributions": {
+        "axiom": {
+          "cellprofiler": {
+            "auroc": {
+              "count": 2,
+              "first_quartile": 0.886122675879437,
+              "maximum": 0.932395950506187,
+              "median": 0.90154710075502,
+              "minimum": 0.870698251003854,
+              "third_quartile": 0.916971525630603
+            },
+            "prauc": {
+              "count": 2,
+              "first_quartile": 0.786936775469116,
+              "maximum": 0.842825856470077,
+              "median": 0.805566469136103,
+              "minimum": 0.768307081802129,
+              "third_quartile": 0.82419616280309
+            }
+          },
+          "cpcnn": {
+            "auroc": {
+              "count": 2,
+              "first_quartile": 0.875648309933742,
+              "maximum": 0.925928008998875,
+              "median": 0.89240820962212,
+              "minimum": 0.858888410245365,
+              "third_quartile": 0.909168109310498
+            },
+            "prauc": {
+              "count": 2,
+              "first_quartile": 0.749822503458767,
+              "maximum": 0.834197186534911,
+              "median": 0.777947397817482,
+              "minimum": 0.721697609100053,
+              "third_quartile": 0.806072292176196
+            }
+          },
+          "dino": {
+            "auroc": {
+              "count": 2,
+              "first_quartile": 0.891846419094387,
+              "maximum": 0.939551209257365,
+              "median": 0.907748015815379,
+              "minimum": 0.875944822373394,
+              "third_quartile": 0.923649612536372
+            },
+            "prauc": {
+              "count": 2,
+              "first_quartile": 0.78671366119655,
+              "maximum": 0.837959459995157,
+              "median": 0.803795594129419,
+              "minimum": 0.769631728263681,
+              "third_quartile": 0.820877527062288
+            }
+          }
+        },
+        "toxcast_cellbased": {
+          "cellprofiler": {
+            "auroc": {
+              "count": 267,
+              "first_quartile": 0.50891688355112,
+              "maximum": 0.921235380116959,
+              "median": 0.607226107226107,
+              "minimum": 0.223890784982935,
+              "third_quartile": 0.685389223179921
+            },
+            "prauc": {
+              "count": 267,
+              "first_quartile": 0.0774170424816076,
+              "maximum": 0.85,
+              "median": 0.144839974879456,
+              "minimum": 0.00934207107761375,
+              "third_quartile": 0.24191671494439
+            }
+          },
+          "cpcnn": {
+            "auroc": {
+              "count": 267,
+              "first_quartile": 0.519910222861074,
+              "maximum": 0.941071428571429,
+              "median": 0.597315436241611,
+              "minimum": 0.261083743842365,
+              "third_quartile": 0.669481410896528
+            },
+            "prauc": {
+              "count": 267,
+              "first_quartile": 0.0737608803453223,
+              "maximum": 0.95,
+              "median": 0.143400730076678,
+              "minimum": 0.00809734597998577,
+              "third_quartile": 0.242111900579154
+            }
+          },
+          "dino": {
+            "auroc": {
+              "count": 267,
+              "first_quartile": 0.540129708599858,
+              "maximum": 0.912371134020618,
+              "median": 0.619047619047619,
+              "minimum": 0.0827160493827161,
+              "third_quartile": 0.692952635599694
+            },
+            "prauc": {
+              "count": 267,
+              "first_quartile": 0.0825516173272117,
+              "maximum": 0.764923051251583,
+              "median": 0.158140824193273,
+              "minimum": 0.00857100570738824,
+              "third_quartile": 0.26117666666134
+            }
+          }
+        },
+        "toxcast_cellfree": {
+          "cellprofiler": {
+            "auroc": {
+              "count": 53,
+              "first_quartile": 0.404829545454545,
+              "maximum": 0.971428571428572,
+              "median": 0.532085561497326,
+              "minimum": 0.210702341137124,
+              "third_quartile": 0.631578947368421
+            },
+            "prauc": {
+              "count": 53,
+              "first_quartile": 0.336925280818844,
+              "maximum": 0.981818181818182,
+              "median": 0.454015201822219,
+              "minimum": 0.107340721112651,
+              "third_quartile": 0.695904335683515
+            }
+          },
+          "cpcnn": {
+            "auroc": {
+              "count": 53,
+              "first_quartile": 0.429512516469038,
+              "maximum": 0.9625,
+              "median": 0.522222222222222,
+              "minimum": 0.138888888888889,
+              "third_quartile": 0.668217054263566
+            },
+            "prauc": {
+              "count": 53,
+              "first_quartile": 0.338860544217687,
+              "maximum": 0.935676268176268,
+              "median": 0.487900432900433,
+              "minimum": 0.133244866583281,
+              "third_quartile": 0.697162609830146
+            }
+          },
+          "dino": {
+            "auroc": {
+              "count": 53,
+              "first_quartile": 0.433455433455433,
+              "maximum": 0.846153846153846,
+              "median": 0.51505016722408,
+              "minimum": 0.208333333333333,
+              "third_quartile": 0.58187134502924
+            },
+            "prauc": {
+              "count": 53,
+              "first_quartile": 0.302590266875981,
+              "maximum": 0.907096886152133,
+              "median": 0.475314519655841,
+              "minimum": 0.158377958129828,
+              "third_quartile": 0.670585457054354
+            }
+          }
+        },
+        "toxcast_cytotox": {
+          "cellprofiler": {
+            "auroc": {
+              "count": 34,
+              "first_quartile": 0.657038907038907,
+              "maximum": 0.916600581549035,
+              "median": 0.737210441587034,
+              "minimum": 0.241071428571429,
+              "third_quartile": 0.776169090558556
+            },
+            "prauc": {
+              "count": 34,
+              "first_quartile": 0.389099237594533,
+              "maximum": 0.686363636363636,
+              "median": 0.477454853975985,
+              "minimum": 0.18984126984127,
+              "third_quartile": 0.635674795190797
+            }
+          },
+          "cpcnn": {
+            "auroc": {
+              "count": 34,
+              "first_quartile": 0.680756905411171,
+              "maximum": 0.844435633095427,
+              "median": 0.750481611208406,
+              "minimum": 0.531862745098039,
+              "third_quartile": 0.775087781028927
+            },
+            "prauc": {
+              "count": 34,
+              "first_quartile": 0.363406512262489,
+              "maximum": 0.755675345247907,
+              "median": 0.482249075455216,
+              "minimum": 0.121016675434231,
+              "third_quartile": 0.596768707482993
+            }
+          },
+          "dino": {
+            "auroc": {
+              "count": 34,
+              "first_quartile": 0.650143809985064,
+              "maximum": 0.835595611285266,
+              "median": 0.745739116769894,
+              "minimum": 0.232142857142857,
+              "third_quartile": 0.784158973986503
+            },
+            "prauc": {
+              "count": 34,
+              "first_quartile": 0.384427354966172,
+              "maximum": 0.719704868596439,
+              "median": 0.450633426199112,
+              "minimum": 0.0529409317343045,
+              "third_quartile": 0.625708177577391
+            }
+          }
+        }
+      },
+      "file_rows": {
+        "compiled_axiom_metrics.parquet": 81,
+        "compiled_toxcast_cellbased_metrics.parquet": 7209,
+        "compiled_toxcast_cellfree_metrics.parquet": 1431,
+        "compiled_toxcast_cytotox_metrics.parquet": 918
+      },
+      "filter_effects": {
+        "axiom": {
+          "auroc": {
+            "contrast": "allpodcc - allpod",
+            "matched_endpoints": 2,
+            "mean_difference": -0.124974386867459,
+            "median_difference": -0.124974386867459,
+            "paired_t_p_value": 0.343668448342862,
+            "paired_t_statistic": -1.66888398665537
+          },
+          "prauc": {
+            "contrast": "allpodcc - allpod",
+            "matched_endpoints": 2,
+            "mean_difference": -0.372361412793057,
+            "median_difference": -0.372361412793057,
+            "paired_t_p_value": 0.320267948455261,
+            "paired_t_statistic": -1.8171811199088
+          }
+        },
+        "toxcast_cellbased": {
+          "auroc": {
+            "contrast": "allpodcc - allpod",
+            "matched_endpoints": 267,
+            "mean_difference": -0.00797018904098499,
+            "median_difference": -0.0047355958958169,
+            "paired_t_p_value": 0.213890975509644,
+            "paired_t_statistic": -1.2459173468803
+          },
+          "prauc": {
+            "contrast": "allpodcc - allpod",
+            "matched_endpoints": 267,
+            "mean_difference": -0.00659679632924061,
+            "median_difference": -0.00425903676008369,
+            "paired_t_p_value": 0.135291256501804,
+            "paired_t_statistic": -1.49810674992077
+          }
+        },
+        "toxcast_cellfree": {
+          "auroc": {
+            "contrast": "allpodcc - allpod",
+            "matched_endpoints": 53,
+            "mean_difference": 0.0134291664332844,
+            "median_difference": 0.0266666666666666,
+            "paired_t_p_value": 0.441289565593257,
+            "paired_t_statistic": 0.775956722523608
+          },
+          "prauc": {
+            "contrast": "allpodcc - allpod",
+            "matched_endpoints": 53,
+            "mean_difference": 0.00515195738908095,
+            "median_difference": -0.00237446985035011,
+            "paired_t_p_value": 0.757789633156037,
+            "paired_t_statistic": 0.310013653077604
+          }
+        },
+        "toxcast_cytotox": {
+          "auroc": {
+            "contrast": "allpodcc - allpod",
+            "matched_endpoints": 34,
+            "mean_difference": -0.0885859686562654,
+            "median_difference": -0.0850192118819929,
+            "paired_t_p_value": 1.98218912819222e-06,
+            "paired_t_statistic": -5.75556698059535
+          },
+          "prauc": {
+            "contrast": "allpodcc - allpod",
+            "matched_endpoints": 34,
+            "mean_difference": -0.167163560277532,
+            "median_difference": -0.177995120101904,
+            "paired_t_p_value": 1.21460617571794e-06,
+            "paired_t_statistic": -5.92172813977499
+          }
+        }
+      },
+      "method_trace": {
+        "compound_level_label_join": true,
+        "consensus_strategies": true,
+        "folds": 5,
+        "model": "XGBClassifier",
+        "paired_assay_hitcalls": true,
+        "published_baselines": true,
+        "stratified": true,
+        "workflow_wiring": true
+      },
+      "modeled_endpoint_counts": {
+        "axiom": 2,
+        "toxcast_cellbased": 267,
+        "toxcast_cellfree": 53,
+        "toxcast_cytotox": 34
+      },
+      "raw_prediction_recomputation": false,
+      "representation_effects": {
+        "axiom": {
+          "auroc": {
+            "cpcnn": {
+              "contrast": "cpcnn - cellprofiler",
+              "matched_endpoints": 2,
+              "mean_difference": -0.00913889113290023,
+              "median_difference": -0.00913889113290023,
+              "paired_t_p_value": 0.181018110022963,
+              "paired_t_statistic": -3.42158872834813
+            },
+            "dino": {
+              "contrast": "dino - cellprofiler",
+              "matched_endpoints": 2,
+              "mean_difference": 0.00620091506035919,
+              "median_difference": 0.00620091506035919,
+              "paired_t_p_value": 0.0972153602934984,
+              "paired_t_statistic": 6.49757013119435
+            },
+            "dino_vs_cpcnn": {
+              "contrast": "dino - cpcnn",
+              "matched_endpoints": 2,
+              "mean_difference": 0.0153398061932594,
+              "median_difference": 0.0153398061932594,
+              "paired_t_p_value": 0.0709459750102717,
+              "paired_t_statistic": 8.93612557346571
+            }
+          },
+          "prauc": {
+            "cpcnn": {
+              "contrast": "cpcnn - cellprofiler",
+              "matched_endpoints": 2,
+              "mean_difference": -0.0276190713186213,
+              "median_difference": -0.0276190713186213,
+              "paired_t_p_value": 0.383463872556844,
+              "paired_t_statistic": -1.45437006627378
+            },
+            "dino": {
+              "contrast": "dino - cellprofiler",
+              "matched_endpoints": 2,
+              "mean_difference": -0.00177087500668432,
+              "median_difference": -0.00177087500668432,
+              "paired_t_p_value": 0.66919046860896,
+              "paired_t_statistic": -0.572076473982064
+            },
+            "dino_vs_cpcnn": {
+              "contrast": "dino - cpcnn",
+              "matched_endpoints": 2,
+              "mean_difference": 0.025848196311937,
+              "median_difference": 0.025848196311937,
+              "paired_t_p_value": 0.45013494658883,
+              "paired_t_statistic": 1.17034712497683
+            }
+          }
+        },
+        "toxcast_cellbased": {
+          "auroc": {
+            "cpcnn": {
+              "contrast": "cpcnn - cellprofiler",
+              "matched_endpoints": 267,
+              "mean_difference": 0.00109178591847575,
+              "median_difference": -0.00301829843425772,
+              "paired_t_p_value": 0.897467493100046,
+              "paired_t_statistic": 0.128984364515985
+            },
+            "dino": {
+              "contrast": "dino - cellprofiler",
+              "matched_endpoints": 267,
+              "mean_difference": 0.0118822411673017,
+              "median_difference": 0.0220902090209021,
+              "paired_t_p_value": 0.184682036962303,
+              "paired_t_statistic": 1.32992553625742
+            },
+            "dino_vs_cpcnn": {
+              "contrast": "dino - cpcnn",
+              "matched_endpoints": 267,
+              "mean_difference": 0.010790455248826,
+              "median_difference": 0.0158730158730159,
+              "paired_t_p_value": 0.210461109337432,
+              "paired_t_statistic": 1.25532873558324
+            }
+          },
+          "prauc": {
+            "cpcnn": {
+              "contrast": "cpcnn - cellprofiler",
+              "matched_endpoints": 267,
+              "mean_difference": 0.00116906499639486,
+              "median_difference": 0.00074739835596889,
+              "paired_t_p_value": 0.840952445201806,
+              "paired_t_statistic": 0.200871644916681
+            },
+            "dino": {
+              "contrast": "dino - cellprofiler",
+              "matched_endpoints": 267,
+              "mean_difference": 0.0127751729740296,
+              "median_difference": 0.00994823782864959,
+              "paired_t_p_value": 0.0312718934655318,
+              "paired_t_statistic": 2.16506606447174
+            },
+            "dino_vs_cpcnn": {
+              "contrast": "dino - cpcnn",
+              "matched_endpoints": 267,
+              "mean_difference": 0.0116061079776347,
+              "median_difference": 0.00417463296570882,
+              "paired_t_p_value": 0.0498439016731581,
+              "paired_t_statistic": 1.97027536294364
+            }
+          }
+        },
+        "toxcast_cellfree": {
+          "auroc": {
+            "cpcnn": {
+              "contrast": "cpcnn - cellprofiler",
+              "matched_endpoints": 53,
+              "mean_difference": 0.00617497007147371,
+              "median_difference": 0.0089285714285714,
+              "paired_t_p_value": 0.823136098342598,
+              "paired_t_statistic": 0.224644706468268
+            },
+            "dino": {
+              "contrast": "dino - cellprofiler",
+              "matched_endpoints": 53,
+              "mean_difference": -0.019851920041798,
+              "median_difference": 0.00317460317460316,
+              "paired_t_p_value": 0.463640777165636,
+              "paired_t_statistic": -0.738317564543492
+            },
+            "dino_vs_cpcnn": {
+              "contrast": "dino - cpcnn",
+              "matched_endpoints": 53,
+              "mean_difference": -0.0260268901132717,
+              "median_difference": -0.0173010380622838,
+              "paired_t_p_value": 0.325137126191827,
+              "paired_t_statistic": -0.993354837416304
+            }
+          },
+          "prauc": {
+            "cpcnn": {
+              "contrast": "cpcnn - cellprofiler",
+              "matched_endpoints": 53,
+              "mean_difference": 0.0207139189764737,
+              "median_difference": 0.0316914867611461,
+              "paired_t_p_value": 0.348350391514609,
+              "paired_t_statistic": 0.946343491786597
+            },
+            "dino": {
+              "contrast": "dino - cellprofiler",
+              "matched_endpoints": 53,
+              "mean_difference": 0.00194765193540622,
+              "median_difference": -0.00992694385181725,
+              "paired_t_p_value": 0.931442410648799,
+              "paired_t_statistic": 0.0864478769797504
+            },
+            "dino_vs_cpcnn": {
+              "contrast": "dino - cpcnn",
+              "matched_endpoints": 53,
+              "mean_difference": -0.0187662670410675,
+              "median_difference": -0.0036434527570397,
+              "paired_t_p_value": 0.438739266213964,
+              "paired_t_statistic": -0.780321640910277
+            }
+          }
+        },
+        "toxcast_cytotox": {
+          "auroc": {
+            "cpcnn": {
+              "contrast": "cpcnn - cellprofiler",
+              "matched_endpoints": 34,
+              "mean_difference": 0.0211212806696949,
+              "median_difference": -0.00288196361919735,
+              "paired_t_p_value": 0.265377055373296,
+              "paired_t_statistic": 1.13300508896848
+            },
+            "dino": {
+              "contrast": "dino - cellprofiler",
+              "matched_endpoints": 34,
+              "mean_difference": -0.0328222342333006,
+              "median_difference": -0.00212003374768588,
+              "paired_t_p_value": 0.12871389212652,
+              "paired_t_statistic": -1.5582497207235
+            },
+            "dino_vs_cpcnn": {
+              "contrast": "dino - cpcnn",
+              "matched_endpoints": 34,
+              "mean_difference": -0.0539435149029955,
+              "median_difference": 0.00976310402031944,
+              "paired_t_p_value": 0.0736541189873315,
+              "paired_t_statistic": -1.84751306441926
+            }
+          },
+          "prauc": {
+            "cpcnn": {
+              "contrast": "cpcnn - cellprofiler",
+              "matched_endpoints": 34,
+              "mean_difference": 0.0026487692620246,
+              "median_difference": -0.00660173160173161,
+              "paired_t_p_value": 0.864802698086029,
+              "paired_t_statistic": 0.171596513998741
+            },
+            "dino": {
+              "contrast": "dino - cellprofiler",
+              "matched_endpoints": 34,
+              "mean_difference": -0.0136341760225736,
+              "median_difference": 0.0208894906343584,
+              "paired_t_p_value": 0.536714550964777,
+              "paired_t_statistic": -0.624313170751325
+            },
+            "dino_vs_cpcnn": {
+              "contrast": "dino - cpcnn",
+              "matched_endpoints": 34,
+              "mean_difference": -0.0162829452845982,
+              "median_difference": 0.0347644322810661,
+              "paired_t_p_value": 0.51447840347918,
+              "paired_t_statistic": -0.658983902906179
+            }
+          }
+        }
+      },
+      "strategy_effects": {
+        "axiom": {
+          "auroc": {
+            "allpod": {
+              "contrast": "allpod - all",
+              "matched_endpoints": 2,
+              "mean_difference": -0.00120666686613236,
+              "median_difference": -0.00120666686613236,
+              "paired_t_p_value": 0.952518147592293,
+              "paired_t_statistic": -0.0747229275122436
+            },
+            "allpodcc": {
+              "contrast": "allpodcc - all",
+              "matched_endpoints": 2,
+              "mean_difference": -0.126181053733592,
+              "median_difference": -0.126181053733592,
+              "paired_t_p_value": 0.277351893503587,
+              "paired_t_statistic": -2.14825784675732
+            }
+          },
+          "prauc": {
+            "allpod": {
+              "contrast": "allpod - all",
+              "matched_endpoints": 2,
+              "mean_difference": 0.00765120554079635,
+              "median_difference": 0.00765120554079635,
+              "paired_t_p_value": 0.873329178774155,
+              "paired_t_statistic": 0.201642160671826
+            },
+            "allpodcc": {
+              "contrast": "allpodcc - all",
+              "matched_endpoints": 2,
+              "mean_difference": -0.364710207252261,
+              "median_difference": -0.364710207252261,
+              "paired_t_p_value": 0.273318490089833,
+              "paired_t_statistic": -2.18432399088652
+            }
+          }
+        },
+        "toxcast_cellbased": {
+          "auroc": {
+            "allpod": {
+              "contrast": "allpod - all",
+              "matched_endpoints": 267,
+              "mean_difference": 0.0194208177600396,
+              "median_difference": 0.00971223021582746,
+              "paired_t_p_value": 0.0270956558416494,
+              "paired_t_statistic": 2.22242617784978
+            },
+            "allpodcc": {
+              "contrast": "allpodcc - all",
+              "matched_endpoints": 267,
+              "mean_difference": 0.0114506287190546,
+              "median_difference": 0.00466200466200462,
+              "paired_t_p_value": 0.160959065310323,
+              "paired_t_statistic": 1.40577112638978
+            }
+          },
+          "prauc": {
+            "allpod": {
+              "contrast": "allpod - all",
+              "matched_endpoints": 267,
+              "mean_difference": -0.00587492908333049,
+              "median_difference": -0.00219147144168043,
+              "paired_t_p_value": 0.308336007006314,
+              "paired_t_statistic": -1.02067462616011
+            },
+            "allpodcc": {
+              "contrast": "allpodcc - all",
+              "matched_endpoints": 267,
+              "mean_difference": -0.0124717254125711,
+              "median_difference": -0.0060494149046138,
+              "paired_t_p_value": 0.022393599686231,
+              "paired_t_statistic": -2.29703865346715
+            }
+          }
+        },
+        "toxcast_cellfree": {
+          "auroc": {
+            "allpod": {
+              "contrast": "allpod - all",
+              "matched_endpoints": 53,
+              "mean_difference": -0.0248170581031128,
+              "median_difference": -0.0476190476190476,
+              "paired_t_p_value": 0.266134175146393,
+              "paired_t_statistic": -1.12409756204259
+            },
+            "allpodcc": {
+              "contrast": "allpodcc - all",
+              "matched_endpoints": 53,
+              "mean_difference": -0.0113878916698283,
+              "median_difference": -0.0146520146520147,
+              "paired_t_p_value": 0.635805968536172,
+              "paired_t_statistic": -0.47637063055373
+            }
+          },
+          "prauc": {
+            "allpod": {
+              "contrast": "allpod - all",
+              "matched_endpoints": 53,
+              "mean_difference": -0.0061252889070165,
+              "median_difference": -0.00952380952380949,
+              "paired_t_p_value": 0.715615292140617,
+              "paired_t_statistic": -0.366316338406943
+            },
+            "allpodcc": {
+              "contrast": "allpodcc - all",
+              "matched_endpoints": 53,
+              "mean_difference": -0.000973331517935556,
+              "median_difference": -0.0255000819607678,
+              "paired_t_p_value": 0.965505070005669,
+              "paired_t_statistic": -0.0434552572439932
+            }
+          }
+        },
+        "toxcast_cytotox": {
+          "auroc": {
+            "allpod": {
+              "contrast": "allpod - all",
+              "matched_endpoints": 34,
+              "mean_difference": 0.0385615283053352,
+              "median_difference": -0.018076826643035,
+              "paired_t_p_value": 0.263191783861803,
+              "paired_t_statistic": 1.13830052856965
+            },
+            "allpodcc": {
+              "contrast": "allpodcc - all",
+              "matched_endpoints": 34,
+              "mean_difference": -0.0500244403509303,
+              "median_difference": -0.0979984022977283,
+              "paired_t_p_value": 0.0395341220544803,
+              "paired_t_statistic": -2.1435263241484
+            }
+          },
+          "prauc": {
+            "allpod": {
+              "contrast": "allpod - all",
+              "matched_endpoints": 34,
+              "mean_difference": 0.0598628442557177,
+              "median_difference": -6.28536330952445e-05,
+              "paired_t_p_value": 0.119771593898773,
+              "paired_t_statistic": 1.59712153929278
+            },
+            "allpodcc": {
+              "contrast": "allpodcc - all",
+              "matched_endpoints": 34,
+              "mean_difference": -0.107300716021814,
+              "median_difference": -0.140691278826449,
+              "paired_t_p_value": 8.95177767019907e-05,
+              "paired_t_statistic": -4.46060713002844
+            }
+          }
+        }
+      },
+      "table2": {
+        "rows": [
+          {
+            "auroc": 0.730446194225722,
+            "count_0": 840,
+            "count_1": 127,
+            "endpoint": "LDH",
+            "prauc": 0.418537755354911,
+            "row": "Cell count"
+          },
+          {
+            "auroc": 0.500543682039745,
+            "count_0": 840,
+            "count_1": 127,
+            "endpoint": "LDH",
+            "prauc": 0.137194940827752,
+            "row": "Random"
+          },
+          {
+            "auroc": 0.932395950506187,
+            "count_0": 840,
+            "count_1": 127,
+            "endpoint": "LDH",
+            "prauc": 0.768307081802129,
+            "row": "CellProfiler"
+          },
+          {
+            "auroc": 0.925928008998875,
+            "count_0": 840,
+            "count_1": 127,
+            "endpoint": "LDH",
+            "prauc": 0.721697609100053,
+            "row": "CP-CNN"
+          },
+          {
+            "auroc": 0.939551209257365,
+            "count_0": 839,
+            "count_1": 127,
+            "endpoint": "LDH",
+            "prauc": 0.769631728263681,
+            "row": "DINO"
+          },
+          {
+            "auroc": 0.688951320954717,
+            "count_0": 589,
+            "count_1": 378,
+            "endpoint": "MTT",
+            "prauc": 0.639079036992903,
+            "row": "Cell count"
+          },
+          {
+            "auroc": 0.50539431014813,
+            "count_0": 589,
+            "count_1": 378,
+            "endpoint": "MTT",
+            "prauc": 0.396563421811497,
+            "row": "Random"
+          },
+          {
+            "auroc": 0.870698251003854,
+            "count_0": 589,
+            "count_1": 378,
+            "endpoint": "MTT",
+            "prauc": 0.842825856470077,
+            "row": "CellProfiler"
+          },
+          {
+            "auroc": 0.858888410245365,
+            "count_0": 588,
+            "count_1": 379,
+            "endpoint": "MTT",
+            "prauc": 0.834197186534911,
+            "row": "CP-CNN"
+          },
+          {
+            "auroc": 0.875944822373394,
+            "count_0": 588,
+            "count_1": 378,
+            "endpoint": "MTT",
+            "prauc": 0.837959459995157,
+            "row": "DINO"
+          }
+        ]
+      },
+      "target_effects": {
+        "dino_vs_cellprofiler_cellbased_auroc": {
+          "mean_difference": 0.0118822411673017,
+          "median_difference": 0.0220902090209021
+        },
+        "dino_vs_cpcnn_cellbased_auroc": {
+          "mean_difference": 0.010790455248826,
+          "median_difference": 0.0158730158730159
+        }
+      }
+    },
+    "external_image": {
+      "identity_trace": true,
+      "limitation": "The raw source TIFF and image index are external and intentionally absent.",
+      "navigation_image_bytes": 250125,
+      "navigation_image_sha256": "8d06b306f781201580ddac11beefa3c91f957791267908d92dfa072b8ee63839",
+      "source_image_available": false
+    },
+    "regression_enrichment": {
+      "files": {
+        "err_higher_targets.csv": {
+          "hit_list_size": 304,
+          "maximum_fdr_recomputation_error": 1.11022302462516e-16,
+          "maximum_p_value_recomputation_error": 1.11022302462516e-16,
+          "minimum_fdr": 7.91291923766024e-23,
+          "minimum_p_value": 8.93307658349542e-27,
+          "rows": 8858,
+          "significant_count": 178,
+          "universe_size": 13176
+        },
+        "err_lower_targets.csv": {
+          "hit_list_size": 138,
+          "maximum_fdr_recomputation_error": 0.0,
+          "maximum_p_value_recomputation_error": 1.11022302462516e-16,
+          "minimum_fdr": 1.0,
+          "minimum_p_value": 0.0001137713489089,
+          "rows": 8858,
+          "significant_count": 0,
+          "universe_size": 13176
+        },
+        "mtt_higher_targets.csv": {
+          "hit_list_size": 261,
+          "maximum_fdr_recomputation_error": 1.11022302462516e-16,
+          "maximum_p_value_recomputation_error": 1.11022302462516e-16,
+          "minimum_fdr": 1.58168463293359e-06,
+          "minimum_p_value": 1.78560017265025e-10,
+          "rows": 8858,
+          "significant_count": 147,
+          "universe_size": 13176
+        },
+        "mtt_lower_targets.csv": {
+          "hit_list_size": 131,
+          "maximum_fdr_recomputation_error": 1.11022302462516e-16,
+          "maximum_p_value_recomputation_error": 1.11022302462516e-16,
+          "minimum_fdr": 1.55186540392722e-06,
+          "minimum_p_value": 1.75193655896051e-10,
+          "rows": 8858,
+          "significant_count": 107,
+          "universe_size": 13176
+        }
+      },
+      "limitations": [
+        "Tracked enrichment tables permit direct reanalysis; regression predictions and metrics are not tracked.",
+        "Enrichment is an association conditional on selected exposure wells and does not establish mechanism."
+      ],
+      "regression_trace": {
+        "compound_group_isolation": true,
+        "err_304_acceptance_available": false,
+        "err_480_acceptance_available": false,
+        "group_shuffle_split_count": 10,
+        "historical_enrichment_provenance": true,
+        "mechanism_claim_is_hypothesis": true,
+        "method_deviation_traced": true,
+        "numerical_acceptance_rerun": false,
+        "prediction_artifacts_available": false,
+        "relative_performance_documentary": true,
+        "replicate_effect_documentary": true,
+        "sfig2_documentary": true,
+        "table_1_documentary": true,
+        "test_fraction": 0.2
+      },
+      "significant_classes": {
+        "mtt_higher": {
+          "cyp_prefix_count": 8,
+          "htr_prefix_count": 6,
+          "transporters_present": [
+            "ABCB1",
+            "ABCG2",
+            "SLCO1B1",
+            "SLCO1B3"
+          ]
+        },
+        "mtt_lower": {
+          "cyp_prefix_count": 3,
+          "psm_prefix_count": 18
+        }
+      }
+    },
+    "sources_design": {
+      "documentary_trace": {
+        "assay_and_exposure_design": true,
+        "experimental_design": true,
+        "feature_count_claims": true,
+        "figure_1_workflow": true,
+        "resource_locations": true,
+        "statistical_thresholds": true,
+        "table_key_resources": true,
+        "tracked_only_boundary": true
+      },
+      "key_resources_data_rows": 34,
+      "office_archive_count": 6,
+      "office_archives": [
+        {
+          "crc_passed": true,
+          "members": 11,
+          "path": "paper/sources/table-s1.xlsx"
+        },
+        {
+          "crc_passed": true,
+          "members": 10,
+          "path": "paper/sources/table-s2.xlsx"
+        },
+        {
+          "crc_passed": true,
+          "members": 10,
+          "path": "paper/sources/table-s3.xlsx"
+        },
+        {
+          "crc_passed": true,
+          "members": 10,
+          "path": "paper/sources/table-s4.xlsx"
+        },
+        {
+          "crc_passed": true,
+          "members": 12,
+          "path": "paper/sources/table-s5.xlsx"
+        },
+        {
+          "crc_passed": true,
+          "members": 9,
+          "path": "paper/sources/manuscript-source.docx"
+        }
+      ],
+      "source_count": 8,
+      "sources": [
+        {
+          "bytes": 4541568,
+          "canonical": true,
+          "id": "main",
+          "path": "paper/sources/main.pdf",
+          "sha256": "b24665d58da4c7e12fc37165c15003e36a3e5fbd4ad431457dadfe656f7df80c"
+        },
+        {
+          "bytes": 4109803,
+          "canonical": true,
+          "id": "supplemental-figures",
+          "path": "paper/sources/supplemental-figures.pdf",
+          "sha256": "c2a7090d8fa668fab5e18fcd5703f3b4a7985ad61d137dcbba77c865fb3ea7a9"
+        },
+        {
+          "bytes": 97586,
+          "canonical": true,
+          "id": "table-s1",
+          "path": "paper/sources/table-s1.xlsx",
+          "sha256": "345dff689db7d3e0ed2c6d39403879b755c3526e33360d66f874c9dc7828560d"
+        },
+        {
+          "bytes": 65528,
+          "canonical": true,
+          "id": "table-s2",
+          "path": "paper/sources/table-s2.xlsx",
+          "sha256": "01db4942cef5a3ff53b10efd5c60ed86d9a3afbf68aad44fc7f8362389a4efa4"
+        },
+        {
+          "bytes": 817711,
+          "canonical": true,
+          "id": "table-s3",
+          "path": "paper/sources/table-s3.xlsx",
+          "sha256": "c6b9a5b00c40c62ea2c3763874cdc0880449316066e00bea856c2d0877a3ae38"
+        },
+        {
+          "bytes": 57444,
+          "canonical": true,
+          "id": "table-s4",
+          "path": "paper/sources/table-s4.xlsx",
+          "sha256": "d65a212abcc2ca3fe00b8d73659c47dd69d66e1b32f731b73c4d3e3528bef338"
+        },
+        {
+          "bytes": 139769,
+          "canonical": true,
+          "id": "table-s5",
+          "path": "paper/sources/table-s5.xlsx",
+          "sha256": "112432976c3f944d5ca953481bfbec808fb25c065c218bf1e258508ccfc0e7e5"
+        },
+        {
+          "bytes": 54532,
+          "canonical": false,
+          "id": "manuscript-source",
+          "path": "paper/sources/manuscript-source.docx",
+          "sha256": "23786cb09d47fd5b12c302f9cb1f884ad486f6fbe4e0ab21c00ffeac711aa27b"
+        }
+      ],
+      "table_s1": {
+        "annotation_covered_ids": 966,
+        "annotation_rows": 1494,
+        "annotation_unique_ids": 1477,
+        "blank_id_count": 119,
+        "preferred_name_matches": 790,
+        "purchased_annotation_ids": 966,
+        "rows": 1085,
+        "stable_id_count": 966,
+        "unique_compound_names": 1084,
+        "url_count": 891
+      }
+    },
+    "toxcast": {
+      "annotation_union_not_tested_library_join": true,
+      "binary_activity": {
+        "cellbased": {
+          "active_fraction": 0.0784291756533431,
+          "active_values": 8400,
+          "compound_rows": 963,
+          "endpoint_count": 292,
+          "median_endpoint_active_fraction": 0.071161355334425,
+          "median_endpoint_observed_compounds": 306.0,
+          "observed_values": 107103,
+          "unique_ids": 963
+        },
+        "cellfree": {
+          "active_fraction": 0.387034035656402,
+          "active_values": 1194,
+          "compound_rows": 371,
+          "endpoint_count": 72,
+          "median_endpoint_active_fraction": 0.413429522752497,
+          "median_endpoint_observed_compounds": 33.0,
+          "observed_values": 3085,
+          "unique_ids": 371
+        },
+        "cytotox": {
+          "active_fraction": 0.176454984349302,
+          "active_values": 3326,
+          "compound_rows": 963,
+          "endpoint_count": 38,
+          "median_endpoint_active_fraction": 0.206834880123743,
+          "median_endpoint_observed_compounds": 346.0,
+          "observed_values": 18849,
+          "unique_ids": 963
+        }
+      },
+      "binary_endpoint_counts": {
+        "cellbased": 292,
+        "cellfree": 72,
+        "cytotox": 38
+      },
+      "composition": {
+        "cellbased_tissues": {
+          "kidney": 35,
+          "liver": 151,
+          "vascular": 63
+        },
+        "cellfree_assay_types": {
+          "binding": 37,
+          "enzymatic activity": 35
+        },
+        "cellfree_target_families": {
+          "cyp": 11,
+          "gpcr": 21,
+          "nuclear receptor": 10
+        }
+      },
+      "documented_tested_intersection": {
+        "documented_in_tracked_evidence": true,
+        "ids": 670,
+        "percent_of_published_library": 61.7511520737327
+      },
+      "endpoint_medians": {
+        "active_fraction": {
+          "cellbased": 0.071161355334425,
+          "cellfree": 0.413429522752497,
+          "cytotox": 0.206834880123743
+        },
+        "observed_compounds": {
+          "cellbased": 306,
+          "cellfree": 33,
+          "cytotox": 346
+        }
+      },
+      "heatmap_summary": {
+        "cell_categories": 12,
+        "complete_compounds": 839,
+        "tissue_categories": 6
+      },
+      "method_trace": {
+        "cytotoxicity_consensus_20_percent": true,
+        "hitcall_strictly_above_0_9": true,
+        "median_positive_ac50": true,
+        "minimum_five_positive_and_negative": true,
+        "notebook_reads_pinned_parquets": true,
+        "specific_endpoint_100_um_deviation_traced": true
+      },
+      "source_activity": {
+        "cellbased": {
+          "active_rows": 24633,
+          "endpoint_count": 292,
+          "median_positive_ac50_um": 22.0864586641519,
+          "positive_ac50_count": 24633,
+          "rows": 144203
+        },
+        "cellfree": {
+          "active_rows": 1838,
+          "endpoint_count": 72,
+          "median_positive_ac50_um": 7.53098429780993,
+          "positive_ac50_count": 1838,
+          "rows": 4032
+        },
+        "cytotox": {
+          "endpoint_count": 48,
+          "median_positive_ac50_um": 28.5029939109064,
+          "positive_consensus_ac50_count": 3422,
+          "rows": 19380,
+          "rows_with_source_hits": 4393
+        }
+      },
+      "source_endpoint_counts": {
+        "cellbased": 292,
+        "cellfree": 72,
+        "cytotox": 48
+      },
+      "table_s5": {
+        "cytotoxicity_binary_active": 0,
+        "cytotoxicity_binary_observed": 19,
+        "cytotoxicity_categories": 19,
+        "cytotoxicity_source_hits": 0,
+        "cytotoxicity_source_tests": 102,
+        "maximum_shared_ac50_difference_um": 4.81224908810418e-08,
+        "mmp_ac50_um": 14.8795940571651,
+        "mmp_hitcall": 0.999797722028155,
+        "nuclear_receptor_ac50_max_um": 45.0,
+        "nuclear_receptor_ac50_min_um": 1.64808942,
+        "nuclear_receptor_assays": 12,
+        "retained_endpoints": 15,
+        "retained_nuclear_receptor_assays": 8,
+        "workbook_rows": 22
+      },
+      "union_fraction_of_published_library": 0.887557603686636,
+      "union_ids": 963
+    }
+  },
+  "executed_groups": [
+    "sources_design",
+    "activity_pods",
+    "regression_enrichment",
+    "toxcast",
+    "classifier",
+    "external_image"
+  ],
+  "groups": {
+    "activity_pods": {
+      "checks": [
+        {
+          "expected": {
+            "Cell count": 220,
+            "LDH": 147,
+            "MT": 429,
+            "unique_compounds": 437
+          },
+          "id": "ACTIVITY-001:01",
+          "name": "published Table S2 activity counts",
+          "observed": {
+            "Cell count": 220,
+            "LDH": 147,
+            "MT": 429,
+            "unique_compounds": 437
+          },
+          "passed": true,
+          "target_id": "ACTIVITY-001"
+        },
+        {
+          "expected": 429,
+          "id": "ACTIVITY-002:01",
+          "name": "direction-aware cytotoxic compound count",
+          "observed": 429,
+          "passed": true,
+          "target_id": "ACTIVITY-002"
+        },
+        {
+          "expected": true,
+          "id": "ACTIVITY-002:02",
+          "name": "direction-aware definition trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "ACTIVITY-002"
+        },
+        {
+          "expected": 10,
+          "id": "ACTIVITY-003:01",
+          "name": "camera-ready increasing-MT call count",
+          "observed": 10,
+          "passed": true,
+          "target_id": "ACTIVITY-003"
+        },
+        {
+          "expected": true,
+          "id": "ACTIVITY-003:02",
+          "name": "increasing-MT count documentary trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "ACTIVITY-003"
+        },
+        {
+          "expected": [
+            "Benzarone",
+            "Tiratricol",
+            "Tolcapone",
+            "2-Ethylanthracene-9,10-dione"
+          ],
+          "id": "ACTIVITY-003:03",
+          "name": "four dominant increasing-MT compounds",
+          "observed": [
+            "Benzarone",
+            "Tiratricol",
+            "Tolcapone",
+            "2-Ethylanthracene-9,10-dione"
+          ],
+          "passed": true,
+          "target_id": "ACTIVITY-003"
+        },
+        {
+          "expected": "increasing MT",
+          "id": "ACTIVITY-003:04",
+          "name": "increasing-MT direction",
+          "observed": "increasing MT",
+          "passed": true,
+          "target_id": "ACTIVITY-003"
+        },
+        {
+          "expected": [
+            "Benzarone",
+            "Tiratricol",
+            "Tolcapone",
+            "2-Ethylanthracene-9,10-dione"
+          ],
+          "id": "FIG-2A:01",
+          "name": "Figure 2A four published compounds",
+          "observed": [
+            "Benzarone",
+            "Tiratricol",
+            "Tolcapone",
+            "2-Ethylanthracene-9,10-dione"
+          ],
+          "passed": true,
+          "target_id": "FIG-2A"
+        },
+        {
+          "expected": 1e-06,
+          "id": "FIG-2A:02",
+          "name": "Figure 2A Table S2 POD agreement",
+          "observed": 4.4072791993698957e-07,
+          "passed": true,
+          "target_id": "FIG-2A"
+        },
+        {
+          "expected": {
+            "cellprofiler": {
+              "categorical": 598,
+              "general": 607,
+              "global": 169
+            },
+            "cpcnn": {
+              "categorical": 0,
+              "general": 539,
+              "global": 539
+            },
+            "dino": {
+              "categorical": 626,
+              "general": 644,
+              "global": 545
+            }
+          },
+          "id": "BIOACTIVITY-001:01",
+          "name": "all published-SI morphology count estimands",
+          "observed": {
+            "cellprofiler": {
+              "categorical": 598,
+              "general": 607,
+              "global": 169
+            },
+            "cpcnn": {
+              "categorical": 0,
+              "general": 539,
+              "global": 539
+            },
+            "dino": {
+              "categorical": 626,
+              "general": 644,
+              "global": 545
+            }
+          },
+          "passed": true,
+          "target_id": "BIOACTIVITY-001"
+        },
+        {
+          "expected": 0.156,
+          "id": "BIOACTIVITY-001:02",
+          "name": "CellProfiler-global published-SI fraction",
+          "observed": [
+            0.155760368663594,
+            0.0005
+          ],
+          "passed": true,
+          "target_id": "BIOACTIVITY-001"
+        },
+        {
+          "expected": 607,
+          "id": "BIOACTIVITY-001:03",
+          "name": "CellProfiler general published-SI count",
+          "observed": 607,
+          "passed": true,
+          "target_id": "BIOACTIVITY-001"
+        },
+        {
+          "expected": true,
+          "id": "BIOACTIVITY-001:04",
+          "name": "published-SI general morphology ordering over cytotoxic assays",
+          "observed": true,
+          "passed": true,
+          "target_id": "BIOACTIVITY-001"
+        },
+        {
+          "expected": 607,
+          "id": "FIG-2B:01",
+          "name": "CellProfiler general active compounds",
+          "observed": 607,
+          "passed": true,
+          "target_id": "FIG-2B"
+        },
+        {
+          "expected": 644,
+          "id": "FIG-2B:02",
+          "name": "DINO general active compounds",
+          "observed": 644,
+          "passed": true,
+          "target_id": "FIG-2B"
+        },
+        {
+          "expected": 488,
+          "id": "BIOACTIVITY-002:01",
+          "name": "three-general shared compounds",
+          "observed": 488,
+          "passed": true,
+          "target_id": "BIOACTIVITY-002"
+        },
+        {
+          "expected": 1.8181,
+          "id": "BIOACTIVITY-002:02",
+          "name": "CP-CNN over CellProfiler general POD ratio",
+          "observed": [
+            1.81811349465688,
+            5e-05
+          ],
+          "passed": true,
+          "target_id": "BIOACTIVITY-002"
+        },
+        {
+          "expected": 0.05,
+          "id": "BIOACTIVITY-002:03",
+          "name": "CellProfiler-DINO null conclusion is substrate-dependent",
+          "observed": 0.261389384315177,
+          "passed": true,
+          "target_id": "BIOACTIVITY-002"
+        },
+        {
+          "expected": 342,
+          "id": "FIG-2C:01",
+          "name": "camera-ready five-series count trace",
+          "observed": 342,
+          "passed": true,
+          "target_id": "FIG-2C"
+        },
+        {
+          "expected": 156,
+          "id": "FIG-2C:02",
+          "name": "published-SI five-series complete cases",
+          "observed": 156,
+          "passed": true,
+          "target_id": "FIG-2C"
+        },
+        {
+          "expected": 186,
+          "id": "FIG-2C:03",
+          "name": "published-SI count deviation from camera-ready",
+          "observed": 186,
+          "passed": true,
+          "target_id": "FIG-2C"
+        },
+        {
+          "expected": true,
+          "id": "FIG-2C:04",
+          "name": "five-series median ordering preserved",
+          "observed": true,
+          "passed": true,
+          "target_id": "FIG-2C"
+        },
+        {
+          "expected": {
+            "finite_nonempty": true,
+            "median_order": [
+              "cellprofiler_categorical",
+              "dino_categorical",
+              "dino_global",
+              "cpcnn_global",
+              "cellprofiler_global"
+            ],
+            "series_count": 5
+          },
+          "id": "FIG-2C:05",
+          "name": "tracked-SI five-series finite POD summaries and median order",
+          "observed": {
+            "finite_nonempty": true,
+            "median_order": [
+              "cellprofiler_categorical",
+              "dino_categorical",
+              "dino_global",
+              "cpcnn_global",
+              "cellprofiler_global"
+            ],
+            "series_count": 5
+          },
+          "passed": true,
+          "target_id": "FIG-2C"
+        },
+        {
+          "expected": "Morphology < MT < cell count < LDH",
+          "id": "BIOACTIVITY-003:01",
+          "name": "assay median sensitivity ordering",
+          "observed": [
+            5.05543414478975,
+            8.95705965699234,
+            23.8188547870137,
+            40.5354608552776
+          ],
+          "passed": true,
+          "target_id": "BIOACTIVITY-003"
+        },
+        {
+          "expected": 121,
+          "id": "BIOACTIVITY-003:02",
+          "name": "published-SI complete cases",
+          "observed": 121,
+          "passed": true,
+          "target_id": "BIOACTIVITY-003"
+        },
+        {
+          "expected": 121,
+          "id": "FIG-2D:01",
+          "name": "published-SI four-assay complete cases",
+          "observed": 121,
+          "passed": true,
+          "target_id": "FIG-2D"
+        },
+        {
+          "expected": 1.78550470485347,
+          "id": "FIG-2D:02",
+          "name": "MT fold ratio versus morphology",
+          "observed": 1.78550470485347,
+          "passed": true,
+          "target_id": "FIG-2D"
+        },
+        {
+          "expected": 796,
+          "id": "TABLE-S2:01",
+          "name": "Table S2 semantic keys",
+          "observed": 796,
+          "passed": true,
+          "target_id": "TABLE-S2"
+        },
+        {
+          "expected": 1e-12,
+          "id": "TABLE-S2:02",
+          "name": "Table S2 maximum POD difference",
+          "observed": 4.40536496171262e-13,
+          "passed": true,
+          "target_id": "TABLE-S2"
+        },
+        {
+          "expected": 10935,
+          "id": "TABLE-S3:01",
+          "name": "Table S3 semantic keys",
+          "observed": 10935,
+          "passed": true,
+          "target_id": "TABLE-S3"
+        },
+        {
+          "expected": 10935,
+          "id": "TABLE-S3:02",
+          "name": "Table S3 exact bioactivity flags",
+          "observed": 10935,
+          "passed": true,
+          "target_id": "TABLE-S3"
+        },
+        {
+          "expected": 1086,
+          "id": "TABLE-S4:01",
+          "name": "Table S4 semantic keys",
+          "observed": 1086,
+          "passed": true,
+          "target_id": "TABLE-S4"
+        },
+        {
+          "expected": 1086,
+          "id": "TABLE-S4:02",
+          "name": "Table S4 exact tracked hit rows",
+          "observed": 1086,
+          "passed": true,
+          "target_id": "TABLE-S4"
+        },
+        {
+          "expected": true,
+          "id": "METHOD-POD:01",
+          "name": "POD implementation and deviation trace",
+          "observed": {
+            "compound_minimum_pod": true,
+            "dmso_control": true,
+            "documented_ci_ratio_threshold_40": true,
+            "documented_dmso_95th_percentile_benchmark": true,
+            "documented_eight_model_names": true,
+            "documented_highest_tested_concentration_filter": true,
+            "known_selection_deviation_traced": true,
+            "morphology_residual_sd_selection": true,
+            "paired_assay_scorespod_default": true
+          },
+          "passed": true,
+          "target_id": "METHOD-POD"
+        },
+        {
+          "expected": true,
+          "id": "CONCLUSION-001:01",
+          "name": "morphology sensitivity inequalities",
+          "observed": {
+            "complete_case_median_order": true,
+            "general_morphology_count_exceeds_mt": true
+          },
+          "passed": true,
+          "target_id": "CONCLUSION-001"
+        }
+      ],
+      "evidence_strength_counts": {
+        "derived-artifact-reanalysis": 1,
+        "documentary-trace": 3,
+        "source-recomputation": 11
+      },
+      "execution_outcome_counts": {
+        "blocked": 1,
+        "checked": 11,
+        "documentary-only": 3
+      },
+      "target_count": 15,
+      "target_ids": [
+        "ACTIVITY-001",
+        "ACTIVITY-002",
+        "ACTIVITY-003",
+        "FIG-2A",
+        "BIOACTIVITY-001",
+        "FIG-2B",
+        "BIOACTIVITY-002",
+        "FIG-2C",
+        "BIOACTIVITY-003",
+        "FIG-2D",
+        "TABLE-S2",
+        "TABLE-S3",
+        "TABLE-S4",
+        "METHOD-POD",
+        "CONCLUSION-001"
+      ]
+    },
+    "classifier": {
+      "checks": [
+        {
+          "expected": 10,
+          "id": "TABLE-2:01",
+          "name": "Table 2 row count",
+          "observed": 10,
+          "passed": true,
+          "target_id": "TABLE-2"
+        },
+        {
+          "expected": true,
+          "id": "TABLE-2:02",
+          "name": "Table 2 conclusion gates",
+          "observed": true,
+          "passed": true,
+          "target_id": "TABLE-2"
+        },
+        {
+          "expected": 0.932625,
+          "id": "CLASSIFIER-001:01",
+          "name": "LDH morphology mean AUROC",
+          "observed": [
+            0.932625056254142,
+            5e-07
+          ],
+          "passed": true,
+          "target_id": "CLASSIFIER-001"
+        },
+        {
+          "expected": 0.753212,
+          "id": "CLASSIFIER-001:02",
+          "name": "LDH morphology mean PRAUC",
+          "observed": [
+            0.753212139721954,
+            5e-07
+          ],
+          "passed": true,
+          "target_id": "CLASSIFIER-001"
+        },
+        {
+          "expected": true,
+          "id": "CLASSIFIER-001:03",
+          "name": "LDH representations beat both baselines",
+          "observed": true,
+          "passed": true,
+          "target_id": "CLASSIFIER-001"
+        },
+        {
+          "expected": {
+            "axiom": 2,
+            "toxcast_cellbased": 267,
+            "toxcast_cellfree": 53,
+            "toxcast_cytotox": 34
+          },
+          "id": "FIG-3AB:01",
+          "name": "classifier modeled endpoint distributions",
+          "observed": {
+            "axiom": 2,
+            "toxcast_cellbased": 267,
+            "toxcast_cellfree": 53,
+            "toxcast_cytotox": 34
+          },
+          "passed": true,
+          "target_id": "FIG-3AB"
+        },
+        {
+          "expected": {
+            "axiom": {
+              "auroc": 0.901547,
+              "prauc": 0.805566
+            },
+            "toxcast_cellbased": {
+              "auroc": 0.607226,
+              "prauc": 0.14484
+            },
+            "toxcast_cellfree": {
+              "auroc": 0.532086,
+              "prauc": 0.454015
+            },
+            "toxcast_cytotox": {
+              "auroc": 0.73721,
+              "prauc": 0.477455
+            }
+          },
+          "id": "FIG-3AB:02",
+          "name": "all-concentration CellProfiler distribution summaries",
+          "observed": {
+            "axiom": {
+              "auroc": 0.90154710075502,
+              "prauc": 0.805566469136103
+            },
+            "toxcast_cellbased": {
+              "auroc": 0.607226107226107,
+              "prauc": 0.144839974879456
+            },
+            "toxcast_cellfree": {
+              "auroc": 0.532085561497326,
+              "prauc": 0.454015201822219
+            },
+            "toxcast_cytotox": {
+              "auroc": 0.737210441587034,
+              "prauc": 0.477454853975985
+            }
+          },
+          "passed": true,
+          "target_id": "FIG-3AB"
+        },
+        {
+          "expected": true,
+          "id": "FIG-3C:01",
+          "name": "cell-based versus cell-free baseline conclusion",
+          "observed": true,
+          "passed": true,
+          "target_id": "FIG-3C"
+        },
+        {
+          "expected": true,
+          "id": "FILTER-001:01",
+          "name": "allpod versus all effects remain small",
+          "observed": true,
+          "passed": true,
+          "target_id": "FILTER-001"
+        },
+        {
+          "expected": -0.124974386867459,
+          "id": "FILTER-002:01",
+          "name": "Axiom allpodcc minus allpod mean AUROC",
+          "observed": -0.124974386867459,
+          "passed": true,
+          "target_id": "FILTER-002"
+        },
+        {
+          "expected": -0.372361412793057,
+          "id": "FILTER-002:02",
+          "name": "Axiom allpodcc minus allpod mean PRAUC",
+          "observed": -0.372361412793057,
+          "passed": true,
+          "target_id": "FILTER-002"
+        },
+        {
+          "expected": {
+            "toxcast_cellbased": -0.007970189,
+            "toxcast_cellfree": 0.0134291664,
+            "toxcast_cytotox": -0.0885859687
+          },
+          "id": "FILTER-002:03",
+          "name": "allpodcc minus allpod mean AUROC",
+          "observed": {
+            "toxcast_cellbased": -0.00797018904098499,
+            "toxcast_cellfree": 0.0134291664332844,
+            "toxcast_cytotox": -0.0885859686562654
+          },
+          "passed": true,
+          "target_id": "FILTER-002"
+        },
+        {
+          "expected": {
+            "toxcast_cellbased": -0.0065967963,
+            "toxcast_cellfree": 0.0051519574,
+            "toxcast_cytotox": -0.1671635603
+          },
+          "id": "FILTER-002:04",
+          "name": "allpodcc minus allpod mean PRAUC",
+          "observed": {
+            "toxcast_cellbased": -0.00659679632924061,
+            "toxcast_cellfree": 0.00515195738908095,
+            "toxcast_cytotox": -0.167163560277532
+          },
+          "passed": true,
+          "target_id": "FILTER-002"
+        },
+        {
+          "expected": true,
+          "id": "FILTER-002:05",
+          "name": "Axiom and cytotoxic effects are negative while cell-based and cell-free effects remain below 0.02",
+          "observed": true,
+          "passed": true,
+          "target_id": "FILTER-002"
+        },
+        {
+          "expected": true,
+          "id": "FIG-4A:01",
+          "name": "all-concentration strategy conclusion",
+          "observed": true,
+          "passed": true,
+          "target_id": "FIG-4A"
+        },
+        {
+          "expected": {
+            "mean_difference": 0.01079046,
+            "median_difference": 0.01587302
+          },
+          "id": "REPRESENTATION-001:01",
+          "name": "DINO versus CP-CNN cell-based AUROC effects",
+          "observed": {
+            "mean_difference": 0.010790455248826,
+            "median_difference": 0.0158730158730159
+          },
+          "passed": true,
+          "target_id": "REPRESENTATION-001"
+        },
+        {
+          "expected": 0.02209021,
+          "id": "REPRESENTATION-001:02",
+          "name": "DINO versus CellProfiler median cell-based AUROC",
+          "observed": 0.0220902090209021,
+          "passed": true,
+          "target_id": "REPRESENTATION-001"
+        },
+        {
+          "expected": true,
+          "id": "FIG-4B:01",
+          "name": "representation effects remain practically small",
+          "observed": true,
+          "passed": true,
+          "target_id": "FIG-4B"
+        },
+        {
+          "expected": true,
+          "id": "SFIG-4:01",
+          "name": "PRAUC filtering and representation practical conclusion",
+          "observed": true,
+          "passed": true,
+          "target_id": "SFIG-4"
+        },
+        {
+          "expected": true,
+          "id": "METHOD-CLASSIFIER:01",
+          "name": "classifier implementation trace",
+          "observed": {
+            "compound_level_label_join": true,
+            "consensus_strategies": true,
+            "folds": 5,
+            "model": "XGBClassifier",
+            "paired_assay_hitcalls": true,
+            "published_baselines": true,
+            "stratified": true,
+            "workflow_wiring": true
+          },
+          "passed": true,
+          "target_id": "METHOD-CLASSIFIER"
+        },
+        {
+          "expected": true,
+          "id": "CONCLUSION-002:01",
+          "name": "cell-based but not cell-free inequality gate",
+          "observed": true,
+          "passed": true,
+          "target_id": "CONCLUSION-002"
+        },
+        {
+          "expected": true,
+          "id": "CONCLUSION-003:01",
+          "name": "representation and filtering practical-equivalence gates",
+          "observed": true,
+          "passed": true,
+          "target_id": "CONCLUSION-003"
+        }
+      ],
+      "evidence_strength_counts": {
+        "derived-artifact-reanalysis": 12,
+        "documentary-trace": 1
+      },
+      "execution_outcome_counts": {
+        "checked": 12,
+        "documentary-only": 1
+      },
+      "target_count": 13,
+      "target_ids": [
+        "TABLE-2",
+        "CLASSIFIER-001",
+        "FIG-3AB",
+        "FIG-3C",
+        "FILTER-001",
+        "FILTER-002",
+        "FIG-4A",
+        "REPRESENTATION-001",
+        "FIG-4B",
+        "SFIG-4",
+        "METHOD-CLASSIFIER",
+        "CONCLUSION-002",
+        "CONCLUSION-003"
+      ]
+    },
+    "external_image": {
+      "checks": [
+        {
+          "expected": true,
+          "id": "SFIG-1:01",
+          "name": "tracked navigation image identity trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "SFIG-1"
+        },
+        {
+          "expected": false,
+          "id": "SFIG-1:02",
+          "name": "external source image available",
+          "observed": false,
+          "passed": true,
+          "target_id": "SFIG-1"
+        }
+      ],
+      "evidence_strength_counts": {
+        "unavailable": 1
+      },
+      "execution_outcome_counts": {
+        "out-of-scope": 1
+      },
+      "target_count": 1,
+      "target_ids": [
+        "SFIG-1"
+      ]
+    },
+    "regression_enrichment": {
+      "checks": [
+        {
+          "expected": true,
+          "id": "TABLE-1:01",
+          "name": "Table 1 documentary schema and value trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "TABLE-1"
+        },
+        {
+          "expected": false,
+          "id": "TABLE-1:02",
+          "name": "Table 1 numerical acceptance rerun",
+          "observed": false,
+          "passed": true,
+          "target_id": "TABLE-1"
+        },
+        {
+          "expected": true,
+          "id": "REGRESSION-001:01",
+          "name": "regression comparison documentary trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "REGRESSION-001"
+        },
+        {
+          "expected": false,
+          "id": "REGRESSION-001:02",
+          "name": "regression numerical acceptance rerun",
+          "observed": false,
+          "passed": true,
+          "target_id": "REGRESSION-001"
+        },
+        {
+          "expected": true,
+          "id": "REGRESSION-002:01",
+          "name": "LDH replicate comparison documentary trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "REGRESSION-002"
+        },
+        {
+          "expected": false,
+          "id": "REGRESSION-002:02",
+          "name": "regression numerical acceptance rerun",
+          "observed": false,
+          "passed": true,
+          "target_id": "REGRESSION-002"
+        },
+        {
+          "expected": 304,
+          "id": "ENRICH-001:01",
+          "name": "historical higher hit-list size",
+          "observed": 304,
+          "passed": true,
+          "target_id": "ENRICH-001"
+        },
+        {
+          "expected": 178,
+          "id": "ENRICH-001:02",
+          "name": "stored higher significant sets",
+          "observed": 178,
+          "passed": true,
+          "target_id": "ENRICH-001"
+        },
+        {
+          "expected": false,
+          "id": "ENRICH-001:03",
+          "name": "literal 480-target acceptance available",
+          "observed": false,
+          "passed": true,
+          "target_id": "ENRICH-001"
+        },
+        {
+          "expected": 138,
+          "id": "ENRICH-002:01",
+          "name": "stored lower hit-list size",
+          "observed": 138,
+          "passed": true,
+          "target_id": "ENRICH-002"
+        },
+        {
+          "expected": 0,
+          "id": "ENRICH-002:02",
+          "name": "stored lower significant sets",
+          "observed": 0,
+          "passed": true,
+          "target_id": "ENRICH-002"
+        },
+        {
+          "expected": false,
+          "id": "ENRICH-002:03",
+          "name": "literal 304-well acceptance available",
+          "observed": false,
+          "passed": true,
+          "target_id": "ENRICH-002"
+        },
+        {
+          "expected": 261,
+          "id": "ENRICH-003:01",
+          "name": "MT higher hit-list size",
+          "observed": 261,
+          "passed": true,
+          "target_id": "ENRICH-003"
+        },
+        {
+          "expected": 147,
+          "id": "ENRICH-003:02",
+          "name": "MT higher significant sets",
+          "observed": 147,
+          "passed": true,
+          "target_id": "ENRICH-003"
+        },
+        {
+          "expected": {
+            "cyp_prefix_count": 8,
+            "htr_prefix_count": 6,
+            "transporters_present": [
+              "ABCB1",
+              "ABCG2",
+              "SLCO1B1",
+              "SLCO1B3"
+            ]
+          },
+          "id": "ENRICH-003:03",
+          "name": "MT higher named target classes",
+          "observed": {
+            "cyp_prefix_count": 8,
+            "htr_prefix_count": 6,
+            "transporters_present": [
+              "ABCB1",
+              "ABCG2",
+              "SLCO1B1",
+              "SLCO1B3"
+            ]
+          },
+          "passed": true,
+          "target_id": "ENRICH-003"
+        },
+        {
+          "expected": 131,
+          "id": "ENRICH-004:01",
+          "name": "MT lower hit-list size",
+          "observed": 131,
+          "passed": true,
+          "target_id": "ENRICH-004"
+        },
+        {
+          "expected": 107,
+          "id": "ENRICH-004:02",
+          "name": "MT lower significant sets",
+          "observed": 107,
+          "passed": true,
+          "target_id": "ENRICH-004"
+        },
+        {
+          "expected": {
+            "cyp_prefix_count": 3,
+            "psm_prefix_count": 18
+          },
+          "id": "ENRICH-004:03",
+          "name": "MT lower named target classes",
+          "observed": {
+            "cyp_prefix_count": 3,
+            "psm_prefix_count": 18
+          },
+          "passed": true,
+          "target_id": "ENRICH-004"
+        },
+        {
+          "expected": true,
+          "id": "SFIG-2:01",
+          "name": "Figure S2 panel documentary trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "SFIG-2"
+        },
+        {
+          "expected": false,
+          "id": "SFIG-2:02",
+          "name": "Figure S2 numerical acceptance rerun",
+          "observed": false,
+          "passed": true,
+          "target_id": "SFIG-2"
+        },
+        {
+          "expected": true,
+          "id": "METHOD-REGRESSION:01",
+          "name": "ten 80/20 compound-group splits",
+          "observed": true,
+          "passed": true,
+          "target_id": "METHOD-REGRESSION"
+        },
+        {
+          "expected": true,
+          "id": "INTERPRETATION-001:01",
+          "name": "direct enrichment associations separated from mechanism",
+          "observed": true,
+          "passed": true,
+          "target_id": "INTERPRETATION-001"
+        }
+      ],
+      "evidence_strength_counts": {
+        "derived-artifact-reanalysis": 5,
+        "documentary-trace": 5
+      },
+      "execution_outcome_counts": {
+        "blocked": 2,
+        "checked": 3,
+        "documentary-only": 5
+      },
+      "target_count": 10,
+      "target_ids": [
+        "TABLE-1",
+        "REGRESSION-001",
+        "REGRESSION-002",
+        "ENRICH-001",
+        "ENRICH-002",
+        "ENRICH-003",
+        "ENRICH-004",
+        "SFIG-2",
+        "METHOD-REGRESSION",
+        "INTERPRETATION-001"
+      ]
+    },
+    "sources_design": {
+      "checks": [
+        {
+          "expected": true,
+          "id": "DESIGN-001:01",
+          "name": "published compound, dose, and replicate design",
+          "observed": true,
+          "passed": true,
+          "target_id": "DESIGN-001"
+        },
+        {
+          "expected": true,
+          "id": "DESIGN-002:01",
+          "name": "published representation feature counts",
+          "observed": true,
+          "passed": true,
+          "target_id": "DESIGN-002"
+        },
+        {
+          "expected": true,
+          "id": "DESIGN-003:01",
+          "name": "published assay and exposure constants",
+          "observed": true,
+          "passed": true,
+          "target_id": "DESIGN-003"
+        },
+        {
+          "expected": true,
+          "id": "FIG-1:01",
+          "name": "Figure 1 workflow stages and outcomes",
+          "observed": true,
+          "passed": true,
+          "target_id": "FIG-1"
+        },
+        {
+          "expected": 1085,
+          "id": "TABLE-S1:01",
+          "name": "Table S1 rows",
+          "observed": 1085,
+          "passed": true,
+          "target_id": "TABLE-S1"
+        },
+        {
+          "expected": 966,
+          "id": "TABLE-S1:02",
+          "name": "Table S1 stable IDs",
+          "observed": 966,
+          "passed": true,
+          "target_id": "TABLE-S1"
+        },
+        {
+          "expected": 119,
+          "id": "TABLE-S1:03",
+          "name": "Table S1 blank IDs",
+          "observed": 119,
+          "passed": true,
+          "target_id": "TABLE-S1"
+        },
+        {
+          "expected": true,
+          "id": "TABLE-KEY-RESOURCES:01",
+          "name": "Key Resources transcription trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "TABLE-KEY-RESOURCES"
+        },
+        {
+          "expected": 34,
+          "id": "TABLE-KEY-RESOURCES:02",
+          "name": "Key Resources Markdown data rows",
+          "observed": 34,
+          "passed": true,
+          "target_id": "TABLE-KEY-RESOURCES"
+        },
+        {
+          "expected": true,
+          "id": "METHOD-STATS:01",
+          "name": "statistical thresholds and sample design trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "METHOD-STATS"
+        },
+        {
+          "expected": true,
+          "id": "RESOURCE-001:01",
+          "name": "published data and code locations",
+          "observed": true,
+          "passed": true,
+          "target_id": "RESOURCE-001"
+        },
+        {
+          "expected": true,
+          "id": "RESOURCE-001:02",
+          "name": "tracked-only resource boundary",
+          "observed": true,
+          "passed": true,
+          "target_id": "RESOURCE-001"
+        }
+      ],
+      "evidence_strength_counts": {
+        "documentary-trace": 7,
+        "source-recomputation": 1
+      },
+      "execution_outcome_counts": {
+        "checked": 1,
+        "documentary-only": 7
+      },
+      "target_count": 8,
+      "target_ids": [
+        "DESIGN-001",
+        "DESIGN-002",
+        "DESIGN-003",
+        "FIG-1",
+        "TABLE-S1",
+        "TABLE-KEY-RESOURCES",
+        "METHOD-STATS",
+        "RESOURCE-001"
+      ]
+    },
+    "toxcast": {
+      "checks": [
+        {
+          "expected": 963,
+          "id": "TOXCAST-001:01",
+          "name": "stored ToxCast annotation-ID union, not tested overlap",
+          "observed": 963,
+          "passed": true,
+          "target_id": "TOXCAST-001"
+        },
+        {
+          "expected": 0.89,
+          "id": "TOXCAST-001:02",
+          "name": "stored annotation-union/library-denominator arithmetic, not tested overlap",
+          "observed": [
+            0.887557603686636,
+            0.005
+          ],
+          "passed": true,
+          "target_id": "TOXCAST-001"
+        },
+        {
+          "expected": 670,
+          "id": "TOXCAST-001:03",
+          "name": "documented tested-library intersection IDs",
+          "observed": 670,
+          "passed": true,
+          "target_id": "TOXCAST-001"
+        },
+        {
+          "expected": 61.751152,
+          "id": "TOXCAST-001:04",
+          "name": "documented tested-library intersection percentage",
+          "observed": [
+            61.7511520737327,
+            5e-07
+          ],
+          "passed": true,
+          "target_id": "TOXCAST-001"
+        },
+        {
+          "expected": true,
+          "id": "TOXCAST-001:05",
+          "name": "963 is an annotation union rather than a tested-library join",
+          "observed": true,
+          "passed": true,
+          "target_id": "TOXCAST-001"
+        },
+        {
+          "expected": {
+            "cellbased": 292,
+            "cellfree": 72,
+            "cytotox": 48
+          },
+          "id": "TOXCAST-002:01",
+          "name": "ToxCast source endpoint counts",
+          "observed": {
+            "cellbased": 292,
+            "cellfree": 72,
+            "cytotox": 48
+          },
+          "passed": true,
+          "target_id": "TOXCAST-002"
+        },
+        {
+          "expected": {
+            "cellbased": 292,
+            "cellfree": 72,
+            "cytotox": 38
+          },
+          "id": "TOXCAST-002:02",
+          "name": "classification-ready binary endpoint counts",
+          "observed": {
+            "cellbased": 292,
+            "cellfree": 72,
+            "cytotox": 38
+          },
+          "passed": true,
+          "target_id": "TOXCAST-002"
+        },
+        {
+          "expected": {
+            "kidney": 35,
+            "liver": 151,
+            "vascular": 63
+          },
+          "id": "TOXCAST-003:01",
+          "name": "cell-based tissue composition",
+          "observed": {
+            "kidney": 35,
+            "liver": 151,
+            "vascular": 63
+          },
+          "passed": true,
+          "target_id": "TOXCAST-003"
+        },
+        {
+          "expected": {
+            "binding": 37,
+            "enzymatic activity": 35
+          },
+          "id": "TOXCAST-003:02",
+          "name": "cell-free assay composition",
+          "observed": {
+            "binding": 37,
+            "enzymatic activity": 35
+          },
+          "passed": true,
+          "target_id": "TOXCAST-003"
+        },
+        {
+          "expected": {
+            "cyp": 11,
+            "gpcr": 21,
+            "nuclear receptor": 10
+          },
+          "id": "TOXCAST-003:03",
+          "name": "cell-free target-family composition",
+          "observed": {
+            "cyp": 11,
+            "gpcr": 21,
+            "nuclear receptor": 10
+          },
+          "passed": true,
+          "target_id": "TOXCAST-003"
+        },
+        {
+          "expected": {
+            "cellbased": 306,
+            "cellfree": 33,
+            "cytotox": 346
+          },
+          "id": "TOXCAST-003:04",
+          "name": "median compounds tested per endpoint",
+          "observed": {
+            "cellbased": 306,
+            "cellfree": 33,
+            "cytotox": 346
+          },
+          "passed": true,
+          "target_id": "TOXCAST-003"
+        },
+        {
+          "expected": {
+            "cellbased": 0.0711613553,
+            "cellfree": 0.4134295228,
+            "cytotox": 0.2068348801
+          },
+          "id": "TOXCAST-003:05",
+          "name": "median endpoint active fractions",
+          "observed": {
+            "cellbased": 0.071161355334425,
+            "cellfree": 0.413429522752497,
+            "cytotox": 0.206834880123743
+          },
+          "passed": true,
+          "target_id": "TOXCAST-003"
+        },
+        {
+          "expected": {
+            "cell_categories": 12,
+            "complete_compounds": 839,
+            "tissue_categories": 6
+          },
+          "id": "SFIG-3:01",
+          "name": "cytotoxicity heatmap summary",
+          "observed": {
+            "cell_categories": 12,
+            "complete_compounds": 839,
+            "tissue_categories": 6
+          },
+          "passed": true,
+          "target_id": "SFIG-3"
+        },
+        {
+          "expected": 12,
+          "id": "TABLE-S5:01",
+          "name": "Table S5 nuclear-receptor assays",
+          "observed": 12,
+          "passed": true,
+          "target_id": "TABLE-S5"
+        },
+        {
+          "expected": 1.648,
+          "id": "TABLE-S5:02",
+          "name": "Table S5 nuclear-receptor AC50 minimum",
+          "observed": [
+            1.64808942,
+            0.001
+          ],
+          "passed": true,
+          "target_id": "TABLE-S5"
+        },
+        {
+          "expected": 45.0,
+          "id": "TABLE-S5:03",
+          "name": "Table S5 nuclear-receptor AC50 maximum",
+          "observed": 45.0,
+          "passed": true,
+          "target_id": "TABLE-S5"
+        },
+        {
+          "expected": 8,
+          "id": "TABLE-S5:04",
+          "name": "Table S5 retained pinned receptor assays",
+          "observed": 8,
+          "passed": true,
+          "target_id": "TABLE-S5"
+        },
+        {
+          "expected": 0,
+          "id": "TABLE-S5:05",
+          "name": "Table S5 source cytotoxicity hits",
+          "observed": 0,
+          "passed": true,
+          "target_id": "TABLE-S5"
+        },
+        {
+          "expected": "active finite MMP signal",
+          "id": "TABLE-S5:06",
+          "name": "Table S5 MMP activity evidence",
+          "observed": {
+            "ac50_um": 14.8795940571651,
+            "hitcall_above_0_9": true
+          },
+          "passed": true,
+          "target_id": "TABLE-S5"
+        },
+        {
+          "expected": true,
+          "id": "METHOD-TOXCAST:01",
+          "name": "ToxCast threshold and decision-rule trace",
+          "observed": {
+            "cytotoxicity_consensus_20_percent": true,
+            "hitcall_strictly_above_0_9": true,
+            "median_positive_ac50": true,
+            "minimum_five_positive_and_negative": true,
+            "notebook_reads_pinned_parquets": true,
+            "specific_endpoint_100_um_deviation_traced": true
+          },
+          "passed": true,
+          "target_id": "METHOD-TOXCAST"
+        }
+      ],
+      "evidence_strength_counts": {
+        "documentary-trace": 1,
+        "source-recomputation": 5
+      },
+      "execution_outcome_counts": {
+        "checked": 5,
+        "documentary-only": 1
+      },
+      "target_count": 6,
+      "target_ids": [
+        "TOXCAST-001",
+        "TOXCAST-002",
+        "TOXCAST-003",
+        "SFIG-3",
+        "TABLE-S5",
+        "METHOD-TOXCAST"
+      ]
+    }
+  },
+  "ledger_sha256": "abbd88ada4cfa7615c84b421b7bd9f566a435472c4c79c38ad989e82087af38f",
+  "mode": "tracked",
+  "schema_version": 3,
+  "summary": {
+    "acceptance_class_counts": {
+      "close": 18,
+      "exact": 14,
+      "qualitative": 19,
+      "trace-only": 2
+    },
+    "evidence_strength_counts": {
+      "derived-artifact-reanalysis": 18,
+      "documentary-trace": 17,
+      "source-recomputation": 17,
+      "unavailable": 1
+    },
+    "execution_outcome_counts": {
+      "blocked": 3,
+      "checked": 32,
+      "documentary-only": 17,
+      "out-of-scope": 1
+    },
+    "ledger_status_counts": {
+      "blocked": 3,
+      "out-of-scope": 1,
+      "reproduced": 7,
+      "reproduced-with-deviation": 42
+    },
+    "total": 53
+  },
+  "targets": [
+    {
+      "acceptance": "exact: counts, range, and replicate design agree",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "DESIGN-001:01",
+          "name": "published compound, dose, and replicate design",
+          "observed": true,
+          "passed": true,
+          "target_id": "DESIGN-001"
+        }
+      ],
+      "description": "Tested compound design",
+      "deviation": "Published design and 1085-compound library agree; post-QC metadata excludes three microscope plates, leaving Hycanthone at seven concentrations and 941 of 8679 compound-concentration groups with one retained row",
+      "evidence": "evidence/experimental-design-and-figure-1.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "1085 compounds; eight concentrations from 0.01 to 100 uM; two biological replicates",
+      "group": "sources_design",
+      "id": "DESIGN-001",
+      "inputs": [
+        "paper/paper.md",
+        "paper/evidence/experimental-design-and-figure-1.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Published design and 1085-compound library agree; post-QC metadata excludes three microscope plates, leaving Hycanthone at seven concentrations and 941 of 8679 compound-concentration groups with one retained row",
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "1_snakemake/inputs/metadata/metadata.parquet",
+      "source": "main:p2-p3:experimental-design",
+      "summary": "Tested compound design: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "exact: representation names and feature counts agree",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "DESIGN-002:01",
+          "name": "published representation feature counts",
+          "observed": true,
+          "passed": true,
+          "target_id": "DESIGN-002"
+        }
+      ],
+      "description": "Image representation feature counts",
+      "deviation": "-",
+      "evidence": "evidence/experimental-design-and-figure-1.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "CellProfiler 5640; CP-CNN 672; DINO 4608",
+      "group": "sources_design",
+      "id": "DESIGN-002",
+      "inputs": [
+        "paper/paper.md",
+        "paper/evidence/experimental-design-and-figure-1.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced",
+      "limitations": [
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "0_prepare_data; downloaded profile schemas",
+      "source": "main:p2-p3:experimental-design",
+      "summary": "Image representation feature counts: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "exact: procedural constants and readout types agree",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "DESIGN-003:01",
+          "name": "published assay and exposure constants",
+          "observed": true,
+          "passed": true,
+          "target_id": "DESIGN-003"
+        }
+      ],
+      "description": "Assay and exposure design",
+      "deviation": "-",
+      "evidence": "evidence/experimental-design-and-figure-1.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "384-well plates; 44-hour exposure; Cell Painting, LDH, and MT readouts",
+      "group": "sources_design",
+      "id": "DESIGN-003",
+      "inputs": [
+        "paper/paper.md",
+        "paper/evidence/experimental-design-and-figure-1.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced",
+      "limitations": [
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "paper methods; input metadata",
+      "source": "main:p2-p3:experimental-design",
+      "summary": "Assay and exposure design: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "qualitative: same experimental stages, sample scale, assays, and intended outcomes; publisher layout need not match",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "FIG-1:01",
+          "name": "Figure 1 workflow stages and outcomes",
+          "observed": true,
+          "passed": true,
+          "target_id": "FIG-1"
+        }
+      ],
+      "description": "Overview of the experimental design",
+      "deviation": "-",
+      "evidence": "evidence/experimental-design-and-figure-1.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "The published workflow connects compound exposures to three measured assays and prediction outcomes",
+      "group": "sources_design",
+      "id": "FIG-1",
+      "inputs": [
+        "paper/figures/figure-1.jpg",
+        "paper/evidence/experimental-design-and-figure-1.md"
+      ],
+      "kind": "figure",
+      "ledger_status": "reproduced",
+      "limitations": [
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "unknown",
+      "source": "main:p3:figure-1",
+      "summary": "Overview of the experimental design: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "exact: counts agree on the fixed published substrate",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": {
+            "Cell count": 220,
+            "LDH": 147,
+            "MT": 429,
+            "unique_compounds": 437
+          },
+          "id": "ACTIVITY-001:01",
+          "name": "published Table S2 activity counts",
+          "observed": {
+            "Cell count": 220,
+            "LDH": 147,
+            "MT": 429,
+            "unique_compounds": 437
+          },
+          "passed": true,
+          "target_id": "ACTIVITY-001"
+        }
+      ],
+      "description": "Activity counts in paired cytotoxicity-related assays",
+      "deviation": "CellProfiler Parquets reproduce 430/221/144 and 438 unique; the DINO count notebook yields 431/220/144 and 439, while published Table S2 has 429/220/147 and 437 unique",
+      "evidence": "evidence/activity-and-figure-2a.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "MT 430 of 1085; cell count 221; LDH 144; 438 unique active compounds",
+      "group": "activity_pods",
+      "id": "ACTIVITY-001",
+      "inputs": [
+        "paper/sources/table-s2.xlsx",
+        "2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "CellProfiler Parquets reproduce 430/221/144 and 438 unique; the DINO count notebook yields 431/220/144 and 439, while published Table S2 has 429/220/147 and 437 unique"
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/1_2_number_active_readouts.ipynb",
+      "source": "main:p3:results-2.1.1",
+      "summary": "Activity counts in paired cytotoxicity-related assays: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "exact: count and direction-aware definition agree",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": 429,
+          "id": "ACTIVITY-002:01",
+          "name": "direction-aware cytotoxic compound count",
+          "observed": 429,
+          "passed": true,
+          "target_id": "ACTIVITY-002"
+        },
+        {
+          "expected": true,
+          "id": "ACTIVITY-002:02",
+          "name": "direction-aware definition trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "ACTIVITY-002"
+        }
+      ],
+      "description": "Overall cytotoxic compound count",
+      "deviation": "-",
+      "evidence": "evidence/activity-and-figure-2a.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "429 compounds are cytotoxic in at least one assay",
+      "group": "activity_pods",
+      "id": "ACTIVITY-002",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv",
+        "paper/evidence/activity-and-figure-2a.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced",
+      "limitations": [
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/1_2_number_active_readouts.ipynb",
+      "source": "main:p3:results-2.1.1",
+      "summary": "Overall cytotoxic compound count: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "close: same small set and same four dominant responses; document borderline call differences",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": 10,
+          "id": "ACTIVITY-003:01",
+          "name": "camera-ready increasing-MT call count",
+          "observed": 10,
+          "passed": true,
+          "target_id": "ACTIVITY-003"
+        },
+        {
+          "expected": true,
+          "id": "ACTIVITY-003:02",
+          "name": "increasing-MT count documentary trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "ACTIVITY-003"
+        },
+        {
+          "expected": [
+            "Benzarone",
+            "Tiratricol",
+            "Tolcapone",
+            "2-Ethylanthracene-9,10-dione"
+          ],
+          "id": "ACTIVITY-003:03",
+          "name": "four dominant increasing-MT compounds",
+          "observed": [
+            "Benzarone",
+            "Tiratricol",
+            "Tolcapone",
+            "2-Ethylanthracene-9,10-dione"
+          ],
+          "passed": true,
+          "target_id": "ACTIVITY-003"
+        },
+        {
+          "expected": "increasing MT",
+          "id": "ACTIVITY-003:04",
+          "name": "increasing-MT direction",
+          "observed": "increasing MT",
+          "passed": true,
+          "target_id": "ACTIVITY-003"
+        }
+      ],
+      "description": "Compounds with increased MT readout",
+      "deviation": "CellProfiler reproduces ten and the same four dominant compounds; the DINO notebook adds Clodinafop-propargyl after an order-sensitive Exp2-to-Exp3 model change",
+      "evidence": "evidence/activity-and-figure-2a.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "Ten compounds increase MT; four have particularly strong responses",
+      "group": "activity_pods",
+      "id": "ACTIVITY-003",
+      "inputs": [
+        "paper/evidence/activity-and-figure-2a.md",
+        "2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "CellProfiler reproduces ten and the same four dominant compounds; the DINO notebook adds Clodinafop-propargyl after an order-sensitive Exp2-to-Exp3 model change",
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/1_2_1_cmpds_increase_mt.ipynb",
+      "source": "main:p3:results-2.1.1",
+      "summary": "Compounds with increased MT readout: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "qualitative: same compounds, response direction, and approximate curve and POD locations",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": [
+            "Benzarone",
+            "Tiratricol",
+            "Tolcapone",
+            "2-Ethylanthracene-9,10-dione"
+          ],
+          "id": "FIG-2A:01",
+          "name": "Figure 2A four published compounds",
+          "observed": [
+            "Benzarone",
+            "Tiratricol",
+            "Tolcapone",
+            "2-Ethylanthracene-9,10-dione"
+          ],
+          "passed": true,
+          "target_id": "FIG-2A"
+        },
+        {
+          "expected": 1e-06,
+          "id": "FIG-2A:02",
+          "name": "Figure 2A Table S2 POD agreement",
+          "observed": 4.4072791993698957e-07,
+          "passed": true,
+          "target_id": "FIG-2A"
+        }
+      ],
+      "description": "Strong MT-increasing concentration-response curves",
+      "deviation": "-",
+      "evidence": "evidence/activity-and-figure-2a.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "Four dominant MT-increasing compounds with POD markers",
+      "group": "activity_pods",
+      "id": "FIG-2A",
+      "inputs": [
+        "paper/sources/table-s2.xlsx",
+        "2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv",
+        "paper/evidence/activity-and-figure-2a.md"
+      ],
+      "kind": "figure",
+      "ledger_status": "reproduced",
+      "limitations": [],
+      "producer": "2_downstream_analysis/manuscript_notebooks/1_2_1_cmpds_increase_mt.ipynb",
+      "source": "main:p4:figure-2a",
+      "summary": "Strong MT-increasing concentration-response curves: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: same range, ordering, and outlier; small POD pass-call drift is acceptable",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": {
+            "cellprofiler": {
+              "categorical": 598,
+              "general": 607,
+              "global": 169
+            },
+            "cpcnn": {
+              "categorical": 0,
+              "general": 539,
+              "global": 539
+            },
+            "dino": {
+              "categorical": 626,
+              "general": 644,
+              "global": 545
+            }
+          },
+          "id": "BIOACTIVITY-001:01",
+          "name": "all published-SI morphology count estimands",
+          "observed": {
+            "cellprofiler": {
+              "categorical": 598,
+              "general": 607,
+              "global": 169
+            },
+            "cpcnn": {
+              "categorical": 0,
+              "general": 539,
+              "global": 539
+            },
+            "dino": {
+              "categorical": 626,
+              "general": 644,
+              "global": 545
+            }
+          },
+          "passed": true,
+          "target_id": "BIOACTIVITY-001"
+        },
+        {
+          "expected": 0.156,
+          "id": "BIOACTIVITY-001:02",
+          "name": "CellProfiler-global published-SI fraction",
+          "observed": [
+            0.155760368663594,
+            0.0005
+          ],
+          "passed": true,
+          "target_id": "BIOACTIVITY-001"
+        },
+        {
+          "expected": 607,
+          "id": "BIOACTIVITY-001:03",
+          "name": "CellProfiler general published-SI count",
+          "observed": 607,
+          "passed": true,
+          "target_id": "BIOACTIVITY-001"
+        },
+        {
+          "expected": true,
+          "id": "BIOACTIVITY-001:04",
+          "name": "published-SI general morphology ordering over cytotoxic assays",
+          "observed": true,
+          "passed": true,
+          "target_id": "BIOACTIVITY-001"
+        }
+      ],
+      "description": "Morphological bioactivity frequency",
+      "deviation": "Current notebook-read data preserve 34-59 percent and ordering; published Table S3 has 169 CellProfiler-global calls (15.6 percent) versus the panel's 372 (34.3 percent) because of model/pass-call drift.",
+      "evidence": "evidence/bioactivity-and-figure-2b-d.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "34-59 percent active depending on representation and distance metric; CellProfiler global is the 34 percent outlier",
+      "group": "activity_pods",
+      "id": "BIOACTIVITY-001",
+      "inputs": [
+        "paper/sources/table-s3.xlsx",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv",
+        "paper/evidence/bioactivity-and-figure-2b-d.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Current notebook-read data preserve 34-59 percent and ordering; published Table S3 has 169 CellProfiler-global calls (15.6 percent) versus the panel's 372 (34.3 percent) because of model/pass-call drift."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/4_1_results_tables_SI.ipynb",
+      "source": "main:p5:results-2.1.2",
+      "summary": "Morphological bioactivity frequency: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "qualitative: same ordering, approximate proportions, and distribution shapes",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": 607,
+          "id": "FIG-2B:01",
+          "name": "CellProfiler general active compounds",
+          "observed": 607,
+          "passed": true,
+          "target_id": "FIG-2B"
+        },
+        {
+          "expected": 644,
+          "id": "FIG-2B:02",
+          "name": "DINO general active compounds",
+          "observed": 644,
+          "passed": true,
+          "target_id": "FIG-2B"
+        }
+      ],
+      "description": "Active-compound counts and morphology POD distributions",
+      "deviation": "Current counts differ by at most six and medians by 0.6 uM; published Table S3 loses 203 CellProfiler-global calls and shifts its median from 25.0 to 52.8 uM.",
+      "evidence": "evidence/bioactivity-and-figure-2b-d.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "Representation and distance choices produce the published activity-count ordering and POD distributions",
+      "group": "activity_pods",
+      "id": "FIG-2B",
+      "inputs": [
+        "paper/sources/table-s3.xlsx",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv"
+      ],
+      "kind": "figure",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Current counts differ by at most six and medians by 0.6 uM; published Table S3 loses 203 CellProfiler-global calls and shifts its median from 25.0 to 52.8 uM."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/1_3_compare_pods.ipynb",
+      "source": "main:p4:figure-2b",
+      "summary": "Active-compound counts and morphology POD distributions: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: ratios remain near published magnitude and statistical conclusion is unchanged",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "blocked",
+      "checks": [
+        {
+          "expected": 488,
+          "id": "BIOACTIVITY-002:01",
+          "name": "three-general shared compounds",
+          "observed": 488,
+          "passed": true,
+          "target_id": "BIOACTIVITY-002"
+        },
+        {
+          "expected": 1.8181,
+          "id": "BIOACTIVITY-002:02",
+          "name": "CP-CNN over CellProfiler general POD ratio",
+          "observed": [
+            1.81811349465688,
+            5e-05
+          ],
+          "passed": true,
+          "target_id": "BIOACTIVITY-002"
+        },
+        {
+          "expected": 0.05,
+          "id": "BIOACTIVITY-002:03",
+          "name": "CellProfiler-DINO null conclusion is substrate-dependent",
+          "observed": 0.261389384315177,
+          "passed": true,
+          "target_id": "BIOACTIVITY-002"
+        }
+      ],
+      "description": "Relative morphology POD sensitivity by representation",
+      "deviation": "Ratios remain near 2.0 and 1.5, but CellProfiler-DINO is p=0.261 in published SI, p=0.034 on the current notebook path, and p=0.0545 with the filtered config; the absent historical extended matrix is excluded.",
+      "evidence": "evidence/bioactivity-and-figure-2b-d.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "blocked",
+      "expected": "CP-CNN PODs are about 2.0-fold higher than CellProfiler and 1.5-fold higher than DINO; CellProfiler and DINO are not significantly different",
+      "group": "activity_pods",
+      "id": "BIOACTIVITY-002",
+      "inputs": [
+        "paper/sources/table-s3.xlsx",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv",
+        "paper/evidence/bioactivity-and-figure-2b-d.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "blocked",
+      "limitations": [
+        "Ratios remain near 2.0 and 1.5, but CellProfiler-DINO is p=0.261 in published SI, p=0.034 on the current notebook path, and p=0.0545 with the filtered config; the absent historical extended matrix is excluded."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/1_3_compare_pods.ipynb",
+      "source": "main:p5:results-2.1.2",
+      "summary": "Relative morphology POD sensitivity by representation: target-specific tracked-only checks completed with execution outcome blocked."
+    },
+    {
+      "acceptance": "qualitative: same paired universe at useful resolution, same ordering, and similar spread; document row drift",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": 342,
+          "id": "FIG-2C:01",
+          "name": "camera-ready five-series count trace",
+          "observed": 342,
+          "passed": true,
+          "target_id": "FIG-2C"
+        },
+        {
+          "expected": 156,
+          "id": "FIG-2C:02",
+          "name": "published-SI five-series complete cases",
+          "observed": 156,
+          "passed": true,
+          "target_id": "FIG-2C"
+        },
+        {
+          "expected": 186,
+          "id": "FIG-2C:03",
+          "name": "published-SI count deviation from camera-ready",
+          "observed": 186,
+          "passed": true,
+          "target_id": "FIG-2C"
+        },
+        {
+          "expected": true,
+          "id": "FIG-2C:04",
+          "name": "five-series median ordering preserved",
+          "observed": true,
+          "passed": true,
+          "target_id": "FIG-2C"
+        },
+        {
+          "expected": {
+            "finite_nonempty": true,
+            "median_order": [
+              "cellprofiler_categorical",
+              "dino_categorical",
+              "dino_global",
+              "cpcnn_global",
+              "cellprofiler_global"
+            ],
+            "series_count": 5
+          },
+          "id": "FIG-2C:05",
+          "name": "tracked-SI five-series finite POD summaries and median order",
+          "observed": {
+            "finite_nonempty": true,
+            "median_order": [
+              "cellprofiler_categorical",
+              "dino_categorical",
+              "dino_global",
+              "cpcnn_global",
+              "cellprofiler_global"
+            ],
+            "series_count": 5
+          },
+          "passed": true,
+          "target_id": "FIG-2C"
+        }
+      ],
+      "description": "POD comparison across representations",
+      "deviation": "Five-series complete counts are 342 camera-ready, 156 published SI, 341 current notebook-read, 330 current filtered, and 408 stored; current notebook-read distributions and ordering agree closely.",
+      "evidence": "evidence/bioactivity-and-figure-2b-d.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "Published paired comparison for 342 compounds with PODs in all representations",
+      "group": "activity_pods",
+      "id": "FIG-2C",
+      "inputs": [
+        "paper/sources/table-s3.xlsx",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv",
+        "paper/evidence/bioactivity-and-figure-2b-d.md"
+      ],
+      "kind": "figure",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Five-series complete counts are 342 camera-ready, 156 published SI, 341 current notebook-read, 330 current filtered, and 408 stored; current notebook-read distributions and ordering agree closely."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/1_3_compare_pods.ipynb",
+      "source": "main:p4:figure-2c",
+      "summary": "POD comparison across representations: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: ordering is preserved, shared-compound count is similar, and fold differences remain broadly comparable",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": "Morphology < MT < cell count < LDH",
+          "id": "BIOACTIVITY-003:01",
+          "name": "assay median sensitivity ordering",
+          "observed": [
+            5.05543414478975,
+            8.95705965699234,
+            23.8188547870137,
+            40.5354608552776
+          ],
+          "passed": true,
+          "target_id": "BIOACTIVITY-003"
+        },
+        {
+          "expected": 121,
+          "id": "BIOACTIVITY-003:02",
+          "name": "published-SI complete cases",
+          "observed": 121,
+          "passed": true,
+          "target_id": "BIOACTIVITY-003"
+        }
+      ],
+      "description": "Assay sensitivity ordering and fold differences",
+      "deviation": "Ordering holds; published 121-compound folds are 1.79, 4.28, and 8.15, while current direction-aware 131-compound folds are 1.68, 3.87, and 7.41.",
+      "evidence": "evidence/bioactivity-and-figure-2b-d.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "Morphology > MT > cell count > LDH; among 121 compounds morphology POD is 1.8-fold, 3.9-fold, and 7.0-fold lower respectively",
+      "group": "activity_pods",
+      "id": "BIOACTIVITY-003",
+      "inputs": [
+        "paper/sources/table-s2.xlsx",
+        "paper/sources/table-s3.xlsx",
+        "paper/sources/table-s4.xlsx",
+        "2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Ordering holds; published 121-compound folds are 1.79, 4.28, and 8.15, while current direction-aware 131-compound folds are 1.68, 3.87, and 7.41."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/1_3_compare_pods.ipynb",
+      "source": "main:p5:results-2.1.3",
+      "summary": "Assay sensitivity ordering and fold differences: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "qualitative: same sensitivity ordering and similar paired distributions; exact plotted points are not required",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": 121,
+          "id": "FIG-2D:01",
+          "name": "published-SI four-assay complete cases",
+          "observed": 121,
+          "passed": true,
+          "target_id": "FIG-2D"
+        },
+        {
+          "expected": 1.78550470485347,
+          "id": "FIG-2D:02",
+          "name": "MT fold ratio versus morphology",
+          "observed": 1.78550470485347,
+          "passed": true,
+          "target_id": "FIG-2D"
+        }
+      ],
+      "description": "POD comparison across morphology and cytotoxicity assays",
+      "deviation": "Published Table S4 has 121 complete hits after a null-ID join excludes 15 rows; current direction-aware data have 131 and preserve distributions, paired ordering, and significance.",
+      "evidence": "evidence/bioactivity-and-figure-2b-d.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "Published paired comparison for 121 compounds with all four PODs",
+      "group": "activity_pods",
+      "id": "FIG-2D",
+      "inputs": [
+        "paper/sources/table-s2.xlsx",
+        "paper/sources/table-s3.xlsx",
+        "paper/sources/table-s4.xlsx",
+        "2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv"
+      ],
+      "kind": "figure",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Published Table S4 has 121 complete hits after a null-ID join excludes 15 rows; current direction-aware data have 131 and preserve distributions, paired ordering, and significance."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/1_3_compare_pods.ipynb",
+      "source": "main:p4:figure-2d",
+      "summary": "POD comparison across morphology and cytotoxicity assays: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: schemas and labels are exact; rounded metrics are close and preserve comparison conclusions",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "enrichment-summary.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "TABLE-1:01",
+          "name": "Table 1 documentary schema and value trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "TABLE-1"
+        },
+        {
+          "expected": false,
+          "id": "TABLE-1:02",
+          "name": "Table 1 numerical acceptance rerun",
+          "observed": false,
+          "passed": true,
+          "target_id": "TABLE-1"
+        }
+      ],
+      "description": "Regression prediction of paired LDH and MT readouts",
+      "deviation": "Schemas, labels, and ten splits agree; 51 of 72 mean or SD entries match at two significant figures, with maximum absolute mean drift 0.00849 R2, 0.000990 RMSE, and 0.000428 MAE",
+      "evidence": "evidence/regression-and-figure-s2.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "Published R2, RMSE, and MAE means and standard deviations across six input-feature or baseline rows per assay",
+      "group": "regression_enrichment",
+      "id": "TABLE-1",
+      "inputs": [
+        "paper/paper.md",
+        "1_snakemake/classifier/regression.py",
+        "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+        "paper/evidence/regression-and-figure-s2.md"
+      ],
+      "kind": "table",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Schemas, labels, and ten splits agree; 51 of 72 mean or SD entries match at two significant figures, with maximum absolute mean drift 0.00849 R2, 0.000990 RMSE, and 0.000428 MAE",
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+      "source": "main:p5:table-1",
+      "summary": "Regression prediction of paired LDH and MT readouts: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "qualitative: significance and performance ordering conclusions agree",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "enrichment-summary.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "REGRESSION-001:01",
+          "name": "regression comparison documentary trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "REGRESSION-001"
+        },
+        {
+          "expected": false,
+          "id": "REGRESSION-001:02",
+          "name": "regression numerical acceptance rerun",
+          "observed": false,
+          "passed": true,
+          "target_id": "REGRESSION-001"
+        }
+      ],
+      "description": "Relative regression performance across representations and baselines",
+      "deviation": "Practical similarity and MT-versus-LDH ordering hold; LDH MAE has small significant DINO differences and formally favors the technical baseline",
+      "evidence": "evidence/regression-and-figure-s2.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "Representations perform similarly; Cell Painting beats the technical baseline for MT but not LDH",
+      "group": "regression_enrichment",
+      "id": "REGRESSION-001",
+      "inputs": [
+        "1_snakemake/classifier/regression.py",
+        "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+        "paper/evidence/regression-and-figure-s2.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Practical similarity and MT-versus-LDH ordering hold; LDH MAE has small significant DINO differences and formally favors the technical baseline",
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+      "source": "main:p5-p6:results-2.2.1",
+      "summary": "Relative regression performance across representations and baselines: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "close: effect remains positive and near 0.20 with a clearly significant result",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "enrichment-summary.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "REGRESSION-002:01",
+          "name": "LDH replicate comparison documentary trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "REGRESSION-002"
+        },
+        {
+          "expected": false,
+          "id": "REGRESSION-002:02",
+          "name": "regression numerical acceptance rerun",
+          "observed": false,
+          "passed": true,
+          "target_id": "REGRESSION-002"
+        }
+      ],
+      "description": "LDH model versus replicate performance",
+      "deviation": "Current pooled effect is 0.203758 with two-sided equal-variance independent t-test p = 1.88446e-14; distinct 966-compound model and 1,085-compound replicate split universes are documented",
+      "evidence": "evidence/regression-and-figure-s2.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "Cell Painting or technical baseline R2 exceeds replicate R2 by mean 0.20 with p < 1e-14",
+      "group": "regression_enrichment",
+      "id": "REGRESSION-002",
+      "inputs": [
+        "paper/paper.md",
+        "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+        "paper/evidence/regression-and-figure-s2.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Current pooled effect is 0.203758 with two-sided equal-variance independent t-test p = 1.88446e-14; distinct 966-compound model and 1,085-compound replicate split universes are documented",
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+      "source": "main:p5:results-2.2.1",
+      "summary": "LDH model versus replicate performance: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "close: keys and labels are exact; rounded metrics are close and all main performance conclusions agree",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "classifier-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": 10,
+          "id": "TABLE-2:01",
+          "name": "Table 2 row count",
+          "observed": 10,
+          "passed": true,
+          "target_id": "TABLE-2"
+        },
+        {
+          "expected": true,
+          "id": "TABLE-2:02",
+          "name": "Table 2 conclusion gates",
+          "observed": true,
+          "passed": true,
+          "target_id": "TABLE-2"
+        }
+      ],
+      "description": "Binary LDH and MT classifier performance",
+      "deviation": "Both compiled and current layers match 19 of 20 entries at two decimals; compiled DINO MT AUROC is 0.875945 and current DINO MT PRAUC is 0.832443; the caption says ten splits while code pools five folds",
+      "evidence": "evidence/classifier-and-table-2.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "Published AUROC and PRAUC values for cell count, random, CellProfiler, CP-CNN, and DINO rows",
+      "group": "classifier",
+      "id": "TABLE-2",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet"
+      ],
+      "kind": "table",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Both compiled and current layers match 19 of 20 entries at two decimals; compiled DINO MT AUROC is 0.875945 and current DINO MT PRAUC is 0.832443; the caption says ten splits while code pools five folds",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_2_0_assay_metrics.ipynb",
+      "source": "main:p6:table-2",
+      "summary": "Binary LDH and MT classifier performance: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: values remain near published magnitude and Cell Painting still beats both baselines",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "classifier-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": 0.932625,
+          "id": "CLASSIFIER-001:01",
+          "name": "LDH morphology mean AUROC",
+          "observed": [
+            0.932625056254142,
+            5e-07
+          ],
+          "passed": true,
+          "target_id": "CLASSIFIER-001"
+        },
+        {
+          "expected": 0.753212,
+          "id": "CLASSIFIER-001:02",
+          "name": "LDH morphology mean PRAUC",
+          "observed": [
+            0.753212139721954,
+            5e-07
+          ],
+          "passed": true,
+          "target_id": "CLASSIFIER-001"
+        },
+        {
+          "expected": true,
+          "id": "CLASSIFIER-001:03",
+          "name": "LDH representations beat both baselines",
+          "observed": true,
+          "passed": true,
+          "target_id": "CLASSIFIER-001"
+        }
+      ],
+      "description": "Paired LDH classifier performance",
+      "deviation": "Current LDH morphology means are 0.932625 AUROC and 0.753212 PRAUC and all representations beat both baselines; split-count, keyed-universe, and localized DINO MT deviations are documented",
+      "evidence": "evidence/classifier-and-table-2.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "Mean AUROC about 0.93 and PRAUC about 0.75; Cell Painting beats baselines",
+      "group": "classifier",
+      "id": "CLASSIFIER-001",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Current LDH morphology means are 0.932625 AUROC and 0.753212 PRAUC and all representations beat both baselines; split-count, keyed-universe, and localized DINO MT deviations are documented",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_2_0_assay_metrics.ipynb",
+      "source": "main:p6:results-2.2.2",
+      "summary": "Paired LDH classifier performance: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: comparable hit-list scale and the same major pathway interpretation; exact hits and FDR values may drift",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "enrichment-summary.svg"
+      ],
+      "availability": "blocked",
+      "checks": [
+        {
+          "expected": 304,
+          "id": "ENRICH-001:01",
+          "name": "historical higher hit-list size",
+          "observed": 304,
+          "passed": true,
+          "target_id": "ENRICH-001"
+        },
+        {
+          "expected": 178,
+          "id": "ENRICH-001:02",
+          "name": "stored higher significant sets",
+          "observed": 178,
+          "passed": true,
+          "target_id": "ENRICH-001"
+        },
+        {
+          "expected": false,
+          "id": "ENRICH-001:03",
+          "name": "literal 480-target acceptance available",
+          "observed": false,
+          "passed": true,
+          "target_id": "ENRICH-001"
+        }
+      ],
+      "description": "Targets among wells better predicted by Cell Painting",
+      "deviation": "Code maps the Cell Painting label to 304 historical and 292 current Higher wells with 178 and 839 significant target sets; the 480 result and pathway mapping are absent, and signed residuals do not establish better prediction",
+      "evidence": "evidence/prediction-error-enrichment.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "blocked",
+      "expected": "About 138 wells and 480 enriched targets, including cell cycle, PI3K-Akt, MAPK, and p53 signals",
+      "group": "regression_enrichment",
+      "id": "ENRICH-001",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/err_higher_targets.csv",
+        "paper/evidence/prediction-error-enrichment.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "blocked",
+      "limitations": [
+        "Code maps the Cell Painting label to 304 historical and 292 current Higher wells with 178 and 839 significant target sets; the 480 result and pathway mapping are absent, and signed residuals do not establish better prediction",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+      "source": "main:p6:results-2.3",
+      "summary": "Targets among wells better predicted by Cell Painting: target-specific tracked-only checks completed with execution outcome blocked."
+    },
+    {
+      "acceptance": "close: hit-list scale is comparable and the no-enrichment conclusion holds",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "enrichment-summary.svg"
+      ],
+      "availability": "blocked",
+      "checks": [
+        {
+          "expected": 138,
+          "id": "ENRICH-002:01",
+          "name": "stored lower hit-list size",
+          "observed": 138,
+          "passed": true,
+          "target_id": "ENRICH-002"
+        },
+        {
+          "expected": 0,
+          "id": "ENRICH-002:02",
+          "name": "stored lower significant sets",
+          "observed": 0,
+          "passed": true,
+          "target_id": "ENRICH-002"
+        },
+        {
+          "expected": false,
+          "id": "ENRICH-002:03",
+          "name": "literal 304-well acceptance available",
+          "observed": false,
+          "passed": true,
+          "target_id": "ENRICH-002"
+        }
+      ],
+      "description": "Targets among wells better predicted by the technical baseline",
+      "deviation": "No enrichment holds for the 138 historical and 134 current Lower wells labeled technical baseline, while the 304 and 292 Higher wells are labeled Cell Painting and enriched; no source layer satisfies both acceptance conditions",
+      "evidence": "evidence/prediction-error-enrichment.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "blocked",
+      "expected": "About 304 wells with no significantly enriched targets",
+      "group": "regression_enrichment",
+      "id": "ENRICH-002",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/err_lower_targets.csv",
+        "paper/evidence/prediction-error-enrichment.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "blocked",
+      "limitations": [
+        "No enrichment holds for the 138 historical and 134 current Lower wells labeled technical baseline, while the 304 and 292 Higher wells are labeled Cell Painting and enriched; no source layer satisfies both acceptance conditions",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+      "source": "main:p6:results-2.3",
+      "summary": "Targets among wells better predicted by the technical baseline: target-specific tracked-only checks completed with execution outcome blocked."
+    },
+    {
+      "acceptance": "qualitative: similar discrepancy group and the same broad biological target classes; individual members may differ",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "enrichment-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": 261,
+          "id": "ENRICH-003:01",
+          "name": "MT higher hit-list size",
+          "observed": 261,
+          "passed": true,
+          "target_id": "ENRICH-003"
+        },
+        {
+          "expected": 147,
+          "id": "ENRICH-003:02",
+          "name": "MT higher significant sets",
+          "observed": 147,
+          "passed": true,
+          "target_id": "ENRICH-003"
+        },
+        {
+          "expected": {
+            "cyp_prefix_count": 8,
+            "htr_prefix_count": 6,
+            "transporters_present": [
+              "ABCB1",
+              "ABCG2",
+              "SLCO1B1",
+              "SLCO1B3"
+            ]
+          },
+          "id": "ENRICH-003:03",
+          "name": "MT higher named target classes",
+          "observed": {
+            "cyp_prefix_count": 8,
+            "htr_prefix_count": 6,
+            "transporters_present": [
+              "ABCB1",
+              "ABCG2",
+              "SLCO1B1",
+              "SLCO1B3"
+            ]
+          },
+          "passed": true,
+          "target_id": "ENRICH-003"
+        }
+      ],
+      "description": "Higher morphology-predicted than observed MT cases",
+      "deviation": "Stored 261-well group and 147 significant sets support all named CYPs and transporters plus six HTR sets; current selector gives 262 wells, no DRD or adrenergic set is significant, and two named compounds lack significant overlaps",
+      "evidence": "evidence/mt-discrepancy-enrichment.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "261 wells enriched for 147 proteins, including CYPs, neurotransmitter receptors, and xenobiotic transporters",
+      "group": "regression_enrichment",
+      "id": "ENRICH-003",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/mtt_higher_targets.csv",
+        "paper/evidence/mt-discrepancy-enrichment.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Stored 261-well group and 147 significant sets support all named CYPs and transporters plus six HTR sets; current selector gives 262 wells, no DRD or adrenergic set is significant, and two named compounds lack significant overlaps",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/2_2_outlier_enrichment_analysis.ipynb",
+      "source": "main:p6-p7:results-2.3",
+      "summary": "Higher morphology-predicted than observed MT cases: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "qualitative: similar discrepancy group and the same broad biological processes",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "enrichment-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": 131,
+          "id": "ENRICH-004:01",
+          "name": "MT lower hit-list size",
+          "observed": 131,
+          "passed": true,
+          "target_id": "ENRICH-004"
+        },
+        {
+          "expected": 107,
+          "id": "ENRICH-004:02",
+          "name": "MT lower significant sets",
+          "observed": 107,
+          "passed": true,
+          "target_id": "ENRICH-004"
+        },
+        {
+          "expected": {
+            "cyp_prefix_count": 3,
+            "psm_prefix_count": 18
+          },
+          "id": "ENRICH-004:03",
+          "name": "MT lower named target classes",
+          "observed": {
+            "cyp_prefix_count": 3,
+            "psm_prefix_count": 18
+          },
+          "passed": true,
+          "target_id": "ENRICH-004"
+        }
+      ],
+      "description": "Lower morphology-predicted than observed MT cases",
+      "deviation": "Stored 131-well group supports 18 proteasome sets and three CYP sets; current selector gives 142 wells, carfilzomib is absent from overlaps, and three process labels lack repository mappings",
+      "evidence": "evidence/mt-discrepancy-enrichment.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "131 wells enriched for proteasome inhibition, xenobiotic metabolism, bile acid synthesis, cell stress, and apoptosis",
+      "group": "regression_enrichment",
+      "id": "ENRICH-004",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/mtt_lower_targets.csv",
+        "paper/evidence/mt-discrepancy-enrichment.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Stored 131-well group supports 18 proteasome sets and three CYP sets; current selector gives 142 wells, carfilzomib is absent from overlaps, and three process labels lack repository mappings",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/2_2_outlier_enrichment_analysis.ipynb",
+      "source": "main:p6-p7:results-2.3",
+      "summary": "Lower morphology-predicted than observed MT cases: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: same overlap definition and count within ordinary source-version drift",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "toxcast-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": 963,
+          "id": "TOXCAST-001:01",
+          "name": "stored ToxCast annotation-ID union, not tested overlap",
+          "observed": 963,
+          "passed": true,
+          "target_id": "TOXCAST-001"
+        },
+        {
+          "expected": 0.89,
+          "id": "TOXCAST-001:02",
+          "name": "stored annotation-union/library-denominator arithmetic, not tested overlap",
+          "observed": [
+            0.887557603686636,
+            0.005
+          ],
+          "passed": true,
+          "target_id": "TOXCAST-001"
+        },
+        {
+          "expected": 670,
+          "id": "TOXCAST-001:03",
+          "name": "documented tested-library intersection IDs",
+          "observed": 670,
+          "passed": true,
+          "target_id": "TOXCAST-001"
+        },
+        {
+          "expected": 61.751152,
+          "id": "TOXCAST-001:04",
+          "name": "documented tested-library intersection percentage",
+          "observed": [
+            61.7511520737327,
+            5e-07
+          ],
+          "passed": true,
+          "target_id": "TOXCAST-001"
+        },
+        {
+          "expected": true,
+          "id": "TOXCAST-001:05",
+          "name": "963 is an annotation union rather than a tested-library join",
+          "observed": true,
+          "passed": true,
+          "target_id": "TOXCAST-001"
+        }
+      ],
+      "description": "OASIS and ToxCast overlap",
+      "deviation": "The stored 963-ID union gives 88.755760 percent of 1085, but it is not intersected with tested metadata; only 670 tested IDs overlap the pinned ToxCast union",
+      "evidence": "evidence/toxcast-curation-and-figure-s3.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "963 tested compounds, or 89 percent, overlap ToxCast",
+      "group": "toxcast",
+      "id": "TOXCAST-001",
+      "inputs": [
+        "1_snakemake/inputs/annotations/toxcast_cellbased_binary.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cellbased_info.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cellfree_binary.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cellfree_info.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cytotox_info.parquet",
+        "paper/evidence/toxcast-curation-and-figure-s3.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "The stored 963-ID union gives 88.755760 percent of 1085, but it is not intersected with tested metadata; only 670 tested IDs overlap the pinned ToxCast union"
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb",
+      "source": "main:p7:results-3",
+      "summary": "OASIS and ToxCast overlap: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "exact: endpoint category keys and counts agree for the pinned input",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "toxcast-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": {
+            "cellbased": 292,
+            "cellfree": 72,
+            "cytotox": 48
+          },
+          "id": "TOXCAST-002:01",
+          "name": "ToxCast source endpoint counts",
+          "observed": {
+            "cellbased": 292,
+            "cellfree": 72,
+            "cytotox": 48
+          },
+          "passed": true,
+          "target_id": "TOXCAST-002"
+        },
+        {
+          "expected": {
+            "cellbased": 292,
+            "cellfree": 72,
+            "cytotox": 38
+          },
+          "id": "TOXCAST-002:02",
+          "name": "classification-ready binary endpoint counts",
+          "observed": {
+            "cellbased": 292,
+            "cellfree": 72,
+            "cytotox": 38
+          },
+          "passed": true,
+          "target_id": "TOXCAST-002"
+        }
+      ],
+      "description": "Curated ToxCast endpoint counts",
+      "deviation": "Source metadata have 48, 292, and 72 exact keys, but class support retains 38 cytotoxicity keys and enforcing the stated 100 uM rule would reduce cell-based endpoints to 291",
+      "evidence": "evidence/toxcast-curation-and-figure-s3.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "48 cytotoxicity, 292 non-cytotoxicity cell-based, and 72 cell-free endpoints",
+      "group": "toxcast",
+      "id": "TOXCAST-002",
+      "inputs": [
+        "1_snakemake/inputs/annotations/toxcast_cellbased_binary.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cellbased_info.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cellfree_binary.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cellfree_info.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cytotox_info.parquet"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Source metadata have 48, 292, and 72 exact keys, but class support retains 38 cytotoxicity keys and enforcing the stated 100 uM rule would reduce cell-based endpoints to 291"
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb",
+      "source": "main:p7:results-3.1",
+      "summary": "Curated ToxCast endpoint counts: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: proportions and rankings remain broadly comparable; record source-version changes",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "toxcast-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": {
+            "kidney": 35,
+            "liver": 151,
+            "vascular": 63
+          },
+          "id": "TOXCAST-003:01",
+          "name": "cell-based tissue composition",
+          "observed": {
+            "kidney": 35,
+            "liver": 151,
+            "vascular": 63
+          },
+          "passed": true,
+          "target_id": "TOXCAST-003"
+        },
+        {
+          "expected": {
+            "binding": 37,
+            "enzymatic activity": 35
+          },
+          "id": "TOXCAST-003:02",
+          "name": "cell-free assay composition",
+          "observed": {
+            "binding": 37,
+            "enzymatic activity": 35
+          },
+          "passed": true,
+          "target_id": "TOXCAST-003"
+        },
+        {
+          "expected": {
+            "cyp": 11,
+            "gpcr": 21,
+            "nuclear receptor": 10
+          },
+          "id": "TOXCAST-003:03",
+          "name": "cell-free target-family composition",
+          "observed": {
+            "cyp": 11,
+            "gpcr": 21,
+            "nuclear receptor": 10
+          },
+          "passed": true,
+          "target_id": "TOXCAST-003"
+        },
+        {
+          "expected": {
+            "cellbased": 306,
+            "cellfree": 33,
+            "cytotox": 346
+          },
+          "id": "TOXCAST-003:04",
+          "name": "median compounds tested per endpoint",
+          "observed": {
+            "cellbased": 306,
+            "cellfree": 33,
+            "cytotox": 346
+          },
+          "passed": true,
+          "target_id": "TOXCAST-003"
+        },
+        {
+          "expected": {
+            "cellbased": 0.0711613553,
+            "cellfree": 0.4134295228,
+            "cytotox": 0.2068348801
+          },
+          "id": "TOXCAST-003:05",
+          "name": "median endpoint active fractions",
+          "observed": {
+            "cellbased": 0.071161355334425,
+            "cellfree": 0.413429522752497,
+            "cytotox": 0.206834880123743
+          },
+          "passed": true,
+          "target_id": "TOXCAST-003"
+        }
+      ],
+      "description": "ToxCast endpoint composition and activity summaries",
+      "deviation": "All displayed values and rankings match; family percentages use all 292 cell-based endpoints and cytotoxicity medians use the 38 post-support endpoints rather than all 48 source categories",
+      "evidence": "evidence/toxcast-curation-and-figure-s3.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "Published tissue, target-family, overlap, and active-fraction summaries for cell-based and cell-free endpoints",
+      "group": "toxcast",
+      "id": "TOXCAST-003",
+      "inputs": [
+        "1_snakemake/inputs/annotations/toxcast_cellbased_binary.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cellbased_info.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cellfree_binary.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cellfree_info.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cytotox_info.parquet"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "All displayed values and rankings match; family percentages use all 292 cell-based endpoints and cytotoxicity medians use the 38 post-support endpoints rather than all 48 source categories"
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb",
+      "source": "main:p7:results-3.1",
+      "summary": "ToxCast endpoint composition and activity summaries: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "qualitative: same assay-type ordering and broadly similar distributions; no pixel match required",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "classifier-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": {
+            "axiom": 2,
+            "toxcast_cellbased": 267,
+            "toxcast_cellfree": 53,
+            "toxcast_cytotox": 34
+          },
+          "id": "FIG-3AB:01",
+          "name": "classifier modeled endpoint distributions",
+          "observed": {
+            "axiom": 2,
+            "toxcast_cellbased": 267,
+            "toxcast_cellfree": 53,
+            "toxcast_cytotox": 34
+          },
+          "passed": true,
+          "target_id": "FIG-3AB"
+        },
+        {
+          "expected": {
+            "axiom": {
+              "auroc": 0.901547,
+              "prauc": 0.805566
+            },
+            "toxcast_cellbased": {
+              "auroc": 0.607226,
+              "prauc": 0.14484
+            },
+            "toxcast_cellfree": {
+              "auroc": 0.532086,
+              "prauc": 0.454015
+            },
+            "toxcast_cytotox": {
+              "auroc": 0.73721,
+              "prauc": 0.477455
+            }
+          },
+          "id": "FIG-3AB:02",
+          "name": "all-concentration CellProfiler distribution summaries",
+          "observed": {
+            "axiom": {
+              "auroc": 0.90154710075502,
+              "prauc": 0.805566469136103
+            },
+            "toxcast_cellbased": {
+              "auroc": 0.607226107226107,
+              "prauc": 0.144839974879456
+            },
+            "toxcast_cellfree": {
+              "auroc": 0.532085561497326,
+              "prauc": 0.454015201822219
+            },
+            "toxcast_cytotox": {
+              "auroc": 0.737210441587034,
+              "prauc": 0.477454853975985
+            }
+          },
+          "passed": true,
+          "target_id": "FIG-3AB"
+        }
+      ],
+      "description": "AUROC and PRAUC distributions across assay types",
+      "deviation": "Ordering and distributions agree, but caption counts 48/292/72 are source counts rather than the 34/267/53 modeled endpoint counts",
+      "evidence": "evidence/classifier-results.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "Paired MT and LDH perform best, followed by ToxCast cytotoxicity and cell-based assays, with cell-free assays near random",
+      "group": "classifier",
+      "id": "FIG-3AB",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet"
+      ],
+      "kind": "figure",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Ordering and distributions agree, but caption counts 48/292/72 are source counts rather than the 34/267/53 modeled endpoint counts",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_2_1_compare_endpoint_types.ipynb",
+      "source": "main:p8:figure-3a-b",
+      "summary": "AUROC and PRAUC distributions across assay types: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "qualitative: effect directions and main significance conclusions agree",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "classifier-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": true,
+          "id": "FIG-3C:01",
+          "name": "cell-based versus cell-free baseline conclusion",
+          "observed": true,
+          "passed": true,
+          "target_id": "FIG-3C"
+        }
+      ],
+      "description": "Classifier differences from random and cell-count baselines",
+      "deviation": "Matched effects support the conclusion, but the panel mixes endpoint universes and tests and the six-row cell-free PRAUC mixed model does not converge",
+      "evidence": "evidence/classifier-results.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "Morphology improves cytotoxicity and cell-based prediction over random; cell-free prediction does not materially improve",
+      "group": "classifier",
+      "id": "FIG-3C",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet"
+      ],
+      "kind": "figure",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Matched effects support the conclusion, but the panel mixes endpoint universes and tests and the six-row cell-free PRAUC mixed model does not converge",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_2_1_compare_endpoint_types.ipynb",
+      "source": "main:p8:figure-3c",
+      "summary": "Classifier differences from random and cell-count baselines: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: small improvements remain small and the overall no-practical-improvement conclusion holds",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "classifier-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": true,
+          "id": "FILTER-001:01",
+          "name": "allpod versus all effects remain small",
+          "observed": true,
+          "passed": true,
+          "target_id": "FILTER-001"
+        }
+      ],
+      "description": "Filtering to bioactive concentrations",
+      "deviation": "Compiled/current AUROC effects are 0.0386/0.0374 and 0.0194/0.0203, but the published FDR values do not reproduce from the committed notebook",
+      "evidence": "evidence/classifier-results.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "AUROC increases about 0.04 for ToxCast cytotoxicity and 0.02 for cell-based assays; other AUROC and all PRAUC comparisons show no material improvement",
+      "group": "classifier",
+      "id": "FILTER-001",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Compiled/current AUROC effects are 0.0386/0.0374 and 0.0194/0.0203, but the published FDR values do not reproduce from the committed notebook",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_2_2_compare_concs_reps.ipynb",
+      "source": "main:p7:results-3.2.1",
+      "summary": "Filtering to bioactive concentrations: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "qualitative: effect directions and no-improvement conclusion agree",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "classifier-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": -0.124974386867459,
+          "id": "FILTER-002:01",
+          "name": "Axiom allpodcc minus allpod mean AUROC",
+          "observed": -0.124974386867459,
+          "passed": true,
+          "target_id": "FILTER-002"
+        },
+        {
+          "expected": -0.372361412793057,
+          "id": "FILTER-002:02",
+          "name": "Axiom allpodcc minus allpod mean PRAUC",
+          "observed": -0.372361412793057,
+          "passed": true,
+          "target_id": "FILTER-002"
+        },
+        {
+          "expected": {
+            "toxcast_cellbased": -0.007970189,
+            "toxcast_cellfree": 0.0134291664,
+            "toxcast_cytotox": -0.0885859687
+          },
+          "id": "FILTER-002:03",
+          "name": "allpodcc minus allpod mean AUROC",
+          "observed": {
+            "toxcast_cellbased": -0.00797018904098499,
+            "toxcast_cellfree": 0.0134291664332844,
+            "toxcast_cytotox": -0.0885859686562654
+          },
+          "passed": true,
+          "target_id": "FILTER-002"
+        },
+        {
+          "expected": {
+            "toxcast_cellbased": -0.0065967963,
+            "toxcast_cellfree": 0.0051519574,
+            "toxcast_cytotox": -0.1671635603
+          },
+          "id": "FILTER-002:04",
+          "name": "allpodcc minus allpod mean PRAUC",
+          "observed": {
+            "toxcast_cellbased": -0.00659679632924061,
+            "toxcast_cellfree": 0.00515195738908095,
+            "toxcast_cytotox": -0.167163560277532
+          },
+          "passed": true,
+          "target_id": "FILTER-002"
+        },
+        {
+          "expected": true,
+          "id": "FILTER-002:05",
+          "name": "Axiom and cytotoxic effects are negative while cell-based and cell-free effects remain below 0.02",
+          "observed": true,
+          "passed": true,
+          "target_id": "FILTER-002"
+        }
+      ],
+      "description": "Filtering out cytotoxic concentrations",
+      "deviation": "Cytotoxicity performance worsens and other effects remain negligible, with expected numerical drift in POD-derived strategies",
+      "evidence": "evidence/classifier-results.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "Performance worsens for cytotoxicity categories and does not improve cell-based or cell-free prediction",
+      "group": "classifier",
+      "id": "FILTER-002",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Cytotoxicity performance worsens and other effects remain negligible, with expected numerical drift in POD-derived strategies",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_2_2_compare_concs_reps.ipynb",
+      "source": "main:p7:results-3.2.1",
+      "summary": "Filtering out cytotoxic concentrations: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "qualitative: same practical conclusion and similar assay-type patterns",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "classifier-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": true,
+          "id": "FIG-4A:01",
+          "name": "all-concentration strategy conclusion",
+          "observed": true,
+          "passed": true,
+          "target_id": "FIG-4A"
+        }
+      ],
+      "description": "Classifier AUROC across concentration consensus strategies",
+      "deviation": "Distribution directions and the practical conclusion agree, but modeled endpoint counts differ from captions and POD-filtered values drift",
+      "evidence": "evidence/classifier-results.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "All-concentration profiles perform as well as or better than filtered alternatives overall",
+      "group": "classifier",
+      "id": "FIG-4A",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet"
+      ],
+      "kind": "figure",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Distribution directions and the practical conclusion agree, but modeled endpoint counts differ from captions and POD-filtered values drift",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_2_2_compare_concs_reps.ipynb",
+      "source": "main:p9:figure-4a",
+      "summary": "Classifier AUROC across concentration consensus strategies: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: performance remains similar overall and any DINO advantage stays small",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "classifier-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": {
+            "mean_difference": 0.01079046,
+            "median_difference": 0.01587302
+          },
+          "id": "REPRESENTATION-001:01",
+          "name": "DINO versus CP-CNN cell-based AUROC effects",
+          "observed": {
+            "mean_difference": 0.010790455248826,
+            "median_difference": 0.0158730158730159
+          },
+          "passed": true,
+          "target_id": "REPRESENTATION-001"
+        },
+        {
+          "expected": 0.02209021,
+          "id": "REPRESENTATION-001:02",
+          "name": "DINO versus CellProfiler median cell-based AUROC",
+          "observed": 0.0220902090209021,
+          "passed": true,
+          "target_id": "REPRESENTATION-001"
+        }
+      ],
+      "description": "Alternative image representations",
+      "deviation": "DINO median advantages are 0.0221 and 0.0159, but mean effects are about 0.011 and published p-values do not reproduce",
+      "evidence": "evidence/classifier-results.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "Representations perform similarly; DINO cell-based AUROC is about 0.02 higher than CellProfiler and CP-CNN",
+      "group": "classifier",
+      "id": "REPRESENTATION-001",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "DINO median advantages are 0.0221 and 0.0159, but mean effects are about 0.011 and published p-values do not reproduce",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_2_3_compare_endpoints_detail.ipynb; 2_downstream_analysis/manuscript_notebooks/3_2_2_compare_concs_reps.ipynb",
+      "source": "main:p7:results-3.2.2",
+      "summary": "Alternative image representations: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "qualitative: same near-equivalence and assay-type ordering; no pixel match required",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "classifier-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": true,
+          "id": "FIG-4B:01",
+          "name": "representation effects remain practically small",
+          "observed": true,
+          "passed": true,
+          "target_id": "FIG-4B"
+        }
+      ],
+      "description": "Classifier AUROC across CellProfiler, CP-CNN, and DINO",
+      "deviation": "Near-equivalence and ordering agree, with one small ToxCast cytotoxicity Tukey contrast at p = 0.0493",
+      "evidence": "evidence/classifier-results.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "Published representation distributions are very similar within assay types",
+      "group": "classifier",
+      "id": "FIG-4B",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet"
+      ],
+      "kind": "figure",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Near-equivalence and ordering agree, with one small ToxCast cytotoxicity Tukey contrast at p = 0.0493",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_2_3_compare_endpoints_detail.ipynb; 2_downstream_analysis/manuscript_notebooks/3_2_2_compare_concs_reps.ipynb",
+      "source": "main:p9:figure-4b",
+      "summary": "Classifier AUROC across CellProfiler, CP-CNN, and DINO: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "exact: image identity and inventory counts agree when source images are available",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg"
+      ],
+      "availability": "out-of-scope",
+      "checks": [
+        {
+          "expected": true,
+          "id": "SFIG-1:01",
+          "name": "tracked navigation image identity trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "SFIG-1"
+        },
+        {
+          "expected": false,
+          "id": "SFIG-1:02",
+          "name": "external source image available",
+          "observed": false,
+          "passed": true,
+          "target_id": "SFIG-1"
+        }
+      ],
+      "description": "Representative Cell Painting image",
+      "deviation": "Existing recipe excludes external image download and missing output setup",
+      "evidence": "-",
+      "evidence_strength": "unavailable",
+      "execution_outcome": "out-of-scope",
+      "expected": "Plate 41002889, well L12, site 6; representative of 191754 images including 43641 DMSO controls",
+      "group": "external_image",
+      "id": "SFIG-1",
+      "inputs": [
+        "paper/figures/figure-s1.jpg",
+        "paper/paper.md"
+      ],
+      "kind": "figure",
+      "ledger_status": "out-of-scope",
+      "limitations": [
+        "Existing recipe excludes external image download and missing output setup",
+        "The raw source image is external and excluded from tracked-only execution."
+      ],
+      "producer": "2_downstream_analysis/other_notebooks/Plot_images.ipynb",
+      "source": "supp:p2:figure-s1",
+      "summary": "Representative Cell Painting image: target-specific tracked-only checks completed with execution outcome out-of-scope."
+    },
+    {
+      "acceptance": "qualitative: same major spatial and cell-count patterns; exact clustering order is not required",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "enrichment-summary.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "SFIG-2:01",
+          "name": "Figure S2 panel documentary trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "SFIG-2"
+        },
+        {
+          "expected": false,
+          "id": "SFIG-2:02",
+          "name": "Figure S2 numerical acceptance rerun",
+          "observed": false,
+          "passed": true,
+          "target_id": "SFIG-2"
+        }
+      ],
+      "description": "Technical factors and paired-assay prediction diagnostics",
+      "deviation": "All panel directions and major patterns hold; current base selects 292 versus camera-ready text n = 138, and the notebook label is a signed-residual threshold rather than a formal significance test",
+      "evidence": "evidence/regression-and-figure-s2.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "Well-position effects, normalized readout distributions, and DINO similarity clustergram support the technical-factor interpretation",
+      "group": "regression_enrichment",
+      "id": "SFIG-2",
+      "inputs": [
+        "paper/paper.md",
+        "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+        "2_downstream_analysis/other_notebooks/01_checkwelleffects.ipynb",
+        "paper/evidence/regression-and-figure-s2.md"
+      ],
+      "kind": "figure",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "All panel directions and major patterns hold; current base selects 292 versus camera-ready text n = 138, and the notebook label is a signed-residual threshold rather than a formal significance test",
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb; 2_downstream_analysis/other_notebooks/01_checkwelleffects.ipynb",
+      "source": "supp:p3:figure-s2",
+      "summary": "Technical factors and paired-assay prediction diagnostics: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "qualitative: same procedure, category coverage, and major clustered patterns",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "toxcast-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": {
+            "cell_categories": 12,
+            "complete_compounds": 839,
+            "tissue_categories": 6
+          },
+          "id": "SFIG-3:01",
+          "name": "cytotoxicity heatmap summary",
+          "observed": {
+            "cell_categories": 12,
+            "complete_compounds": 839,
+            "tissue_categories": 6
+          },
+          "passed": true,
+          "target_id": "SFIG-3"
+        }
+      ],
+      "description": "ToxCast binarization and cytotoxicity patterns",
+      "deviation": "The 12-cell and 6-tissue heatmaps preserve broad concordance and selective patterns; the image is labeled B and C while the supplemental legend incorrectly says C and D",
+      "evidence": "evidence/toxcast-curation-and-figure-s3.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "Published binarization procedure and broad cell-line and tissue cytotoxicity clusters",
+      "group": "toxcast",
+      "id": "SFIG-3",
+      "inputs": [
+        "1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet",
+        "paper/evidence/toxcast-curation-and-figure-s3.md"
+      ],
+      "kind": "figure",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "The 12-cell and 6-tissue heatmaps preserve broad concordance and selective patterns; the image is labeled B and C while the supplemental legend incorrectly says C and D"
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb",
+      "source": "supp:p4:figure-s3",
+      "summary": "ToxCast binarization and cytotoxicity patterns: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "qualitative: same no-material-improvement conclusion and similar distributions",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "classifier-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": true,
+          "id": "SFIG-4:01",
+          "name": "PRAUC filtering and representation practical conclusion",
+          "observed": true,
+          "passed": true,
+          "target_id": "SFIG-4"
+        }
+      ],
+      "description": "Classifier PRAUC across concentration and image representations",
+      "deviation": "PRAUC shows no practical improvement, while POD-filtered values drift and small unadjusted representation tests differ from Tukey results",
+      "evidence": "evidence/classifier-results.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "Filtering and representation comparisons do not materially improve PRAUC",
+      "group": "classifier",
+      "id": "SFIG-4",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet"
+      ],
+      "kind": "figure",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "PRAUC shows no practical improvement, while POD-filtered values drift and small unadjusted representation tests differ from Tukey results",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_2_2_compare_concs_reps.ipynb; 2_downstream_analysis/manuscript_notebooks/3_2_3_compare_endpoints_detail.ipynb",
+      "source": "supp:p5:figure-s4",
+      "summary": "Classifier PRAUC across concentration and image representations: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "exact: stable compound identifiers and tested-library membership agree; annotation-only differences are documented",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": 1085,
+          "id": "TABLE-S1:01",
+          "name": "Table S1 rows",
+          "observed": 1085,
+          "passed": true,
+          "target_id": "TABLE-S1"
+        },
+        {
+          "expected": 966,
+          "id": "TABLE-S1:02",
+          "name": "Table S1 stable IDs",
+          "observed": 966,
+          "passed": true,
+          "target_id": "TABLE-S1"
+        },
+        {
+          "expected": 119,
+          "id": "TABLE-S1:03",
+          "name": "Table S1 blank IDs",
+          "observed": 119,
+          "passed": true,
+          "target_id": "TABLE-S1"
+        }
+      ],
+      "description": "OASIS compound list",
+      "deviation": "All 966 workbook OASIS IDs and 119 blinded labels map to metadata, but tested metadata additionally has Ribociclib; Vasopressin has two IDs, one workbook name is encoding-corrupted, and 176 preferred-name labels differ",
+      "evidence": "evidence/remaining-paper-reproduction-targets.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "Published compound identities and annotations used to define the study library",
+      "group": "sources_design",
+      "id": "TABLE-S1",
+      "inputs": [
+        "paper/sources/table-s1.xlsx",
+        "1_snakemake/inputs/annotations/v5_oasis_03Sept2024_simple.csv"
+      ],
+      "kind": "table",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "All 966 workbook OASIS IDs and 119 blinded labels map to metadata, but tested metadata additionally has Ribociclib; Vasopressin has two IDs, one workbook name is encoding-corrupted, and 176 preferred-name labels differ"
+      ],
+      "producer": "paper/sources/table-s1.xlsx; 1_snakemake/inputs/metadata/metadata.parquet",
+      "source": "supp:table-s1",
+      "summary": "OASIS compound list: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: schemas and semantic keys agree; coverage, median differences, validity, and material tail satisfy the existing POD gates",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": 796,
+          "id": "TABLE-S2:01",
+          "name": "Table S2 semantic keys",
+          "observed": 796,
+          "passed": true,
+          "target_id": "TABLE-S2"
+        },
+        {
+          "expected": 1e-12,
+          "id": "TABLE-S2:02",
+          "name": "Table S2 maximum POD difference",
+          "observed": 4.40536496171262e-13,
+          "passed": true,
+          "target_id": "TABLE-S2"
+        }
+      ],
+      "description": "Cytotoxicity points of departure",
+      "deviation": "Published workbook keys match all 796 committed semantic rows and POD values agree to spreadsheet precision; regenerated gates pass with documented drift",
+      "evidence": "evidence/published-table-bridge.md; ../REPRODUCING.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "Published MT, cell-count, and LDH POD results",
+      "group": "activity_pods",
+      "id": "TABLE-S2",
+      "inputs": [
+        "paper/sources/table-s2.xlsx",
+        "2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv"
+      ],
+      "kind": "table",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Published workbook keys match all 796 committed semantic rows and POD values agree to spreadsheet precision; regenerated gates pass with documented drift"
+      ],
+      "producer": "2_downstream_analysis/compiled_results/SI_tables",
+      "source": "supp:table-s2",
+      "summary": "Cytotoxicity points of departure: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: schemas and semantic keys agree; coverage, median differences, validity, and material tail satisfy the existing POD gates",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": 10935,
+          "id": "TABLE-S3:01",
+          "name": "Table S3 semantic keys",
+          "observed": 10935,
+          "passed": true,
+          "target_id": "TABLE-S3"
+        },
+        {
+          "expected": 10935,
+          "id": "TABLE-S3:02",
+          "name": "Table S3 exact bioactivity flags",
+          "observed": 10935,
+          "passed": true,
+          "target_id": "TABLE-S3"
+        }
+      ],
+      "description": "Cell Painting points of departure",
+      "deviation": "Published workbook keys match all 10935 nonblank committed semantic rows and POD values agree to spreadsheet precision; regenerated gates pass with documented drift",
+      "evidence": "evidence/published-table-bridge.md; ../REPRODUCING.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "Published CellProfiler, CP-CNN, and DINO POD results",
+      "group": "activity_pods",
+      "id": "TABLE-S3",
+      "inputs": [
+        "paper/sources/table-s3.xlsx",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv"
+      ],
+      "kind": "table",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Published workbook keys match all 10935 nonblank committed semantic rows and POD values agree to spreadsheet precision; regenerated gates pass with documented drift"
+      ],
+      "producer": "2_downstream_analysis/compiled_results/SI_tables",
+      "source": "supp:table-s3",
+      "summary": "Cell Painting points of departure: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: compound identities and main assay-activity relationships agree; small POD pass-call drift is documented",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": 1086,
+          "id": "TABLE-S4:01",
+          "name": "Table S4 semantic keys",
+          "observed": 1086,
+          "passed": true,
+          "target_id": "TABLE-S4"
+        },
+        {
+          "expected": 1086,
+          "id": "TABLE-S4:02",
+          "name": "Table S4 exact tracked hit rows",
+          "observed": 1086,
+          "passed": true,
+          "target_id": "TABLE-S4"
+        }
+      ],
+      "description": "Activity summary across all assays",
+      "deviation": "Published workbook matches all 1086 committed hit-summary rows; regenerated keys are exact and 1070 of 1086 complete hit calls agree",
+      "evidence": "evidence/published-table-bridge.md; ../REPRODUCING.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "Published cross-assay compound activity summary including the 121-compound all-POD subset",
+      "group": "activity_pods",
+      "id": "TABLE-S4",
+      "inputs": [
+        "paper/sources/table-s4.xlsx",
+        "2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv"
+      ],
+      "kind": "table",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Published workbook matches all 1086 committed hit-summary rows; regenerated keys are exact and 1070 of 1086 complete hit calls agree"
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/4_1_results_tables_SI.ipynb",
+      "source": "supp:table-s4",
+      "summary": "Activity summary across all assays: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "close: same broad assay set, concentration range, and metabolic-disruption interpretation",
+      "acceptance_class": "close",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "toxcast-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": 12,
+          "id": "TABLE-S5:01",
+          "name": "Table S5 nuclear-receptor assays",
+          "observed": 12,
+          "passed": true,
+          "target_id": "TABLE-S5"
+        },
+        {
+          "expected": 1.648,
+          "id": "TABLE-S5:02",
+          "name": "Table S5 nuclear-receptor AC50 minimum",
+          "observed": [
+            1.64808942,
+            0.001
+          ],
+          "passed": true,
+          "target_id": "TABLE-S5"
+        },
+        {
+          "expected": 45.0,
+          "id": "TABLE-S5:03",
+          "name": "Table S5 nuclear-receptor AC50 maximum",
+          "observed": 45.0,
+          "passed": true,
+          "target_id": "TABLE-S5"
+        },
+        {
+          "expected": 8,
+          "id": "TABLE-S5:04",
+          "name": "Table S5 retained pinned receptor assays",
+          "observed": 8,
+          "passed": true,
+          "target_id": "TABLE-S5"
+        },
+        {
+          "expected": 0,
+          "id": "TABLE-S5:05",
+          "name": "Table S5 source cytotoxicity hits",
+          "observed": 0,
+          "passed": true,
+          "target_id": "TABLE-S5"
+        },
+        {
+          "expected": "active finite MMP signal",
+          "id": "TABLE-S5:06",
+          "name": "Table S5 MMP activity evidence",
+          "observed": {
+            "ac50_um": 14.8795940571651,
+            "hitcall_above_0_9": true
+          },
+          "passed": true,
+          "target_id": "TABLE-S5"
+        }
+      ],
+      "description": "ToxCast activity for 2-ethylanthraquinone",
+      "deviation": "Workbook has 12 receptor hits at 1.648-45 uM; pinned inputs retain 8 of 12, confirm zero cytotoxicity hits across 102 tests, and support MMP activity without proving directional uncoupling",
+      "evidence": "evidence/remaining-paper-reproduction-targets.md",
+      "evidence_strength": "source-recomputation",
+      "execution_outcome": "checked",
+      "expected": "Activity in 12 nuclear-receptor assays at about 1-45 uM without cytotoxicity, plus mitochondrial depolarization signal",
+      "group": "toxcast",
+      "id": "TABLE-S5",
+      "inputs": [
+        "paper/sources/table-s5.xlsx",
+        "1_snakemake/inputs/annotations/toxcast_cellbased_info.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cytotox_info.parquet",
+        "1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet"
+      ],
+      "kind": "table",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Workbook has 12 receptor hits at 1.648-45 uM; pinned inputs retain 8 of 12, confirm zero cytotoxicity hits across 102 tests, and support MMP activity without proving directional uncoupling"
+      ],
+      "producer": "paper/sources/table-s5.xlsx; 2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb",
+      "source": "supp:table-s5",
+      "summary": "ToxCast activity for 2-ethylanthraquinone: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "exact: resource names, versions, deposited-data paths, and identifiers agree with the published table",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "TABLE-KEY-RESOURCES:01",
+          "name": "Key Resources transcription trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "TABLE-KEY-RESOURCES"
+        },
+        {
+          "expected": 34,
+          "id": "TABLE-KEY-RESOURCES:02",
+          "name": "Key Resources Markdown data rows",
+          "observed": 34,
+          "passed": true,
+          "target_id": "TABLE-KEY-RESOURCES"
+        }
+      ],
+      "description": "Published biological samples, reagents, deposited data, software, and equipment",
+      "deviation": "Transcribed from the camera-ready PDF",
+      "evidence": "paper.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "All Key Resources Table rows and identifiers from the camera-ready paper",
+      "group": "sources_design",
+      "id": "TABLE-KEY-RESOURCES",
+      "inputs": [
+        "paper/paper.md",
+        "paper/sources/main.pdf"
+      ],
+      "kind": "table",
+      "ledger_status": "reproduced",
+      "limitations": [
+        "Transcribed from the camera-ready PDF",
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "paper/paper.md; paper/sources/main.pdf",
+      "source": "main:e1-e2:key-resources-table",
+      "summary": "Published biological samples, reagents, deposited data, software, and equipment: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "exact: model families and thresholds match; the known selection-rule discrepancy is explicit",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "METHOD-POD:01",
+          "name": "POD implementation and deviation trace",
+          "observed": {
+            "compound_minimum_pod": true,
+            "dmso_control": true,
+            "documented_ci_ratio_threshold_40": true,
+            "documented_dmso_95th_percentile_benchmark": true,
+            "documented_eight_model_names": true,
+            "documented_highest_tested_concentration_filter": true,
+            "known_selection_deviation_traced": true,
+            "morphology_residual_sd_selection": true,
+            "paired_assay_scorespod_default": true
+          },
+          "passed": true,
+          "target_id": "METHOD-POD"
+        }
+      ],
+      "description": "Concentration-response model and POD selection",
+      "deviation": "Morphology selects minimum residual SD; cell count, MT, and LDH use scoresPOD default rounded-AIC selection despite the paper's general residual-SD wording",
+      "evidence": "evidence/method-deviations.md; ../REPRODUCING.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "Paper describes eight named models, residual-SD selection, DMSO 95th-percentile benchmark, and confidence-ratio and concentration filters",
+      "group": "activity_pods",
+      "id": "METHOD-POD",
+      "inputs": [
+        "1_snakemake/concresponse/fit_curves.R",
+        "1_snakemake/concresponse/fit_curves_meta.R",
+        "1_snakemake/concresponse/select_pod.R",
+        "paper/paper.md",
+        "paper/evidence/method-deviations.md"
+      ],
+      "kind": "method",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Morphology selects minimum residual SD; cell count, MT, and LDH use scoresPOD default rounded-AIC selection despite the paper's general residual-SD wording",
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "1_snakemake/concresponse",
+      "source": "main:e4-e5:concentration-response",
+      "summary": "Concentration-response model and POD selection: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "exact: thresholds and decision rules match code; input-version effects are separate deviations",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "toxcast-summary.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "METHOD-TOXCAST:01",
+          "name": "ToxCast threshold and decision-rule trace",
+          "observed": {
+            "cytotoxicity_consensus_20_percent": true,
+            "hitcall_strictly_above_0_9": true,
+            "median_positive_ac50": true,
+            "minimum_five_positive_and_negative": true,
+            "notebook_reads_pinned_parquets": true,
+            "specific_endpoint_100_um_deviation_traced": true
+          },
+          "passed": true,
+          "target_id": "METHOD-TOXCAST"
+        }
+      ],
+      "description": "ToxCast hit and cytotoxicity-confounding curation",
+      "deviation": "Core thresholds and matching rules trace exactly, but the stated specific-endpoint 100 uM reset is omitted and raw invitrodb regeneration is not repository-only executable",
+      "evidence": "evidence/toxcast-curation-and-figure-s3.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "Hit call > 0.9; 20 percent consensus cytotoxicity rule; AC50 comparison; minimum five positive and negative calls",
+      "group": "toxcast",
+      "id": "METHOD-TOXCAST",
+      "inputs": [
+        "paper/paper.md",
+        "2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb",
+        "paper/evidence/toxcast-curation-and-figure-s3.md"
+      ],
+      "kind": "method",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Core thresholds and matching rules trace exactly, but the stated specific-endpoint 100 uM reset is omitted and raw invitrodb regeneration is not repository-only executable",
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb",
+      "source": "main:e3-e4:toxcast-curation",
+      "summary": "ToxCast hit and cytotoxicity-confounding curation: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "exact: splits, model family, baselines, and consensus definitions match code",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "classifier-summary.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "METHOD-CLASSIFIER:01",
+          "name": "classifier implementation trace",
+          "observed": {
+            "compound_level_label_join": true,
+            "consensus_strategies": true,
+            "folds": 5,
+            "model": "XGBClassifier",
+            "paired_assay_hitcalls": true,
+            "published_baselines": true,
+            "stratified": true,
+            "workflow_wiring": true
+          },
+          "passed": true,
+          "target_id": "METHOD-CLASSIFIER"
+        }
+      ],
+      "description": "Classifier validation design",
+      "deviation": "Classifier implementation uses StratifiedKFold with five splits",
+      "evidence": "evidence/method-deviations.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "XGBoost classifiers use five-fold compound-level stratified splits, published baselines, and three consensus-profile strategies",
+      "group": "classifier",
+      "id": "METHOD-CLASSIFIER",
+      "inputs": [
+        "1_snakemake/classifier/classify.py",
+        "1_snakemake/classifier/aggregate_profiles.py",
+        "1_snakemake/classifier/hitcalls.py",
+        "1_snakemake/rules/classifier.smk"
+      ],
+      "kind": "method",
+      "ledger_status": "reproduced",
+      "limitations": [
+        "Classifier implementation uses StratifiedKFold with five splits",
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "1_snakemake/classifier/classify.py; 2_downstream_analysis/manuscript_notebooks",
+      "source": "main:e4:supervised-analysis",
+      "summary": "Classifier validation design: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "exact: regression split count, group isolation, test fraction, and model family match Table 1; STAR Methods inconsistency is recorded",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "enrichment-summary.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "METHOD-REGRESSION:01",
+          "name": "ten 80/20 compound-group splits",
+          "observed": true,
+          "passed": true,
+          "target_id": "METHOD-REGRESSION"
+        }
+      ],
+      "description": "Regression validation design",
+      "deviation": "Code and Table 1 use ten GroupShuffleSplit splits, while STAR Methods incorrectly states five-fold validation for all scenarios",
+      "evidence": "evidence/method-deviations.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "Table 1 reports ten train-test splits; regression code uses ten repeated 80/20 compound-group splits",
+      "group": "regression_enrichment",
+      "id": "METHOD-REGRESSION",
+      "inputs": [
+        "1_snakemake/classifier/regression.py",
+        "paper/evidence/method-deviations.md"
+      ],
+      "kind": "method",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Code and Table 1 use ten GroupShuffleSplit splits, while STAR Methods incorrectly states five-fold validation for all scenarios",
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "1_snakemake/classifier/regression.py",
+      "source": "main:p5:table-1; e4:supervised-analysis",
+      "summary": "Regression validation design: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "exact: thresholds and design constants agree",
+      "acceptance_class": "exact",
+      "artifacts": [
+        "evidence-coverage.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "METHOD-STATS:01",
+          "name": "statistical thresholds and sample design trace",
+          "observed": true,
+          "passed": true,
+          "target_id": "METHOD-STATS"
+        }
+      ],
+      "description": "Statistical thresholds and sample design",
+      "deviation": "All constants are declared and BH FDR is executable, but initial seeding is not recomputable, 0.05 gates are not centralized, and only 446 of 1,085 processed compounds retain exactly 16 rows",
+      "evidence": "evidence/remaining-paper-reproduction-targets.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "p < 0.05; FDR < 0.05; 5500 seeded cells per well; sixteen wells per compound",
+      "group": "sources_design",
+      "id": "METHOD-STATS",
+      "inputs": [
+        "paper/paper.md"
+      ],
+      "kind": "method",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "All constants are declared and BH FDR is executable, but initial seeding is not recomputable, 0.05 gates are not centralized, and only 446 of 1,085 processed compounds retain exactly 16 rows",
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "paper methods; analysis notebooks",
+      "source": "main:e5:quantification-and-statistics",
+      "summary": "Statistical thresholds and sample design: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "qualitative: assay ordering and overall conclusion hold across reproduced counts and PODs",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "pod-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": true,
+          "id": "CONCLUSION-001:01",
+          "name": "morphology sensitivity inequalities",
+          "observed": {
+            "complete_case_median_order": true,
+            "general_morphology_count_exceeds_mt": true
+          },
+          "passed": true,
+          "target_id": "CONCLUSION-001"
+        }
+      ],
+      "description": "Morphology is more sensitive than paired cytotoxicity readouts",
+      "deviation": "General-morphology detected-frequency counts exceed all cytotoxicity counts, and complete-case PODs preserve morphology > MT > cell count > LDH sensitivity despite key and pass-call drift.",
+      "evidence": "evidence/bioactivity-and-figure-2b-d.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "Morphology detects more activity and at lower concentrations",
+      "group": "activity_pods",
+      "id": "CONCLUSION-001",
+      "inputs": [
+        "paper/sources/table-s2.xlsx",
+        "paper/sources/table-s3.xlsx",
+        "paper/sources/table-s4.xlsx",
+        "2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv",
+        "2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "General-morphology detected-frequency counts exceed all cytotoxicity counts, and complete-case PODs preserve morphology > MT > cell count > LDH sensitivity despite key and pass-call drift.",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "multiple targets above",
+      "source": "main:p1:summary; p7-p10:discussion",
+      "summary": "Morphology is more sensitive than paired cytotoxicity readouts: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "qualitative: classifier ordering and baseline comparisons support the same conclusion",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "classifier-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": true,
+          "id": "CONCLUSION-002:01",
+          "name": "cell-based but not cell-free inequality gate",
+          "observed": true,
+          "passed": true,
+          "target_id": "CONCLUSION-002"
+        }
+      ],
+      "description": "Morphology predicts cell-based but not cell-free assay activity",
+      "deviation": "Conclusion holds for 2/34/267/53 modeled endpoints with caption-count, test-provenance, and cell-free non-convergence caveats",
+      "evidence": "evidence/classifier-results.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "Cytotoxicity and targeted cell-based assays are predictable above random while cell-free assays are not",
+      "group": "classifier",
+      "id": "CONCLUSION-002",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Conclusion holds for 2/34/267/53 modeled endpoints with caption-count, test-provenance, and cell-free non-convergence caveats",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "multiple targets above",
+      "source": "main:p1:summary; p7-p9:results",
+      "summary": "Morphology predicts cell-based but not cell-free assay activity: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "qualitative: small numerical differences are allowed if the practical conclusion holds",
+      "acceptance_class": "qualitative",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "classifier-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": true,
+          "id": "CONCLUSION-003:01",
+          "name": "representation and filtering practical-equivalence gates",
+          "observed": true,
+          "passed": true,
+          "target_id": "CONCLUSION-003"
+        }
+      ],
+      "description": "Representations and concentration filtering do not materially change performance",
+      "deviation": "Practical conclusion holds despite localized significance differences, CellProfiler scenario provenance, and POD-filtered numerical drift",
+      "evidence": "evidence/classifier-results.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "CellProfiler, CP-CNN, and DINO are similar; filtering concentrations gives no practical improvement",
+      "group": "classifier",
+      "id": "CONCLUSION-003",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet",
+        "2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Practical conclusion holds despite localized significance differences, CellProfiler scenario provenance, and POD-filtered numerical drift",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "multiple targets above",
+      "source": "main:p1:summary; p9:results",
+      "summary": "Representations and concentration filtering do not materially change performance: target-specific tracked-only checks completed with execution outcome checked."
+    },
+    {
+      "acceptance": "trace-only: confirm references and access locations; this is not a numerical reproduction target",
+      "acceptance_class": "trace-only",
+      "artifacts": [
+        "evidence-coverage.svg"
+      ],
+      "availability": "documentary-only",
+      "checks": [
+        {
+          "expected": true,
+          "id": "RESOURCE-001:01",
+          "name": "published data and code locations",
+          "observed": true,
+          "passed": true,
+          "target_id": "RESOURCE-001"
+        },
+        {
+          "expected": true,
+          "id": "RESOURCE-001:02",
+          "name": "tracked-only resource boundary",
+          "observed": true,
+          "passed": true,
+          "target_id": "RESOURCE-001"
+        }
+      ],
+      "description": "Published data and code availability statements",
+      "deviation": "Access classes and paths are traceable, but raw images, ignored compiled inputs and outputs, raw invitrodb, DOI resolution, and equivalence of the published owner URL to the current Broad origin remain external",
+      "evidence": "evidence/remaining-paper-reproduction-targets.md",
+      "evidence_strength": "documentary-trace",
+      "execution_outcome": "documentary-only",
+      "expected": "Cell Painting Gallery data, this analysis repository, and repository DOI are traceable",
+      "group": "sources_design",
+      "id": "RESOURCE-001",
+      "inputs": [
+        "README.md",
+        "paper/paper.md",
+        "paper/evidence/remaining-paper-reproduction-targets.md"
+      ],
+      "kind": "resource",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Access classes and paths are traceable, but raw images, ignored compiled inputs and outputs, raw invitrodb, DOI resolution, and equivalence of the published owner URL to the current Broad origin remain external",
+        "The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only."
+      ],
+      "producer": "paper key resources; README.md",
+      "source": "main:p10:resource-availability",
+      "summary": "Published data and code availability statements: target-specific tracked-only checks completed with execution outcome documentary-only."
+    },
+    {
+      "acceptance": "trace-only: preserve the distinction between enrichment evidence and mechanistic hypothesis",
+      "acceptance_class": "trace-only",
+      "artifacts": [
+        "evidence-coverage.svg",
+        "enrichment-summary.svg"
+      ],
+      "availability": "available",
+      "checks": [
+        {
+          "expected": true,
+          "id": "INTERPRETATION-001:01",
+          "name": "direct enrichment associations separated from mechanism",
+          "observed": true,
+          "passed": true,
+          "target_id": "INTERPRETATION-001"
+        }
+      ],
+      "description": "Mechanistic interpretation of MT prediction discrepancies",
+      "deviation": "Direct enrichment supports CYP, serotonergic, transporter, proteasome, and xenobiotic-metabolism associations; other process and receptor labels remain interpretations and all mechanism claims remain hypotheses",
+      "evidence": "evidence/remaining-paper-reproduction-targets.md",
+      "evidence_strength": "derived-artifact-reanalysis",
+      "execution_outcome": "checked",
+      "expected": "CYP, neurotransmitter-receptor, metabolic, stress, and apoptosis signals motivate testable hypotheses",
+      "group": "regression_enrichment",
+      "id": "INTERPRETATION-001",
+      "inputs": [
+        "2_downstream_analysis/compiled_results/mtt_higher_targets.csv",
+        "2_downstream_analysis/compiled_results/mtt_lower_targets.csv",
+        "paper/paper.md"
+      ],
+      "kind": "claim",
+      "ledger_status": "reproduced-with-deviation",
+      "limitations": [
+        "Direct enrichment supports CYP, serotonergic, transporter, proteasome, and xenobiotic-metabolism associations; other process and receptor labels remain interpretations and all mechanism claims remain hypotheses",
+        "Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated."
+      ],
+      "producer": "paper discussion and cited literature",
+      "source": "main:p7-p10:discussion",
+      "summary": "Mechanistic interpretation of MT prediction discrepancies: target-specific tracked-only checks completed with execution outcome checked."
+    }
+  ],
+  "validated_inputs": [
+    "1_snakemake/classifier/aggregate_profiles.py",
+    "1_snakemake/classifier/classify.py",
+    "1_snakemake/classifier/hitcalls.py",
+    "1_snakemake/classifier/regression.py",
+    "1_snakemake/concresponse/fit_curves.R",
+    "1_snakemake/concresponse/fit_curves_meta.R",
+    "1_snakemake/concresponse/select_pod.R",
+    "1_snakemake/inputs/annotations/toxcast_cellbased_binary.parquet",
+    "1_snakemake/inputs/annotations/toxcast_cellbased_info.parquet",
+    "1_snakemake/inputs/annotations/toxcast_cellfree_binary.parquet",
+    "1_snakemake/inputs/annotations/toxcast_cellfree_info.parquet",
+    "1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet",
+    "1_snakemake/inputs/annotations/toxcast_cytotox_info.parquet",
+    "1_snakemake/inputs/annotations/v5_oasis_03Sept2024_simple.csv",
+    "1_snakemake/rules/classifier.smk",
+    "2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv",
+    "2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv",
+    "2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet",
+    "2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet",
+    "2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet",
+    "2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet",
+    "2_downstream_analysis/compiled_results/err_higher_targets.csv",
+    "2_downstream_analysis/compiled_results/err_lower_targets.csv",
+    "2_downstream_analysis/compiled_results/mtt_higher_targets.csv",
+    "2_downstream_analysis/compiled_results/mtt_lower_targets.csv",
+    "2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb",
+    "2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb",
+    "2_downstream_analysis/other_notebooks/01_checkwelleffects.ipynb",
+    "README.md",
+    "REPRODUCING.md",
+    "paper/evidence/activity-and-figure-2a.md",
+    "paper/evidence/bioactivity-and-figure-2b-d.md",
+    "paper/evidence/experimental-design-and-figure-1.md",
+    "paper/evidence/method-deviations.md",
+    "paper/evidence/mt-discrepancy-enrichment.md",
+    "paper/evidence/prediction-error-enrichment.md",
+    "paper/evidence/regression-and-figure-s2.md",
+    "paper/evidence/remaining-paper-reproduction-targets.md",
+    "paper/evidence/toxcast-curation-and-figure-s3.md",
+    "paper/figures/figure-1.jpg",
+    "paper/figures/figure-s1.jpg",
+    "paper/paper.md",
+    "paper/sources/SHA256SUMS",
+    "paper/sources/main.pdf",
+    "paper/sources/manifest.toml",
+    "paper/sources/manuscript-source.docx",
+    "paper/sources/supplemental-figures.pdf",
+    "paper/sources/table-s1.xlsx",
+    "paper/sources/table-s2.xlsx",
+    "paper/sources/table-s3.xlsx",
+    "paper/sources/table-s4.xlsx",
+    "paper/sources/table-s5.xlsx",
+    "paper/targets.tsv"
+  ]
+}

--- a/paper/reproduction/report.md
+++ b/paper/reproduction/report.md
@@ -1,0 +1,1531 @@
+# Tracked paper audit
+
+This report is an archive-safe reanalysis of tracked sources, annotations, and compiled artifacts.
+It is not a rerun of ignored scientific workflows and its figures are not publisher reproductions.
+An execution outcome of `checked` means the declared checks passed against tracked inputs; it does not mean upstream workflows were regenerated.
+Historical ledger status is retained for provenance and does not determine the execution outcome.
+
+Mode: `tracked`.
+Targets covered: 53.
+Executed groups: sources_design, activity_pods, regression_enrichment, toxcast, classifier, external_image.
+Validated tracked inputs: 58.
+Ledger SHA-256: `abbd88ada4cfa7615c84b421b7bd9f566a435472c4c79c38ad989e82087af38f`.
+
+## Execution outcome counts
+
+| Execution outcome | Count |
+| --- | ---: |
+| blocked | 3 |
+| checked | 32 |
+| documentary-only | 17 |
+| out-of-scope | 1 |
+
+## Historical ledger status counts
+
+| Ledger status | Count |
+| --- | ---: |
+| blocked | 3 |
+| out-of-scope | 1 |
+| reproduced | 7 |
+| reproduced-with-deviation | 42 |
+
+## Evidence coverage
+
+| Evidence strength | Targets |
+| --- | ---: |
+| derived-artifact-reanalysis | 18 |
+| documentary-trace | 17 |
+| source-recomputation | 17 |
+| unavailable | 1 |
+
+[Open the evidence-coverage figure](evidence-coverage.svg).
+
+## Sources, design, and Table S1
+
+All 8 manifest sources passed SHA-256 and byte-count checks.
+All 6 Office archives passed ZIP CRC checks.
+Table S1 has 1085 rows, 966 stable IDs, and 119 blank IDs.
+
+## Activity and PODs
+
+The direction-aware cytotoxicity trace records 429 compounds and explicitly records that direction is absent from hit_summary.csv.
+
+| Figure 2A compound | Published Table S2 POD (uM) |
+| --- | ---: |
+| Benzarone | 69.3371 |
+| Tiratricol | 25.8604 |
+| Tolcapone | 23.6063 |
+| 2-Ethylanthracene-9,10-dione | 8.66085 |
+
+Figure 2C has 156 published-SI five-series cases and 488 three-general cases.
+The three-general CP-CNN ratios are 1.81811 over CellProfiler and 1.68649 over DINO.
+The three-general CellProfiler-DINO paired-log10 p-value is 0.261389.
+Figure 2D has 121 published-SI complete cases and preserves the morphology, MT, cell-count, LDH median ordering.
+
+[Open the POD-summary figure](pod-summary.svg).
+
+## Regression and enrichment
+
+Regression and Figure S2 numerical acceptance was not rerun because the required prediction and metric Parquets are not tracked.
+Their recipes validate the paper, producer notebook, implementation, and evidence trace explicitly.
+The four tracked enrichment tables were directly recomputed with upper-tail hypergeometric tests and BH FDR.
+
+| Enrichment artifact | Hit list | Significant sets | Maximum p error | Maximum FDR error |
+| --- | ---: | ---: | ---: | ---: |
+| err_higher_targets.csv | 304 | 178 | 1.11e-16 | 1.11e-16 |
+| err_lower_targets.csv | 138 | 0 | 1.11e-16 | 0 |
+| mtt_higher_targets.csv | 261 | 147 | 1.11e-16 | 1.11e-16 |
+| mtt_lower_targets.csv | 131 | 107 | 1.11e-16 | 1.11e-16 |
+
+MT-higher significant classes: {"cyp_prefix_count": 8, "htr_prefix_count": 6, "transporters_present": ["ABCB1", "ABCG2", "SLCO1B1", "SLCO1B3"]}.
+MT-lower significant classes: {"cyp_prefix_count": 3, "psm_prefix_count": 18}.
+
+[Open the enrichment-summary figure](enrichment-summary.svg).
+
+## ToxCast and Table S5
+
+The pinned binary annotation union contains 963 OASIS IDs; it is not a tested-library join.
+Tracked evidence documents an actual tested-library intersection of 670 IDs (61.751152%).
+Cell-based tissue composition: {"kidney": 35, "liver": 151, "vascular": 63}.
+Cell-free assay composition: {"binding": 37, "enzymatic activity": 35}.
+Cell-free target-family composition: {"cyp": 11, "gpcr": 21, "nuclear receptor": 10}.
+Median compounds observed per endpoint: {"cellbased": 306, "cellfree": 33, "cytotox": 346}.
+Median endpoint active fractions: {"cellbased": 0.071161355334425, "cellfree": 0.413429522752497, "cytotox": 0.206834880123743}.
+The heatmap substrate has 12 cell categories, 6 tissue categories, and 839 complete compounds.
+Table S5 has 12 nuclear-receptor assays and 0 source cytotoxicity hits.
+
+[Open the ToxCast-summary figure](toxcast-summary.svg).
+
+## Classifier metrics
+
+Modeled endpoint counts: {"axiom": 2, "toxcast_cellbased": 267, "toxcast_cellfree": 53, "toxcast_cytotox": 34}.
+All-concentration CellProfiler median AUROC and PRAUC: {"axiom": {"auroc": 0.90154710075502, "prauc": 0.805566469136103}, "toxcast_cellbased": {"auroc": 0.607226107226107, "prauc": 0.144839974879456}, "toxcast_cellfree": {"auroc": 0.532085561497326, "prauc": 0.454015201822219}, "toxcast_cytotox": {"auroc": 0.737210441587034, "prauc": 0.477454853975985}}.
+DINO cell-based target effects: {"dino_vs_cellprofiler_cellbased_auroc": {"mean_difference": 0.0118822411673017, "median_difference": 0.0220902090209021}, "dino_vs_cpcnn_cellbased_auroc": {"mean_difference": 0.010790455248826, "median_difference": 0.0158730158730159}}.
+
+| Family | Metric | allpodcc minus allpod mean | Median | Matched endpoints |
+| --- | --- | ---: | ---: | ---: |
+| axiom | auroc | -0.124974 | -0.124974 | 2 |
+| axiom | prauc | -0.372361 | -0.372361 | 2 |
+| toxcast_cellbased | auroc | -0.00797019 | -0.0047356 | 267 |
+| toxcast_cellbased | prauc | -0.0065968 | -0.00425904 | 267 |
+| toxcast_cellfree | auroc | 0.0134292 | 0.0266667 | 53 |
+| toxcast_cellfree | prauc | 0.00515196 | -0.00237447 | 53 |
+| toxcast_cytotox | auroc | -0.088586 | -0.0850192 | 34 |
+| toxcast_cytotox | prauc | -0.167164 | -0.177995 | 34 |
+
+[Open the classifier-summary figure](classifier-summary.svg).
+
+## External image boundary
+
+The raw source TIFF and image index are external and intentionally absent.
+
+## Generated figures
+
+Each SVG is generated from this report and labeled as tracked-artifact reanalysis.
+
+- [Evidence coverage](evidence-coverage.svg)
+- [POD summary](pod-summary.svg)
+- [Enrichment summary](enrichment-summary.svg)
+- [ToxCast summary](toxcast-summary.svg)
+- [Classifier summary](classifier-summary.svg)
+
+## Targets
+
+### DESIGN-001 - Tested compound design
+
+Source: main:p2-p3:experimental-design.
+Kind: claim.
+Expected: 1085 compounds; eight concentrations from 0.01 to 100 uM; two biological replicates.
+Full acceptance: exact: counts, range, and replicate design agree.
+Producer: 1_snakemake/inputs/metadata/metadata.parquet.
+Ledger evidence: evidence/experimental-design-and-figure-1.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: Published design and 1085-compound library agree; post-QC metadata excludes three microscope plates, leaving Hycanthone at seven concentrations and 941 of 8679 compound-concentration groups with one retained row.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| DESIGN-001:01 - published compound, dose, and replicate design | True | True | true |
+
+Validated inputs:
+- `paper/paper.md`
+- `paper/evidence/experimental-design-and-figure-1.md`
+
+Limitations and deviations:
+- Published design and 1085-compound library agree; post-QC metadata excludes three microscope plates, leaving Hycanthone at seven concentrations and 941 of 8679 compound-concentration groups with one retained row
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### DESIGN-002 - Image representation feature counts
+
+Source: main:p2-p3:experimental-design.
+Kind: claim.
+Expected: CellProfiler 5640; CP-CNN 672; DINO 4608.
+Full acceptance: exact: representation names and feature counts agree.
+Producer: 0_prepare_data; downloaded profile schemas.
+Ledger evidence: evidence/experimental-design-and-figure-1.md.
+Historical ledger status: `reproduced`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: -.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| DESIGN-002:01 - published representation feature counts | True | True | true |
+
+Validated inputs:
+- `paper/paper.md`
+- `paper/evidence/experimental-design-and-figure-1.md`
+
+Limitations and deviations:
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### DESIGN-003 - Assay and exposure design
+
+Source: main:p2-p3:experimental-design.
+Kind: claim.
+Expected: 384-well plates; 44-hour exposure; Cell Painting, LDH, and MT readouts.
+Full acceptance: exact: procedural constants and readout types agree.
+Producer: paper methods; input metadata.
+Ledger evidence: evidence/experimental-design-and-figure-1.md.
+Historical ledger status: `reproduced`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: -.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| DESIGN-003:01 - published assay and exposure constants | True | True | true |
+
+Validated inputs:
+- `paper/paper.md`
+- `paper/evidence/experimental-design-and-figure-1.md`
+
+Limitations and deviations:
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### FIG-1 - Overview of the experimental design
+
+Source: main:p3:figure-1.
+Kind: figure.
+Expected: The published workflow connects compound exposures to three measured assays and prediction outcomes.
+Full acceptance: qualitative: same experimental stages, sample scale, assays, and intended outcomes; publisher layout need not match.
+Producer: unknown.
+Ledger evidence: evidence/experimental-design-and-figure-1.md.
+Historical ledger status: `reproduced`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: -.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| FIG-1:01 - Figure 1 workflow stages and outcomes | True | True | true |
+
+Validated inputs:
+- `paper/figures/figure-1.jpg`
+- `paper/evidence/experimental-design-and-figure-1.md`
+
+Limitations and deviations:
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### ACTIVITY-001 - Activity counts in paired cytotoxicity-related assays
+
+Source: main:p3:results-2.1.1.
+Kind: claim.
+Expected: MT 430 of 1085; cell count 221; LDH 144; 438 unique active compounds.
+Full acceptance: exact: counts agree on the fixed published substrate.
+Producer: 2_downstream_analysis/manuscript_notebooks/1_2_number_active_readouts.ipynb.
+Ledger evidence: evidence/activity-and-figure-2a.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: CellProfiler Parquets reproduce 430/221/144 and 438 unique; the DINO count notebook yields 431/220/144 and 439, while published Table S2 has 429/220/147 and 437 unique.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| ACTIVITY-001:01 - published Table S2 activity counts | {"Cell count": 220, "LDH": 147, "MT": 429, "unique_compounds": 437} | {"Cell count": 220, "LDH": 147, "MT": 429, "unique_compounds": 437} | true |
+
+Validated inputs:
+- `paper/sources/table-s2.xlsx`
+- `2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv`
+
+Limitations and deviations:
+- CellProfiler Parquets reproduce 430/221/144 and 438 unique; the DINO count notebook yields 431/220/144 and 439, while published Table S2 has 429/220/147 and 437 unique
+
+### ACTIVITY-002 - Overall cytotoxic compound count
+
+Source: main:p3:results-2.1.1.
+Kind: claim.
+Expected: 429 compounds are cytotoxic in at least one assay.
+Full acceptance: exact: count and direction-aware definition agree.
+Producer: 2_downstream_analysis/manuscript_notebooks/1_2_number_active_readouts.ipynb.
+Ledger evidence: evidence/activity-and-figure-2a.md.
+Historical ledger status: `reproduced`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: -.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| ACTIVITY-002:01 - direction-aware cytotoxic compound count | 429 | 429 | true |
+| ACTIVITY-002:02 - direction-aware definition trace | True | True | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv`
+- `paper/evidence/activity-and-figure-2a.md`
+
+Limitations and deviations:
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### ACTIVITY-003 - Compounds with increased MT readout
+
+Source: main:p3:results-2.1.1.
+Kind: claim.
+Expected: Ten compounds increase MT; four have particularly strong responses.
+Full acceptance: close: same small set and same four dominant responses; document borderline call differences.
+Producer: 2_downstream_analysis/manuscript_notebooks/1_2_1_cmpds_increase_mt.ipynb.
+Ledger evidence: evidence/activity-and-figure-2a.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: CellProfiler reproduces ten and the same four dominant compounds; the DINO notebook adds Clodinafop-propargyl after an order-sensitive Exp2-to-Exp3 model change.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| ACTIVITY-003:01 - camera-ready increasing-MT call count | 10 | 10 | true |
+| ACTIVITY-003:02 - increasing-MT count documentary trace | True | True | true |
+| ACTIVITY-003:03 - four dominant increasing-MT compounds | ["Benzarone", "Tiratricol", "Tolcapone", "2-Ethylanthracene-9,10-dione"] | ["Benzarone", "Tiratricol", "Tolcapone", "2-Ethylanthracene-9,10-dione"] | true |
+| ACTIVITY-003:04 - increasing-MT direction | increasing MT | increasing MT | true |
+
+Validated inputs:
+- `paper/evidence/activity-and-figure-2a.md`
+- `2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv`
+
+Limitations and deviations:
+- CellProfiler reproduces ten and the same four dominant compounds; the DINO notebook adds Clodinafop-propargyl after an order-sensitive Exp2-to-Exp3 model change
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### FIG-2A - Strong MT-increasing concentration-response curves
+
+Source: main:p4:figure-2a.
+Kind: figure.
+Expected: Four dominant MT-increasing compounds with POD markers.
+Full acceptance: qualitative: same compounds, response direction, and approximate curve and POD locations.
+Producer: 2_downstream_analysis/manuscript_notebooks/1_2_1_cmpds_increase_mt.ipynb.
+Ledger evidence: evidence/activity-and-figure-2a.md.
+Historical ledger status: `reproduced`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: -.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| FIG-2A:01 - Figure 2A four published compounds | ["Benzarone", "Tiratricol", "Tolcapone", "2-Ethylanthracene-9,10-dione"] | ["Benzarone", "Tiratricol", "Tolcapone", "2-Ethylanthracene-9,10-dione"] | true |
+| FIG-2A:02 - Figure 2A Table S2 POD agreement | 4.4072791993698957e-07 | 1e-06 | true |
+
+Validated inputs:
+- `paper/sources/table-s2.xlsx`
+- `2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv`
+- `paper/evidence/activity-and-figure-2a.md`
+
+Limitations and deviations:
+- None declared.
+
+### BIOACTIVITY-001 - Morphological bioactivity frequency
+
+Source: main:p5:results-2.1.2.
+Kind: claim.
+Expected: 34-59 percent active depending on representation and distance metric; CellProfiler global is the 34 percent outlier.
+Full acceptance: close: same range, ordering, and outlier; small POD pass-call drift is acceptable.
+Producer: 2_downstream_analysis/manuscript_notebooks/4_1_results_tables_SI.ipynb.
+Ledger evidence: evidence/bioactivity-and-figure-2b-d.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: Current notebook-read data preserve 34-59 percent and ordering; published Table S3 has 169 CellProfiler-global calls (15.6 percent) versus the panel's 372 (34.3 percent) because of model/pass-call drift..
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| BIOACTIVITY-001:01 - all published-SI morphology count estimands | {"cellprofiler": {"categorical": 598, "general": 607, "global": 169}, "cpcnn": {"categorical": 0, "general": 539, "global": 539}, "dino": {"categorical": 626, "general": 644, "global": 545}} | {"cellprofiler": {"categorical": 598, "general": 607, "global": 169}, "cpcnn": {"categorical": 0, "general": 539, "global": 539}, "dino": {"categorical": 626, "general": 644, "global": 545}} | true |
+| BIOACTIVITY-001:02 - CellProfiler-global published-SI fraction | [0.155760368663594, 0.0005] | 0.156 | true |
+| BIOACTIVITY-001:03 - CellProfiler general published-SI count | 607 | 607 | true |
+| BIOACTIVITY-001:04 - published-SI general morphology ordering over cytotoxic assays | True | True | true |
+
+Validated inputs:
+- `paper/sources/table-s3.xlsx`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv`
+- `paper/evidence/bioactivity-and-figure-2b-d.md`
+
+Limitations and deviations:
+- Current notebook-read data preserve 34-59 percent and ordering; published Table S3 has 169 CellProfiler-global calls (15.6 percent) versus the panel's 372 (34.3 percent) because of model/pass-call drift.
+
+### FIG-2B - Active-compound counts and morphology POD distributions
+
+Source: main:p4:figure-2b.
+Kind: figure.
+Expected: Representation and distance choices produce the published activity-count ordering and POD distributions.
+Full acceptance: qualitative: same ordering, approximate proportions, and distribution shapes.
+Producer: 2_downstream_analysis/manuscript_notebooks/1_3_compare_pods.ipynb.
+Ledger evidence: evidence/bioactivity-and-figure-2b-d.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: Current counts differ by at most six and medians by 0.6 uM; published Table S3 loses 203 CellProfiler-global calls and shifts its median from 25.0 to 52.8 uM..
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| FIG-2B:01 - CellProfiler general active compounds | 607 | 607 | true |
+| FIG-2B:02 - DINO general active compounds | 644 | 644 | true |
+
+Validated inputs:
+- `paper/sources/table-s3.xlsx`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv`
+
+Limitations and deviations:
+- Current counts differ by at most six and medians by 0.6 uM; published Table S3 loses 203 CellProfiler-global calls and shifts its median from 25.0 to 52.8 uM.
+
+### BIOACTIVITY-002 - Relative morphology POD sensitivity by representation
+
+Source: main:p5:results-2.1.2.
+Kind: claim.
+Expected: CP-CNN PODs are about 2.0-fold higher than CellProfiler and 1.5-fold higher than DINO; CellProfiler and DINO are not significantly different.
+Full acceptance: close: ratios remain near published magnitude and statistical conclusion is unchanged.
+Producer: 2_downstream_analysis/manuscript_notebooks/1_3_compare_pods.ipynb.
+Ledger evidence: evidence/bioactivity-and-figure-2b-d.md.
+Historical ledger status: `blocked`.
+Execution outcome: `blocked`; availability: `blocked`; evidence strength: `source-recomputation`.
+Declared deviation: Ratios remain near 2.0 and 1.5, but CellProfiler-DINO is p=0.261 in published SI, p=0.034 on the current notebook path, and p=0.0545 with the filtered config; the absent historical extended matrix is excluded..
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| BIOACTIVITY-002:01 - three-general shared compounds | 488 | 488 | true |
+| BIOACTIVITY-002:02 - CP-CNN over CellProfiler general POD ratio | [1.81811349465688, 5e-05] | 1.8181 | true |
+| BIOACTIVITY-002:03 - CellProfiler-DINO null conclusion is substrate-dependent | 0.261389384315177 | 0.05 | true |
+
+Validated inputs:
+- `paper/sources/table-s3.xlsx`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv`
+- `paper/evidence/bioactivity-and-figure-2b-d.md`
+
+Limitations and deviations:
+- Ratios remain near 2.0 and 1.5, but CellProfiler-DINO is p=0.261 in published SI, p=0.034 on the current notebook path, and p=0.0545 with the filtered config; the absent historical extended matrix is excluded.
+
+### FIG-2C - POD comparison across representations
+
+Source: main:p4:figure-2c.
+Kind: figure.
+Expected: Published paired comparison for 342 compounds with PODs in all representations.
+Full acceptance: qualitative: same paired universe at useful resolution, same ordering, and similar spread; document row drift.
+Producer: 2_downstream_analysis/manuscript_notebooks/1_3_compare_pods.ipynb.
+Ledger evidence: evidence/bioactivity-and-figure-2b-d.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: Five-series complete counts are 342 camera-ready, 156 published SI, 341 current notebook-read, 330 current filtered, and 408 stored; current notebook-read distributions and ordering agree closely..
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| FIG-2C:01 - camera-ready five-series count trace | 342 | 342 | true |
+| FIG-2C:02 - published-SI five-series complete cases | 156 | 156 | true |
+| FIG-2C:03 - published-SI count deviation from camera-ready | 186 | 186 | true |
+| FIG-2C:04 - five-series median ordering preserved | True | True | true |
+| FIG-2C:05 - tracked-SI five-series finite POD summaries and median order | {"finite_nonempty": true, "median_order": ["cellprofiler_categorical", "dino_categorical", "dino_global", "cpcnn_global", "cellprofiler_global"], "series_count": 5} | {"finite_nonempty": true, "median_order": ["cellprofiler_categorical", "dino_categorical", "dino_global", "cpcnn_global", "cellprofiler_global"], "series_count": 5} | true |
+
+Validated inputs:
+- `paper/sources/table-s3.xlsx`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv`
+- `paper/evidence/bioactivity-and-figure-2b-d.md`
+
+Limitations and deviations:
+- Five-series complete counts are 342 camera-ready, 156 published SI, 341 current notebook-read, 330 current filtered, and 408 stored; current notebook-read distributions and ordering agree closely.
+
+### BIOACTIVITY-003 - Assay sensitivity ordering and fold differences
+
+Source: main:p5:results-2.1.3.
+Kind: claim.
+Expected: Morphology > MT > cell count > LDH; among 121 compounds morphology POD is 1.8-fold, 3.9-fold, and 7.0-fold lower respectively.
+Full acceptance: close: ordering is preserved, shared-compound count is similar, and fold differences remain broadly comparable.
+Producer: 2_downstream_analysis/manuscript_notebooks/1_3_compare_pods.ipynb.
+Ledger evidence: evidence/bioactivity-and-figure-2b-d.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: Ordering holds; published 121-compound folds are 1.79, 4.28, and 8.15, while current direction-aware 131-compound folds are 1.68, 3.87, and 7.41..
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| BIOACTIVITY-003:01 - assay median sensitivity ordering | [5.05543414478975, 8.95705965699234, 23.8188547870137, 40.5354608552776] | Morphology < MT < cell count < LDH | true |
+| BIOACTIVITY-003:02 - published-SI complete cases | 121 | 121 | true |
+
+Validated inputs:
+- `paper/sources/table-s2.xlsx`
+- `paper/sources/table-s3.xlsx`
+- `paper/sources/table-s4.xlsx`
+- `2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv`
+
+Limitations and deviations:
+- Ordering holds; published 121-compound folds are 1.79, 4.28, and 8.15, while current direction-aware 131-compound folds are 1.68, 3.87, and 7.41.
+
+### FIG-2D - POD comparison across morphology and cytotoxicity assays
+
+Source: main:p4:figure-2d.
+Kind: figure.
+Expected: Published paired comparison for 121 compounds with all four PODs.
+Full acceptance: qualitative: same sensitivity ordering and similar paired distributions; exact plotted points are not required.
+Producer: 2_downstream_analysis/manuscript_notebooks/1_3_compare_pods.ipynb.
+Ledger evidence: evidence/bioactivity-and-figure-2b-d.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: Published Table S4 has 121 complete hits after a null-ID join excludes 15 rows; current direction-aware data have 131 and preserve distributions, paired ordering, and significance..
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| FIG-2D:01 - published-SI four-assay complete cases | 121 | 121 | true |
+| FIG-2D:02 - MT fold ratio versus morphology | 1.78550470485347 | 1.78550470485347 | true |
+
+Validated inputs:
+- `paper/sources/table-s2.xlsx`
+- `paper/sources/table-s3.xlsx`
+- `paper/sources/table-s4.xlsx`
+- `2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv`
+
+Limitations and deviations:
+- Published Table S4 has 121 complete hits after a null-ID join excludes 15 rows; current direction-aware data have 131 and preserve distributions, paired ordering, and significance.
+
+### TABLE-1 - Regression prediction of paired LDH and MT readouts
+
+Source: main:p5:table-1.
+Kind: table.
+Expected: Published R2, RMSE, and MAE means and standard deviations across six input-feature or baseline rows per assay.
+Full acceptance: close: schemas and labels are exact; rounded metrics are close and preserve comparison conclusions.
+Producer: 2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb.
+Ledger evidence: evidence/regression-and-figure-s2.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: Schemas, labels, and ten splits agree; 51 of 72 mean or SD entries match at two significant figures, with maximum absolute mean drift 0.00849 R2, 0.000990 RMSE, and 0.000428 MAE.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| TABLE-1:01 - Table 1 documentary schema and value trace | True | True | true |
+| TABLE-1:02 - Table 1 numerical acceptance rerun | False | False | true |
+
+Validated inputs:
+- `paper/paper.md`
+- `1_snakemake/classifier/regression.py`
+- `2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb`
+- `paper/evidence/regression-and-figure-s2.md`
+
+Limitations and deviations:
+- Schemas, labels, and ten splits agree; 51 of 72 mean or SD entries match at two significant figures, with maximum absolute mean drift 0.00849 R2, 0.000990 RMSE, and 0.000428 MAE
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### REGRESSION-001 - Relative regression performance across representations and baselines
+
+Source: main:p5-p6:results-2.2.1.
+Kind: claim.
+Expected: Representations perform similarly; Cell Painting beats the technical baseline for MT but not LDH.
+Full acceptance: qualitative: significance and performance ordering conclusions agree.
+Producer: 2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb.
+Ledger evidence: evidence/regression-and-figure-s2.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: Practical similarity and MT-versus-LDH ordering hold; LDH MAE has small significant DINO differences and formally favors the technical baseline.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| REGRESSION-001:01 - regression comparison documentary trace | True | True | true |
+| REGRESSION-001:02 - regression numerical acceptance rerun | False | False | true |
+
+Validated inputs:
+- `1_snakemake/classifier/regression.py`
+- `2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb`
+- `paper/evidence/regression-and-figure-s2.md`
+
+Limitations and deviations:
+- Practical similarity and MT-versus-LDH ordering hold; LDH MAE has small significant DINO differences and formally favors the technical baseline
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### REGRESSION-002 - LDH model versus replicate performance
+
+Source: main:p5:results-2.2.1.
+Kind: claim.
+Expected: Cell Painting or technical baseline R2 exceeds replicate R2 by mean 0.20 with p < 1e-14.
+Full acceptance: close: effect remains positive and near 0.20 with a clearly significant result.
+Producer: 2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb.
+Ledger evidence: evidence/regression-and-figure-s2.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: Current pooled effect is 0.203758 with two-sided equal-variance independent t-test p = 1.88446e-14; distinct 966-compound model and 1,085-compound replicate split universes are documented.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| REGRESSION-002:01 - LDH replicate comparison documentary trace | True | True | true |
+| REGRESSION-002:02 - regression numerical acceptance rerun | False | False | true |
+
+Validated inputs:
+- `paper/paper.md`
+- `2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb`
+- `paper/evidence/regression-and-figure-s2.md`
+
+Limitations and deviations:
+- Current pooled effect is 0.203758 with two-sided equal-variance independent t-test p = 1.88446e-14; distinct 966-compound model and 1,085-compound replicate split universes are documented
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### TABLE-2 - Binary LDH and MT classifier performance
+
+Source: main:p6:table-2.
+Kind: table.
+Expected: Published AUROC and PRAUC values for cell count, random, CellProfiler, CP-CNN, and DINO rows.
+Full acceptance: close: keys and labels are exact; rounded metrics are close and all main performance conclusions agree.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_2_0_assay_metrics.ipynb.
+Ledger evidence: evidence/classifier-and-table-2.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Both compiled and current layers match 19 of 20 entries at two decimals; compiled DINO MT AUROC is 0.875945 and current DINO MT PRAUC is 0.832443; the caption says ten splits while code pools five folds.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| TABLE-2:01 - Table 2 row count | 10 | 10 | true |
+| TABLE-2:02 - Table 2 conclusion gates | True | True | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet`
+
+Limitations and deviations:
+- Both compiled and current layers match 19 of 20 entries at two decimals; compiled DINO MT AUROC is 0.875945 and current DINO MT PRAUC is 0.832443; the caption says ten splits while code pools five folds
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### CLASSIFIER-001 - Paired LDH classifier performance
+
+Source: main:p6:results-2.2.2.
+Kind: claim.
+Expected: Mean AUROC about 0.93 and PRAUC about 0.75; Cell Painting beats baselines.
+Full acceptance: close: values remain near published magnitude and Cell Painting still beats both baselines.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_2_0_assay_metrics.ipynb.
+Ledger evidence: evidence/classifier-and-table-2.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Current LDH morphology means are 0.932625 AUROC and 0.753212 PRAUC and all representations beat both baselines; split-count, keyed-universe, and localized DINO MT deviations are documented.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| CLASSIFIER-001:01 - LDH morphology mean AUROC | [0.932625056254142, 5e-07] | 0.932625 | true |
+| CLASSIFIER-001:02 - LDH morphology mean PRAUC | [0.753212139721954, 5e-07] | 0.753212 | true |
+| CLASSIFIER-001:03 - LDH representations beat both baselines | True | True | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet`
+
+Limitations and deviations:
+- Current LDH morphology means are 0.932625 AUROC and 0.753212 PRAUC and all representations beat both baselines; split-count, keyed-universe, and localized DINO MT deviations are documented
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### ENRICH-001 - Targets among wells better predicted by Cell Painting
+
+Source: main:p6:results-2.3.
+Kind: claim.
+Expected: About 138 wells and 480 enriched targets, including cell cycle, PI3K-Akt, MAPK, and p53 signals.
+Full acceptance: close: comparable hit-list scale and the same major pathway interpretation; exact hits and FDR values may drift.
+Producer: 2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb.
+Ledger evidence: evidence/prediction-error-enrichment.md.
+Historical ledger status: `blocked`.
+Execution outcome: `blocked`; availability: `blocked`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Code maps the Cell Painting label to 304 historical and 292 current Higher wells with 178 and 839 significant target sets; the 480 result and pathway mapping are absent, and signed residuals do not establish better prediction.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| ENRICH-001:01 - historical higher hit-list size | 304 | 304 | true |
+| ENRICH-001:02 - stored higher significant sets | 178 | 178 | true |
+| ENRICH-001:03 - literal 480-target acceptance available | False | False | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/err_higher_targets.csv`
+- `paper/evidence/prediction-error-enrichment.md`
+
+Limitations and deviations:
+- Code maps the Cell Painting label to 304 historical and 292 current Higher wells with 178 and 839 significant target sets; the 480 result and pathway mapping are absent, and signed residuals do not establish better prediction
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### ENRICH-002 - Targets among wells better predicted by the technical baseline
+
+Source: main:p6:results-2.3.
+Kind: claim.
+Expected: About 304 wells with no significantly enriched targets.
+Full acceptance: close: hit-list scale is comparable and the no-enrichment conclusion holds.
+Producer: 2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb.
+Ledger evidence: evidence/prediction-error-enrichment.md.
+Historical ledger status: `blocked`.
+Execution outcome: `blocked`; availability: `blocked`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: No enrichment holds for the 138 historical and 134 current Lower wells labeled technical baseline, while the 304 and 292 Higher wells are labeled Cell Painting and enriched; no source layer satisfies both acceptance conditions.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| ENRICH-002:01 - stored lower hit-list size | 138 | 138 | true |
+| ENRICH-002:02 - stored lower significant sets | 0 | 0 | true |
+| ENRICH-002:03 - literal 304-well acceptance available | False | False | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/err_lower_targets.csv`
+- `paper/evidence/prediction-error-enrichment.md`
+
+Limitations and deviations:
+- No enrichment holds for the 138 historical and 134 current Lower wells labeled technical baseline, while the 304 and 292 Higher wells are labeled Cell Painting and enriched; no source layer satisfies both acceptance conditions
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### ENRICH-003 - Higher morphology-predicted than observed MT cases
+
+Source: main:p6-p7:results-2.3.
+Kind: claim.
+Expected: 261 wells enriched for 147 proteins, including CYPs, neurotransmitter receptors, and xenobiotic transporters.
+Full acceptance: qualitative: similar discrepancy group and the same broad biological target classes; individual members may differ.
+Producer: 2_downstream_analysis/manuscript_notebooks/2_2_outlier_enrichment_analysis.ipynb.
+Ledger evidence: evidence/mt-discrepancy-enrichment.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Stored 261-well group and 147 significant sets support all named CYPs and transporters plus six HTR sets; current selector gives 262 wells, no DRD or adrenergic set is significant, and two named compounds lack significant overlaps.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| ENRICH-003:01 - MT higher hit-list size | 261 | 261 | true |
+| ENRICH-003:02 - MT higher significant sets | 147 | 147 | true |
+| ENRICH-003:03 - MT higher named target classes | {"cyp_prefix_count": 8, "htr_prefix_count": 6, "transporters_present": ["ABCB1", "ABCG2", "SLCO1B1", "SLCO1B3"]} | {"cyp_prefix_count": 8, "htr_prefix_count": 6, "transporters_present": ["ABCB1", "ABCG2", "SLCO1B1", "SLCO1B3"]} | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/mtt_higher_targets.csv`
+- `paper/evidence/mt-discrepancy-enrichment.md`
+
+Limitations and deviations:
+- Stored 261-well group and 147 significant sets support all named CYPs and transporters plus six HTR sets; current selector gives 262 wells, no DRD or adrenergic set is significant, and two named compounds lack significant overlaps
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### ENRICH-004 - Lower morphology-predicted than observed MT cases
+
+Source: main:p6-p7:results-2.3.
+Kind: claim.
+Expected: 131 wells enriched for proteasome inhibition, xenobiotic metabolism, bile acid synthesis, cell stress, and apoptosis.
+Full acceptance: qualitative: similar discrepancy group and the same broad biological processes.
+Producer: 2_downstream_analysis/manuscript_notebooks/2_2_outlier_enrichment_analysis.ipynb.
+Ledger evidence: evidence/mt-discrepancy-enrichment.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Stored 131-well group supports 18 proteasome sets and three CYP sets; current selector gives 142 wells, carfilzomib is absent from overlaps, and three process labels lack repository mappings.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| ENRICH-004:01 - MT lower hit-list size | 131 | 131 | true |
+| ENRICH-004:02 - MT lower significant sets | 107 | 107 | true |
+| ENRICH-004:03 - MT lower named target classes | {"cyp_prefix_count": 3, "psm_prefix_count": 18} | {"cyp_prefix_count": 3, "psm_prefix_count": 18} | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/mtt_lower_targets.csv`
+- `paper/evidence/mt-discrepancy-enrichment.md`
+
+Limitations and deviations:
+- Stored 131-well group supports 18 proteasome sets and three CYP sets; current selector gives 142 wells, carfilzomib is absent from overlaps, and three process labels lack repository mappings
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### TOXCAST-001 - OASIS and ToxCast overlap
+
+Source: main:p7:results-3.
+Kind: claim.
+Expected: 963 tested compounds, or 89 percent, overlap ToxCast.
+Full acceptance: close: same overlap definition and count within ordinary source-version drift.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb.
+Ledger evidence: evidence/toxcast-curation-and-figure-s3.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: The stored 963-ID union gives 88.755760 percent of 1085, but it is not intersected with tested metadata; only 670 tested IDs overlap the pinned ToxCast union.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| TOXCAST-001:01 - stored ToxCast annotation-ID union, not tested overlap | 963 | 963 | true |
+| TOXCAST-001:02 - stored annotation-union/library-denominator arithmetic, not tested overlap | [0.887557603686636, 0.005] | 0.89 | true |
+| TOXCAST-001:03 - documented tested-library intersection IDs | 670 | 670 | true |
+| TOXCAST-001:04 - documented tested-library intersection percentage | [61.7511520737327, 5e-07] | 61.751152 | true |
+| TOXCAST-001:05 - 963 is an annotation union rather than a tested-library join | True | True | true |
+
+Validated inputs:
+- `1_snakemake/inputs/annotations/toxcast_cellbased_binary.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cellbased_info.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cellfree_binary.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cellfree_info.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cytotox_info.parquet`
+- `paper/evidence/toxcast-curation-and-figure-s3.md`
+
+Limitations and deviations:
+- The stored 963-ID union gives 88.755760 percent of 1085, but it is not intersected with tested metadata; only 670 tested IDs overlap the pinned ToxCast union
+
+### TOXCAST-002 - Curated ToxCast endpoint counts
+
+Source: main:p7:results-3.1.
+Kind: claim.
+Expected: 48 cytotoxicity, 292 non-cytotoxicity cell-based, and 72 cell-free endpoints.
+Full acceptance: exact: endpoint category keys and counts agree for the pinned input.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb.
+Ledger evidence: evidence/toxcast-curation-and-figure-s3.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: Source metadata have 48, 292, and 72 exact keys, but class support retains 38 cytotoxicity keys and enforcing the stated 100 uM rule would reduce cell-based endpoints to 291.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| TOXCAST-002:01 - ToxCast source endpoint counts | {"cellbased": 292, "cellfree": 72, "cytotox": 48} | {"cellbased": 292, "cellfree": 72, "cytotox": 48} | true |
+| TOXCAST-002:02 - classification-ready binary endpoint counts | {"cellbased": 292, "cellfree": 72, "cytotox": 38} | {"cellbased": 292, "cellfree": 72, "cytotox": 38} | true |
+
+Validated inputs:
+- `1_snakemake/inputs/annotations/toxcast_cellbased_binary.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cellbased_info.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cellfree_binary.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cellfree_info.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cytotox_info.parquet`
+
+Limitations and deviations:
+- Source metadata have 48, 292, and 72 exact keys, but class support retains 38 cytotoxicity keys and enforcing the stated 100 uM rule would reduce cell-based endpoints to 291
+
+### TOXCAST-003 - ToxCast endpoint composition and activity summaries
+
+Source: main:p7:results-3.1.
+Kind: claim.
+Expected: Published tissue, target-family, overlap, and active-fraction summaries for cell-based and cell-free endpoints.
+Full acceptance: close: proportions and rankings remain broadly comparable; record source-version changes.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb.
+Ledger evidence: evidence/toxcast-curation-and-figure-s3.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: All displayed values and rankings match; family percentages use all 292 cell-based endpoints and cytotoxicity medians use the 38 post-support endpoints rather than all 48 source categories.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| TOXCAST-003:01 - cell-based tissue composition | {"kidney": 35, "liver": 151, "vascular": 63} | {"kidney": 35, "liver": 151, "vascular": 63} | true |
+| TOXCAST-003:02 - cell-free assay composition | {"binding": 37, "enzymatic activity": 35} | {"binding": 37, "enzymatic activity": 35} | true |
+| TOXCAST-003:03 - cell-free target-family composition | {"cyp": 11, "gpcr": 21, "nuclear receptor": 10} | {"cyp": 11, "gpcr": 21, "nuclear receptor": 10} | true |
+| TOXCAST-003:04 - median compounds tested per endpoint | {"cellbased": 306, "cellfree": 33, "cytotox": 346} | {"cellbased": 306, "cellfree": 33, "cytotox": 346} | true |
+| TOXCAST-003:05 - median endpoint active fractions | {"cellbased": 0.071161355334425, "cellfree": 0.413429522752497, "cytotox": 0.206834880123743} | {"cellbased": 0.0711613553, "cellfree": 0.4134295228, "cytotox": 0.2068348801} | true |
+
+Validated inputs:
+- `1_snakemake/inputs/annotations/toxcast_cellbased_binary.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cellbased_info.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cellfree_binary.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cellfree_info.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cytotox_info.parquet`
+
+Limitations and deviations:
+- All displayed values and rankings match; family percentages use all 292 cell-based endpoints and cytotoxicity medians use the 38 post-support endpoints rather than all 48 source categories
+
+### FIG-3AB - AUROC and PRAUC distributions across assay types
+
+Source: main:p8:figure-3a-b.
+Kind: figure.
+Expected: Paired MT and LDH perform best, followed by ToxCast cytotoxicity and cell-based assays, with cell-free assays near random.
+Full acceptance: qualitative: same assay-type ordering and broadly similar distributions; no pixel match required.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_2_1_compare_endpoint_types.ipynb.
+Ledger evidence: evidence/classifier-results.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Ordering and distributions agree, but caption counts 48/292/72 are source counts rather than the 34/267/53 modeled endpoint counts.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| FIG-3AB:01 - classifier modeled endpoint distributions | {"axiom": 2, "toxcast_cellbased": 267, "toxcast_cellfree": 53, "toxcast_cytotox": 34} | {"axiom": 2, "toxcast_cellbased": 267, "toxcast_cellfree": 53, "toxcast_cytotox": 34} | true |
+| FIG-3AB:02 - all-concentration CellProfiler distribution summaries | {"axiom": {"auroc": 0.90154710075502, "prauc": 0.805566469136103}, "toxcast_cellbased": {"auroc": 0.607226107226107, "prauc": 0.144839974879456}, "toxcast_cellfree": {"auroc": 0.532085561497326, "prauc": 0.454015201822219}, "toxcast_cytotox": {"auroc": 0.737210441587034, "prauc": 0.477454853975985}} | {"axiom": {"auroc": 0.901547, "prauc": 0.805566}, "toxcast_cellbased": {"auroc": 0.607226, "prauc": 0.14484}, "toxcast_cellfree": {"auroc": 0.532086, "prauc": 0.454015}, "toxcast_cytotox": {"auroc": 0.73721, "prauc": 0.477455}} | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet`
+
+Limitations and deviations:
+- Ordering and distributions agree, but caption counts 48/292/72 are source counts rather than the 34/267/53 modeled endpoint counts
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### FIG-3C - Classifier differences from random and cell-count baselines
+
+Source: main:p8:figure-3c.
+Kind: figure.
+Expected: Morphology improves cytotoxicity and cell-based prediction over random; cell-free prediction does not materially improve.
+Full acceptance: qualitative: effect directions and main significance conclusions agree.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_2_1_compare_endpoint_types.ipynb.
+Ledger evidence: evidence/classifier-results.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Matched effects support the conclusion, but the panel mixes endpoint universes and tests and the six-row cell-free PRAUC mixed model does not converge.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| FIG-3C:01 - cell-based versus cell-free baseline conclusion | True | True | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet`
+
+Limitations and deviations:
+- Matched effects support the conclusion, but the panel mixes endpoint universes and tests and the six-row cell-free PRAUC mixed model does not converge
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### FILTER-001 - Filtering to bioactive concentrations
+
+Source: main:p7:results-3.2.1.
+Kind: claim.
+Expected: AUROC increases about 0.04 for ToxCast cytotoxicity and 0.02 for cell-based assays; other AUROC and all PRAUC comparisons show no material improvement.
+Full acceptance: close: small improvements remain small and the overall no-practical-improvement conclusion holds.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_2_2_compare_concs_reps.ipynb.
+Ledger evidence: evidence/classifier-results.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Compiled/current AUROC effects are 0.0386/0.0374 and 0.0194/0.0203, but the published FDR values do not reproduce from the committed notebook.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| FILTER-001:01 - allpod versus all effects remain small | True | True | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet`
+
+Limitations and deviations:
+- Compiled/current AUROC effects are 0.0386/0.0374 and 0.0194/0.0203, but the published FDR values do not reproduce from the committed notebook
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### FILTER-002 - Filtering out cytotoxic concentrations
+
+Source: main:p7:results-3.2.1.
+Kind: claim.
+Expected: Performance worsens for cytotoxicity categories and does not improve cell-based or cell-free prediction.
+Full acceptance: qualitative: effect directions and no-improvement conclusion agree.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_2_2_compare_concs_reps.ipynb.
+Ledger evidence: evidence/classifier-results.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Cytotoxicity performance worsens and other effects remain negligible, with expected numerical drift in POD-derived strategies.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| FILTER-002:01 - Axiom allpodcc minus allpod mean AUROC | -0.124974386867459 | -0.124974386867459 | true |
+| FILTER-002:02 - Axiom allpodcc minus allpod mean PRAUC | -0.372361412793057 | -0.372361412793057 | true |
+| FILTER-002:03 - allpodcc minus allpod mean AUROC | {"toxcast_cellbased": -0.00797018904098499, "toxcast_cellfree": 0.0134291664332844, "toxcast_cytotox": -0.0885859686562654} | {"toxcast_cellbased": -0.007970189, "toxcast_cellfree": 0.0134291664, "toxcast_cytotox": -0.0885859687} | true |
+| FILTER-002:04 - allpodcc minus allpod mean PRAUC | {"toxcast_cellbased": -0.00659679632924061, "toxcast_cellfree": 0.00515195738908095, "toxcast_cytotox": -0.167163560277532} | {"toxcast_cellbased": -0.0065967963, "toxcast_cellfree": 0.0051519574, "toxcast_cytotox": -0.1671635603} | true |
+| FILTER-002:05 - Axiom and cytotoxic effects are negative while cell-based and cell-free effects remain below 0.02 | True | True | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet`
+
+Limitations and deviations:
+- Cytotoxicity performance worsens and other effects remain negligible, with expected numerical drift in POD-derived strategies
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### FIG-4A - Classifier AUROC across concentration consensus strategies
+
+Source: main:p9:figure-4a.
+Kind: figure.
+Expected: All-concentration profiles perform as well as or better than filtered alternatives overall.
+Full acceptance: qualitative: same practical conclusion and similar assay-type patterns.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_2_2_compare_concs_reps.ipynb.
+Ledger evidence: evidence/classifier-results.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Distribution directions and the practical conclusion agree, but modeled endpoint counts differ from captions and POD-filtered values drift.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| FIG-4A:01 - all-concentration strategy conclusion | True | True | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet`
+
+Limitations and deviations:
+- Distribution directions and the practical conclusion agree, but modeled endpoint counts differ from captions and POD-filtered values drift
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### REPRESENTATION-001 - Alternative image representations
+
+Source: main:p7:results-3.2.2.
+Kind: claim.
+Expected: Representations perform similarly; DINO cell-based AUROC is about 0.02 higher than CellProfiler and CP-CNN.
+Full acceptance: close: performance remains similar overall and any DINO advantage stays small.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_2_3_compare_endpoints_detail.ipynb; 2_downstream_analysis/manuscript_notebooks/3_2_2_compare_concs_reps.ipynb.
+Ledger evidence: evidence/classifier-results.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: DINO median advantages are 0.0221 and 0.0159, but mean effects are about 0.011 and published p-values do not reproduce.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| REPRESENTATION-001:01 - DINO versus CP-CNN cell-based AUROC effects | {"mean_difference": 0.010790455248826, "median_difference": 0.0158730158730159} | {"mean_difference": 0.01079046, "median_difference": 0.01587302} | true |
+| REPRESENTATION-001:02 - DINO versus CellProfiler median cell-based AUROC | 0.0220902090209021 | 0.02209021 | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet`
+
+Limitations and deviations:
+- DINO median advantages are 0.0221 and 0.0159, but mean effects are about 0.011 and published p-values do not reproduce
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### FIG-4B - Classifier AUROC across CellProfiler, CP-CNN, and DINO
+
+Source: main:p9:figure-4b.
+Kind: figure.
+Expected: Published representation distributions are very similar within assay types.
+Full acceptance: qualitative: same near-equivalence and assay-type ordering; no pixel match required.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_2_3_compare_endpoints_detail.ipynb; 2_downstream_analysis/manuscript_notebooks/3_2_2_compare_concs_reps.ipynb.
+Ledger evidence: evidence/classifier-results.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Near-equivalence and ordering agree, with one small ToxCast cytotoxicity Tukey contrast at p = 0.0493.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| FIG-4B:01 - representation effects remain practically small | True | True | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet`
+
+Limitations and deviations:
+- Near-equivalence and ordering agree, with one small ToxCast cytotoxicity Tukey contrast at p = 0.0493
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### SFIG-1 - Representative Cell Painting image
+
+Source: supp:p2:figure-s1.
+Kind: figure.
+Expected: Plate 41002889, well L12, site 6; representative of 191754 images including 43641 DMSO controls.
+Full acceptance: exact: image identity and inventory counts agree when source images are available.
+Producer: 2_downstream_analysis/other_notebooks/Plot_images.ipynb.
+Ledger evidence: -.
+Historical ledger status: `out-of-scope`.
+Execution outcome: `out-of-scope`; availability: `out-of-scope`; evidence strength: `unavailable`.
+Declared deviation: Existing recipe excludes external image download and missing output setup.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| SFIG-1:01 - tracked navigation image identity trace | True | True | true |
+| SFIG-1:02 - external source image available | False | False | true |
+
+Validated inputs:
+- `paper/figures/figure-s1.jpg`
+- `paper/paper.md`
+
+Limitations and deviations:
+- Existing recipe excludes external image download and missing output setup
+- The raw source image is external and excluded from tracked-only execution.
+
+### SFIG-2 - Technical factors and paired-assay prediction diagnostics
+
+Source: supp:p3:figure-s2.
+Kind: figure.
+Expected: Well-position effects, normalized readout distributions, and DINO similarity clustergram support the technical-factor interpretation.
+Full acceptance: qualitative: same major spatial and cell-count patterns; exact clustering order is not required.
+Producer: 2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb; 2_downstream_analysis/other_notebooks/01_checkwelleffects.ipynb.
+Ledger evidence: evidence/regression-and-figure-s2.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: All panel directions and major patterns hold; current base selects 292 versus camera-ready text n = 138, and the notebook label is a signed-residual threshold rather than a formal significance test.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| SFIG-2:01 - Figure S2 panel documentary trace | True | True | true |
+| SFIG-2:02 - Figure S2 numerical acceptance rerun | False | False | true |
+
+Validated inputs:
+- `paper/paper.md`
+- `2_downstream_analysis/manuscript_notebooks/2_1_predict_continuous_assays.ipynb`
+- `2_downstream_analysis/other_notebooks/01_checkwelleffects.ipynb`
+- `paper/evidence/regression-and-figure-s2.md`
+
+Limitations and deviations:
+- All panel directions and major patterns hold; current base selects 292 versus camera-ready text n = 138, and the notebook label is a signed-residual threshold rather than a formal significance test
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### SFIG-3 - ToxCast binarization and cytotoxicity patterns
+
+Source: supp:p4:figure-s3.
+Kind: figure.
+Expected: Published binarization procedure and broad cell-line and tissue cytotoxicity clusters.
+Full acceptance: qualitative: same procedure, category coverage, and major clustered patterns.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb.
+Ledger evidence: evidence/toxcast-curation-and-figure-s3.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: The 12-cell and 6-tissue heatmaps preserve broad concordance and selective patterns; the image is labeled B and C while the supplemental legend incorrectly says C and D.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| SFIG-3:01 - cytotoxicity heatmap summary | {"cell_categories": 12, "complete_compounds": 839, "tissue_categories": 6} | {"cell_categories": 12, "complete_compounds": 839, "tissue_categories": 6} | true |
+
+Validated inputs:
+- `1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet`
+- `paper/evidence/toxcast-curation-and-figure-s3.md`
+
+Limitations and deviations:
+- The 12-cell and 6-tissue heatmaps preserve broad concordance and selective patterns; the image is labeled B and C while the supplemental legend incorrectly says C and D
+
+### SFIG-4 - Classifier PRAUC across concentration and image representations
+
+Source: supp:p5:figure-s4.
+Kind: figure.
+Expected: Filtering and representation comparisons do not materially improve PRAUC.
+Full acceptance: qualitative: same no-material-improvement conclusion and similar distributions.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_2_2_compare_concs_reps.ipynb; 2_downstream_analysis/manuscript_notebooks/3_2_3_compare_endpoints_detail.ipynb.
+Ledger evidence: evidence/classifier-results.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: PRAUC shows no practical improvement, while POD-filtered values drift and small unadjusted representation tests differ from Tukey results.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| SFIG-4:01 - PRAUC filtering and representation practical conclusion | True | True | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet`
+
+Limitations and deviations:
+- PRAUC shows no practical improvement, while POD-filtered values drift and small unadjusted representation tests differ from Tukey results
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### TABLE-S1 - OASIS compound list
+
+Source: supp:table-s1.
+Kind: table.
+Expected: Published compound identities and annotations used to define the study library.
+Full acceptance: exact: stable compound identifiers and tested-library membership agree; annotation-only differences are documented.
+Producer: paper/sources/table-s1.xlsx; 1_snakemake/inputs/metadata/metadata.parquet.
+Ledger evidence: evidence/remaining-paper-reproduction-targets.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: All 966 workbook OASIS IDs and 119 blinded labels map to metadata, but tested metadata additionally has Ribociclib; Vasopressin has two IDs, one workbook name is encoding-corrupted, and 176 preferred-name labels differ.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| TABLE-S1:01 - Table S1 rows | 1085 | 1085 | true |
+| TABLE-S1:02 - Table S1 stable IDs | 966 | 966 | true |
+| TABLE-S1:03 - Table S1 blank IDs | 119 | 119 | true |
+
+Validated inputs:
+- `paper/sources/table-s1.xlsx`
+- `1_snakemake/inputs/annotations/v5_oasis_03Sept2024_simple.csv`
+
+Limitations and deviations:
+- All 966 workbook OASIS IDs and 119 blinded labels map to metadata, but tested metadata additionally has Ribociclib; Vasopressin has two IDs, one workbook name is encoding-corrupted, and 176 preferred-name labels differ
+
+### TABLE-S2 - Cytotoxicity points of departure
+
+Source: supp:table-s2.
+Kind: table.
+Expected: Published MT, cell-count, and LDH POD results.
+Full acceptance: close: schemas and semantic keys agree; coverage, median differences, validity, and material tail satisfy the existing POD gates.
+Producer: 2_downstream_analysis/compiled_results/SI_tables.
+Ledger evidence: evidence/published-table-bridge.md; ../REPRODUCING.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: Published workbook keys match all 796 committed semantic rows and POD values agree to spreadsheet precision; regenerated gates pass with documented drift.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| TABLE-S2:01 - Table S2 semantic keys | 796 | 796 | true |
+| TABLE-S2:02 - Table S2 maximum POD difference | 4.40536496171262e-13 | 1e-12 | true |
+
+Validated inputs:
+- `paper/sources/table-s2.xlsx`
+- `2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv`
+
+Limitations and deviations:
+- Published workbook keys match all 796 committed semantic rows and POD values agree to spreadsheet precision; regenerated gates pass with documented drift
+
+### TABLE-S3 - Cell Painting points of departure
+
+Source: supp:table-s3.
+Kind: table.
+Expected: Published CellProfiler, CP-CNN, and DINO POD results.
+Full acceptance: close: schemas and semantic keys agree; coverage, median differences, validity, and material tail satisfy the existing POD gates.
+Producer: 2_downstream_analysis/compiled_results/SI_tables.
+Ledger evidence: evidence/published-table-bridge.md; ../REPRODUCING.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: Published workbook keys match all 10935 nonblank committed semantic rows and POD values agree to spreadsheet precision; regenerated gates pass with documented drift.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| TABLE-S3:01 - Table S3 semantic keys | 10935 | 10935 | true |
+| TABLE-S3:02 - Table S3 exact bioactivity flags | 10935 | 10935 | true |
+
+Validated inputs:
+- `paper/sources/table-s3.xlsx`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv`
+
+Limitations and deviations:
+- Published workbook keys match all 10935 nonblank committed semantic rows and POD values agree to spreadsheet precision; regenerated gates pass with documented drift
+
+### TABLE-S4 - Activity summary across all assays
+
+Source: supp:table-s4.
+Kind: table.
+Expected: Published cross-assay compound activity summary including the 121-compound all-POD subset.
+Full acceptance: close: compound identities and main assay-activity relationships agree; small POD pass-call drift is documented.
+Producer: 2_downstream_analysis/manuscript_notebooks/4_1_results_tables_SI.ipynb.
+Ledger evidence: evidence/published-table-bridge.md; ../REPRODUCING.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: Published workbook matches all 1086 committed hit-summary rows; regenerated keys are exact and 1070 of 1086 complete hit calls agree.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| TABLE-S4:01 - Table S4 semantic keys | 1086 | 1086 | true |
+| TABLE-S4:02 - Table S4 exact tracked hit rows | 1086 | 1086 | true |
+
+Validated inputs:
+- `paper/sources/table-s4.xlsx`
+- `2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv`
+
+Limitations and deviations:
+- Published workbook matches all 1086 committed hit-summary rows; regenerated keys are exact and 1070 of 1086 complete hit calls agree
+
+### TABLE-S5 - ToxCast activity for 2-ethylanthraquinone
+
+Source: supp:table-s5.
+Kind: table.
+Expected: Activity in 12 nuclear-receptor assays at about 1-45 uM without cytotoxicity, plus mitochondrial depolarization signal.
+Full acceptance: close: same broad assay set, concentration range, and metabolic-disruption interpretation.
+Producer: paper/sources/table-s5.xlsx; 2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb.
+Ledger evidence: evidence/remaining-paper-reproduction-targets.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `source-recomputation`.
+Declared deviation: Workbook has 12 receptor hits at 1.648-45 uM; pinned inputs retain 8 of 12, confirm zero cytotoxicity hits across 102 tests, and support MMP activity without proving directional uncoupling.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| TABLE-S5:01 - Table S5 nuclear-receptor assays | 12 | 12 | true |
+| TABLE-S5:02 - Table S5 nuclear-receptor AC50 minimum | [1.64808942, 0.001] | 1.648 | true |
+| TABLE-S5:03 - Table S5 nuclear-receptor AC50 maximum | 45.0 | 45.0 | true |
+| TABLE-S5:04 - Table S5 retained pinned receptor assays | 8 | 8 | true |
+| TABLE-S5:05 - Table S5 source cytotoxicity hits | 0 | 0 | true |
+| TABLE-S5:06 - Table S5 MMP activity evidence | {"ac50_um": 14.8795940571651, "hitcall_above_0_9": true} | active finite MMP signal | true |
+
+Validated inputs:
+- `paper/sources/table-s5.xlsx`
+- `1_snakemake/inputs/annotations/toxcast_cellbased_info.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cytotox_info.parquet`
+- `1_snakemake/inputs/annotations/toxcast_cytotox_binary.parquet`
+
+Limitations and deviations:
+- Workbook has 12 receptor hits at 1.648-45 uM; pinned inputs retain 8 of 12, confirm zero cytotoxicity hits across 102 tests, and support MMP activity without proving directional uncoupling
+
+### TABLE-KEY-RESOURCES - Published biological samples, reagents, deposited data, software, and equipment
+
+Source: main:e1-e2:key-resources-table.
+Kind: table.
+Expected: All Key Resources Table rows and identifiers from the camera-ready paper.
+Full acceptance: exact: resource names, versions, deposited-data paths, and identifiers agree with the published table.
+Producer: paper/paper.md; paper/sources/main.pdf.
+Ledger evidence: paper.md.
+Historical ledger status: `reproduced`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: Transcribed from the camera-ready PDF.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| TABLE-KEY-RESOURCES:01 - Key Resources transcription trace | True | True | true |
+| TABLE-KEY-RESOURCES:02 - Key Resources Markdown data rows | 34 | 34 | true |
+
+Validated inputs:
+- `paper/paper.md`
+- `paper/sources/main.pdf`
+
+Limitations and deviations:
+- Transcribed from the camera-ready PDF
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### METHOD-POD - Concentration-response model and POD selection
+
+Source: main:e4-e5:concentration-response.
+Kind: method.
+Expected: Paper describes eight named models, residual-SD selection, DMSO 95th-percentile benchmark, and confidence-ratio and concentration filters.
+Full acceptance: exact: model families and thresholds match; the known selection-rule discrepancy is explicit.
+Producer: 1_snakemake/concresponse.
+Ledger evidence: evidence/method-deviations.md; ../REPRODUCING.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: Morphology selects minimum residual SD; cell count, MT, and LDH use scoresPOD default rounded-AIC selection despite the paper's general residual-SD wording.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| METHOD-POD:01 - POD implementation and deviation trace | {"compound_minimum_pod": true, "dmso_control": true, "documented_ci_ratio_threshold_40": true, "documented_dmso_95th_percentile_benchmark": true, "documented_eight_model_names": true, "documented_highest_tested_concentration_filter": true, "known_selection_deviation_traced": true, "morphology_residual_sd_selection": true, "paired_assay_scorespod_default": true} | True | true |
+
+Validated inputs:
+- `1_snakemake/concresponse/fit_curves.R`
+- `1_snakemake/concresponse/fit_curves_meta.R`
+- `1_snakemake/concresponse/select_pod.R`
+- `paper/paper.md`
+- `paper/evidence/method-deviations.md`
+
+Limitations and deviations:
+- Morphology selects minimum residual SD; cell count, MT, and LDH use scoresPOD default rounded-AIC selection despite the paper's general residual-SD wording
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### METHOD-TOXCAST - ToxCast hit and cytotoxicity-confounding curation
+
+Source: main:e3-e4:toxcast-curation.
+Kind: method.
+Expected: Hit call > 0.9; 20 percent consensus cytotoxicity rule; AC50 comparison; minimum five positive and negative calls.
+Full acceptance: exact: thresholds and decision rules match code; input-version effects are separate deviations.
+Producer: 2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb.
+Ledger evidence: evidence/toxcast-curation-and-figure-s3.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: Core thresholds and matching rules trace exactly, but the stated specific-endpoint 100 uM reset is omitted and raw invitrodb regeneration is not repository-only executable.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| METHOD-TOXCAST:01 - ToxCast threshold and decision-rule trace | {"cytotoxicity_consensus_20_percent": true, "hitcall_strictly_above_0_9": true, "median_positive_ac50": true, "minimum_five_positive_and_negative": true, "notebook_reads_pinned_parquets": true, "specific_endpoint_100_um_deviation_traced": true} | True | true |
+
+Validated inputs:
+- `paper/paper.md`
+- `2_downstream_analysis/manuscript_notebooks/3_1_toxcast_endpoints.ipynb`
+- `paper/evidence/toxcast-curation-and-figure-s3.md`
+
+Limitations and deviations:
+- Core thresholds and matching rules trace exactly, but the stated specific-endpoint 100 uM reset is omitted and raw invitrodb regeneration is not repository-only executable
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### METHOD-CLASSIFIER - Classifier validation design
+
+Source: main:e4:supervised-analysis.
+Kind: method.
+Expected: XGBoost classifiers use five-fold compound-level stratified splits, published baselines, and three consensus-profile strategies.
+Full acceptance: exact: splits, model family, baselines, and consensus definitions match code.
+Producer: 1_snakemake/classifier/classify.py; 2_downstream_analysis/manuscript_notebooks.
+Ledger evidence: evidence/method-deviations.md.
+Historical ledger status: `reproduced`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: Classifier implementation uses StratifiedKFold with five splits.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| METHOD-CLASSIFIER:01 - classifier implementation trace | {"compound_level_label_join": true, "consensus_strategies": true, "folds": 5, "model": "XGBClassifier", "paired_assay_hitcalls": true, "published_baselines": true, "stratified": true, "workflow_wiring": true} | True | true |
+
+Validated inputs:
+- `1_snakemake/classifier/classify.py`
+- `1_snakemake/classifier/aggregate_profiles.py`
+- `1_snakemake/classifier/hitcalls.py`
+- `1_snakemake/rules/classifier.smk`
+
+Limitations and deviations:
+- Classifier implementation uses StratifiedKFold with five splits
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### METHOD-REGRESSION - Regression validation design
+
+Source: main:p5:table-1; e4:supervised-analysis.
+Kind: method.
+Expected: Table 1 reports ten train-test splits; regression code uses ten repeated 80/20 compound-group splits.
+Full acceptance: exact: regression split count, group isolation, test fraction, and model family match Table 1; STAR Methods inconsistency is recorded.
+Producer: 1_snakemake/classifier/regression.py.
+Ledger evidence: evidence/method-deviations.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: Code and Table 1 use ten GroupShuffleSplit splits, while STAR Methods incorrectly states five-fold validation for all scenarios.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| METHOD-REGRESSION:01 - ten 80/20 compound-group splits | True | True | true |
+
+Validated inputs:
+- `1_snakemake/classifier/regression.py`
+- `paper/evidence/method-deviations.md`
+
+Limitations and deviations:
+- Code and Table 1 use ten GroupShuffleSplit splits, while STAR Methods incorrectly states five-fold validation for all scenarios
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### METHOD-STATS - Statistical thresholds and sample design
+
+Source: main:e5:quantification-and-statistics.
+Kind: method.
+Expected: p < 0.05; FDR < 0.05; 5500 seeded cells per well; sixteen wells per compound.
+Full acceptance: exact: thresholds and design constants agree.
+Producer: paper methods; analysis notebooks.
+Ledger evidence: evidence/remaining-paper-reproduction-targets.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: All constants are declared and BH FDR is executable, but initial seeding is not recomputable, 0.05 gates are not centralized, and only 446 of 1,085 processed compounds retain exactly 16 rows.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| METHOD-STATS:01 - statistical thresholds and sample design trace | True | True | true |
+
+Validated inputs:
+- `paper/paper.md`
+
+Limitations and deviations:
+- All constants are declared and BH FDR is executable, but initial seeding is not recomputable, 0.05 gates are not centralized, and only 446 of 1,085 processed compounds retain exactly 16 rows
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### CONCLUSION-001 - Morphology is more sensitive than paired cytotoxicity readouts
+
+Source: main:p1:summary; p7-p10:discussion.
+Kind: claim.
+Expected: Morphology detects more activity and at lower concentrations.
+Full acceptance: qualitative: assay ordering and overall conclusion hold across reproduced counts and PODs.
+Producer: multiple targets above.
+Ledger evidence: evidence/bioactivity-and-figure-2b-d.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: General-morphology detected-frequency counts exceed all cytotoxicity counts, and complete-case PODs preserve morphology > MT > cell count > LDH sensitivity despite key and pass-call drift..
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| CONCLUSION-001:01 - morphology sensitivity inequalities | {"complete_case_median_order": true, "general_morphology_count_exceeds_mt": true} | True | true |
+
+Validated inputs:
+- `paper/sources/table-s2.xlsx`
+- `paper/sources/table-s3.xlsx`
+- `paper/sources/table-s4.xlsx`
+- `2_downstream_analysis/compiled_results/SI_tables/mt_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellcount_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/ldh_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cellprofiler_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_cpcnn_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/cellpainting_dino_pods.csv`
+- `2_downstream_analysis/compiled_results/SI_tables/hit_summary.csv`
+
+Limitations and deviations:
+- General-morphology detected-frequency counts exceed all cytotoxicity counts, and complete-case PODs preserve morphology > MT > cell count > LDH sensitivity despite key and pass-call drift.
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### CONCLUSION-002 - Morphology predicts cell-based but not cell-free assay activity
+
+Source: main:p1:summary; p7-p9:results.
+Kind: claim.
+Expected: Cytotoxicity and targeted cell-based assays are predictable above random while cell-free assays are not.
+Full acceptance: qualitative: classifier ordering and baseline comparisons support the same conclusion.
+Producer: multiple targets above.
+Ledger evidence: evidence/classifier-results.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Conclusion holds for 2/34/267/53 modeled endpoints with caption-count, test-provenance, and cell-free non-convergence caveats.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| CONCLUSION-002:01 - cell-based but not cell-free inequality gate | True | True | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet`
+
+Limitations and deviations:
+- Conclusion holds for 2/34/267/53 modeled endpoints with caption-count, test-provenance, and cell-free non-convergence caveats
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### CONCLUSION-003 - Representations and concentration filtering do not materially change performance
+
+Source: main:p1:summary; p9:results.
+Kind: claim.
+Expected: CellProfiler, CP-CNN, and DINO are similar; filtering concentrations gives no practical improvement.
+Full acceptance: qualitative: small numerical differences are allowed if the practical conclusion holds.
+Producer: multiple targets above.
+Ledger evidence: evidence/classifier-results.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Practical conclusion holds despite localized significance differences, CellProfiler scenario provenance, and POD-filtered numerical drift.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| CONCLUSION-003:01 - representation and filtering practical-equivalence gates | True | True | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/compiled_axiom_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellbased_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cellfree_metrics.parquet`
+- `2_downstream_analysis/compiled_results/compiled_toxcast_cytotox_metrics.parquet`
+
+Limitations and deviations:
+- Practical conclusion holds despite localized significance differences, CellProfiler scenario provenance, and POD-filtered numerical drift
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.
+
+### RESOURCE-001 - Published data and code availability statements
+
+Source: main:p10:resource-availability.
+Kind: resource.
+Expected: Cell Painting Gallery data, this analysis repository, and repository DOI are traceable.
+Full acceptance: trace-only: confirm references and access locations; this is not a numerical reproduction target.
+Producer: paper key resources; README.md.
+Ledger evidence: evidence/remaining-paper-reproduction-targets.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `documentary-only`; availability: `documentary-only`; evidence strength: `documentary-trace`.
+Declared deviation: Access classes and paths are traceable, but raw images, ignored compiled inputs and outputs, raw invitrodb, DOI resolution, and equivalence of the published owner URL to the current Broad origin remain external.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| RESOURCE-001:01 - published data and code locations | True | True | true |
+| RESOURCE-001:02 - tracked-only resource boundary | True | True | true |
+
+Validated inputs:
+- `README.md`
+- `paper/paper.md`
+- `paper/evidence/remaining-paper-reproduction-targets.md`
+
+Limitations and deviations:
+- Access classes and paths are traceable, but raw images, ignored compiled inputs and outputs, raw invitrodb, DOI resolution, and equivalence of the published owner URL to the current Broad origin remain external
+- The required numerical substrate is not tracked; numerical acceptance was not rerun, and this recipe validates source, notebook, or code trace only.
+
+### INTERPRETATION-001 - Mechanistic interpretation of MT prediction discrepancies
+
+Source: main:p7-p10:discussion.
+Kind: claim.
+Expected: CYP, neurotransmitter-receptor, metabolic, stress, and apoptosis signals motivate testable hypotheses.
+Full acceptance: trace-only: preserve the distinction between enrichment evidence and mechanistic hypothesis.
+Producer: paper discussion and cited literature.
+Ledger evidence: evidence/remaining-paper-reproduction-targets.md.
+Historical ledger status: `reproduced-with-deviation`.
+Execution outcome: `checked`; availability: `available`; evidence strength: `derived-artifact-reanalysis`.
+Declared deviation: Direct enrichment supports CYP, serotonergic, transporter, proteasome, and xenobiotic-metabolism associations; other process and receptor labels remain interpretations and all mechanism claims remain hypotheses.
+
+| Target-specific check | Observed | Expected | Passed |
+| --- | --- | --- | --- |
+| INTERPRETATION-001:01 - direct enrichment associations separated from mechanism | True | True | true |
+
+Validated inputs:
+- `2_downstream_analysis/compiled_results/mtt_higher_targets.csv`
+- `2_downstream_analysis/compiled_results/mtt_lower_targets.csv`
+- `paper/paper.md`
+
+Limitations and deviations:
+- Direct enrichment supports CYP, serotonergic, transporter, proteasome, and xenobiotic-metabolism associations; other process and receptor labels remain interpretations and all mechanism claims remain hypotheses
+- Tracked derived artifacts were reanalyzed; classifiers, curves, predictions, and upstream workflows were not regenerated.

--- a/paper/reproduction/toxcast-summary.svg
+++ b/paper/reproduction/toxcast-summary.svg
@@ -1,0 +1,1370 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="453.049062pt" height="277.164625pt" viewBox="0 0 453.049062 277.164625" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 277.164625
+L 453.049062 277.164625
+L 453.049062 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 44.089063 254.254313
+L 445.849063 254.254313
+L 445.849063 21.406313
+L 44.089063 21.406313
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="md36de533ea" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md36de533ea" x="110.690988" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- cellbased -->
+      <g transform="translate(89.363097 268.092906) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-63" d="M 3122 3366
+L 3122 2828
+Q 2878 2963 2633 3030
+Q 2388 3097 2138 3097
+Q 1578 3097 1268 2742
+Q 959 2388 959 1747
+Q 959 1106 1268 751
+Q 1578 397 2138 397
+Q 2388 397 2633 464
+Q 2878 531 3122 666
+L 3122 134
+Q 2881 22 2623 -34
+Q 2366 -91 2075 -91
+Q 1284 -91 818 406
+Q 353 903 353 1747
+Q 353 2603 823 3093
+Q 1294 3584 2113 3584
+Q 2378 3584 2631 3529
+Q 2884 3475 3122 3366
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-65" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6c" d="M 603 4863
+L 1178 4863
+L 1178 0
+L 603 0
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-62" d="M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+M 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2969
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-61" d="M 2194 1759
+Q 1497 1759 1228 1600
+Q 959 1441 959 1056
+Q 959 750 1161 570
+Q 1363 391 1709 391
+Q 2188 391 2477 730
+Q 2766 1069 2766 1631
+L 2766 1759
+L 2194 1759
+z
+M 3341 1997
+L 3341 0
+L 2766 0
+L 2766 531
+Q 2569 213 2275 61
+Q 1981 -91 1556 -91
+Q 1019 -91 701 211
+Q 384 513 384 1019
+Q 384 1609 779 1909
+Q 1175 2209 1959 2209
+L 2766 2209
+L 2766 2266
+Q 2766 2663 2505 2880
+Q 2244 3097 1772 3097
+Q 1472 3097 1187 3025
+Q 903 2953 641 2809
+L 641 3341
+Q 956 3463 1253 3523
+Q 1550 3584 1831 3584
+Q 2591 3584 2966 3190
+Q 3341 2797 3341 1997
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397
+L 2834 2853
+Q 2591 2978 2328 3040
+Q 2066 3103 1784 3103
+Q 1356 3103 1142 2972
+Q 928 2841 928 2578
+Q 928 2378 1081 2264
+Q 1234 2150 1697 2047
+L 1894 2003
+Q 2506 1872 2764 1633
+Q 3022 1394 3022 966
+Q 3022 478 2636 193
+Q 2250 -91 1575 -91
+Q 1294 -91 989 -36
+Q 684 19 347 128
+L 347 722
+Q 666 556 975 473
+Q 1284 391 1588 391
+Q 1994 391 2212 530
+Q 2431 669 2431 922
+Q 2431 1156 2273 1281
+Q 2116 1406 1581 1522
+L 1381 1569
+Q 847 1681 609 1914
+Q 372 2147 372 2553
+Q 372 3047 722 3315
+Q 1072 3584 1716 3584
+Q 2034 3584 2315 3537
+Q 2597 3491 2834 3397
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-64" d="M 2906 2969
+L 2906 4863
+L 3481 4863
+L 3481 0
+L 2906 0
+L 2906 525
+Q 2725 213 2448 61
+Q 2172 -91 1784 -91
+Q 1150 -91 751 415
+Q 353 922 353 1747
+Q 353 2572 751 3078
+Q 1150 3584 1784 3584
+Q 2172 3584 2448 3432
+Q 2725 3281 2906 2969
+z
+M 947 1747
+Q 947 1113 1208 752
+Q 1469 391 1925 391
+Q 2381 391 2643 752
+Q 2906 1113 2906 1747
+Q 2906 2381 2643 2742
+Q 2381 3103 1925 3103
+Q 1469 3103 1208 2742
+Q 947 2381 947 1747
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-63"/>
+       <use xlink:href="#DejaVuSans-65" x="54.980469"/>
+       <use xlink:href="#DejaVuSans-6c" x="116.503906"/>
+       <use xlink:href="#DejaVuSans-6c" x="144.287109"/>
+       <use xlink:href="#DejaVuSans-62" x="172.070312"/>
+       <use xlink:href="#DejaVuSans-61" x="235.546875"/>
+       <use xlink:href="#DejaVuSans-73" x="296.826172"/>
+       <use xlink:href="#DejaVuSans-65" x="348.925781"/>
+       <use xlink:href="#DejaVuSans-64" x="410.449219"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#md36de533ea" x="244.969063" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- cellfree -->
+      <g transform="translate(228.354922 268.092906) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-66" d="M 2375 4863
+L 2375 4384
+L 1825 4384
+Q 1516 4384 1395 4259
+Q 1275 4134 1275 3809
+L 1275 3500
+L 2222 3500
+L 2222 3053
+L 1275 3053
+L 1275 0
+L 697 0
+L 697 3053
+L 147 3053
+L 147 3500
+L 697 3500
+L 697 3744
+Q 697 4328 969 4595
+Q 1241 4863 1831 4863
+L 2375 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963
+Q 2534 3019 2420 3045
+Q 2306 3072 2169 3072
+Q 1681 3072 1420 2755
+Q 1159 2438 1159 1844
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1341 3275 1631 3429
+Q 1922 3584 2338 3584
+Q 2397 3584 2469 3576
+Q 2541 3569 2628 3553
+L 2631 2963
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-63"/>
+       <use xlink:href="#DejaVuSans-65" x="54.980469"/>
+       <use xlink:href="#DejaVuSans-6c" x="116.503906"/>
+       <use xlink:href="#DejaVuSans-6c" x="144.287109"/>
+       <use xlink:href="#DejaVuSans-66" x="172.070312"/>
+       <use xlink:href="#DejaVuSans-72" x="207.275391"/>
+       <use xlink:href="#DejaVuSans-65" x="246.138672"/>
+       <use xlink:href="#DejaVuSans-65" x="307.662109"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#md36de533ea" x="379.247137" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- cytotox -->
+      <g transform="translate(362.551434 268.092906) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-79" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494
+L 1172 3500
+L 2356 3500
+L 2356 3053
+L 1172 3053
+L 1172 1153
+Q 1172 725 1289 603
+Q 1406 481 1766 481
+L 2356 481
+L 2356 0
+L 1766 0
+Q 1100 0 847 248
+Q 594 497 594 1153
+L 594 3053
+L 172 3053
+L 172 3500
+L 594 3500
+L 594 4494
+L 1172 4494
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6f" d="M 1959 3097
+Q 1497 3097 1228 2736
+Q 959 2375 959 1747
+Q 959 1119 1226 758
+Q 1494 397 1959 397
+Q 2419 397 2687 759
+Q 2956 1122 2956 1747
+Q 2956 2369 2687 2733
+Q 2419 3097 1959 3097
+z
+M 1959 3584
+Q 2709 3584 3137 3096
+Q 3566 2609 3566 1747
+Q 3566 888 3137 398
+Q 2709 -91 1959 -91
+Q 1206 -91 779 398
+Q 353 888 353 1747
+Q 353 2609 779 3096
+Q 1206 3584 1959 3584
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-78" d="M 3513 3500
+L 2247 1797
+L 3578 0
+L 2900 0
+L 1881 1375
+L 863 0
+L 184 0
+L 1544 1831
+L 300 3500
+L 978 3500
+L 1906 2253
+L 2834 3500
+L 3513 3500
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-63"/>
+       <use xlink:href="#DejaVuSans-79" x="54.980469"/>
+       <use xlink:href="#DejaVuSans-74" x="114.160156"/>
+       <use xlink:href="#DejaVuSans-6f" x="153.369141"/>
+       <use xlink:href="#DejaVuSans-74" x="214.550781"/>
+       <use xlink:href="#DejaVuSans-6f" x="253.759766"/>
+       <use xlink:href="#DejaVuSans-78" x="311.816406"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_4">
+      <path d="M 44.089063 254.254313
+L 445.849063 254.254313
+" clip-path="url(#pee68227b19)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_5">
+      <defs>
+       <path id="m77db5bb38e" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="254.254313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0 -->
+      <g transform="translate(31.362813 257.673609) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_6">
+      <path d="M 44.089063 216.28171
+L 445.849063 216.28171
+" clip-path="url(#pee68227b19)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="216.28171" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 50 -->
+      <g transform="translate(25.636563 219.701007) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_8">
+      <path d="M 44.089063 178.309107
+L 445.849063 178.309107
+" clip-path="url(#pee68227b19)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="178.309107" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 100 -->
+      <g transform="translate(19.910313 181.728404) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_10">
+      <path d="M 44.089063 140.336504
+L 445.849063 140.336504
+" clip-path="url(#pee68227b19)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="140.336504" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 150 -->
+      <g transform="translate(19.910313 143.755801) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_12">
+      <path d="M 44.089063 102.363902
+L 445.849063 102.363902
+" clip-path="url(#pee68227b19)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="102.363902" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 200 -->
+      <g transform="translate(19.910313 105.783198) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_14">
+      <path d="M 44.089063 64.391299
+L 445.849063 64.391299
+" clip-path="url(#pee68227b19)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="64.391299" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 250 -->
+      <g transform="translate(19.910313 67.810596) scale(0.09 -0.09)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_16">
+      <path d="M 44.089063 26.418696
+L 445.849063 26.418696
+" clip-path="url(#pee68227b19)" style="fill: none; stroke: #dddddd; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m77db5bb38e" x="44.089063" y="26.418696" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 300 -->
+      <g transform="translate(19.910313 29.837993) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516
+Q 3050 2419 3304 2112
+Q 3559 1806 3559 1356
+Q 3559 666 3084 287
+Q 2609 -91 1734 -91
+Q 1441 -91 1130 -33
+Q 819 25 488 141
+L 488 750
+Q 750 597 1062 519
+Q 1375 441 1716 441
+Q 2309 441 2620 675
+Q 2931 909 2931 1356
+Q 2931 1769 2642 2001
+Q 2353 2234 1838 2234
+L 1294 2234
+L 1294 2753
+L 1863 2753
+Q 2328 2753 2575 2939
+Q 2822 3125 2822 3475
+Q 2822 3834 2567 4026
+Q 2313 4219 1838 4219
+Q 1578 4219 1281 4162
+Q 984 4106 628 3988
+L 628 4550
+Q 988 4650 1302 4700
+Q 1616 4750 1894 4750
+Q 2613 4750 3031 4423
+Q 3450 4097 3450 3541
+Q 3450 3153 3228 2886
+Q 3006 2619 2597 2516
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_11">
+     <!-- Endpoints -->
+     <g transform="translate(14.038594 160.203047) rotate(-90) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-45" d="M 628 4666
+L 3578 4666
+L 3578 4134
+L 1259 4134
+L 1259 2753
+L 3481 2753
+L 3481 2222
+L 1259 2222
+L 1259 531
+L 3634 531
+L 3634 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525
+L 1159 -1331
+L 581 -1331
+L 581 3500
+L 1159 3500
+L 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+z
+M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500
+L 1178 3500
+L 1178 0
+L 603 0
+L 603 3500
+z
+M 603 4863
+L 1178 4863
+L 1178 4134
+L 603 4134
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-45"/>
+      <use xlink:href="#DejaVuSans-6e" x="63.183594"/>
+      <use xlink:href="#DejaVuSans-64" x="126.5625"/>
+      <use xlink:href="#DejaVuSans-70" x="190.039062"/>
+      <use xlink:href="#DejaVuSans-6f" x="253.515625"/>
+      <use xlink:href="#DejaVuSans-69" x="314.697266"/>
+      <use xlink:href="#DejaVuSans-6e" x="342.480469"/>
+      <use xlink:href="#DejaVuSans-74" x="405.859375"/>
+      <use xlink:href="#DejaVuSans-73" x="445.068359"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 62.350881 254.254313
+L 110.690988 254.254313
+L 110.690988 32.494313
+L 62.350881 32.494313
+z
+" clip-path="url(#pee68227b19)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 196.628956 254.254313
+L 244.969063 254.254313
+L 244.969063 199.573765
+L 196.628956 199.573765
+z
+" clip-path="url(#pee68227b19)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 330.90703 254.254313
+L 379.247137 254.254313
+L 379.247137 217.800614
+L 330.90703 217.800614
+z
+" clip-path="url(#pee68227b19)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 110.690988 254.254313
+L 159.031095 254.254313
+L 159.031095 32.494313
+L 110.690988 32.494313
+z
+" clip-path="url(#pee68227b19)" style="fill: #b279a2"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 244.969062 254.254313
+L 293.309169 254.254313
+L 293.309169 199.573765
+L 244.969062 199.573765
+z
+" clip-path="url(#pee68227b19)" style="fill: #b279a2"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 379.247137 254.254313
+L 427.587244 254.254313
+L 427.587244 225.395134
+L 379.247137 225.395134
+z
+" clip-path="url(#pee68227b19)" style="fill: #b279a2"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 44.089063 254.254313
+L 44.089063 21.406313
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 44.089062 254.254313
+L 445.849063 254.254313
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_12">
+    <!-- ToxCast endpoints - tracked-artifact reanalysis -->
+    <g transform="translate(102.277438 15.406313) scale(0.108 -0.108)">
+     <defs>
+      <path id="DejaVuSans-Bold-54" d="M 31 4666
+L 4331 4666
+L 4331 3756
+L 2784 3756
+L 2784 0
+L 1581 0
+L 1581 3756
+L 31 3756
+L 31 4666
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6f" d="M 2203 2784
+Q 1831 2784 1636 2517
+Q 1441 2250 1441 1747
+Q 1441 1244 1636 976
+Q 1831 709 2203 709
+Q 2569 709 2762 976
+Q 2956 1244 2956 1747
+Q 2956 2250 2762 2517
+Q 2569 2784 2203 2784
+z
+M 2203 3584
+Q 3106 3584 3614 3096
+Q 4122 2609 4122 1747
+Q 4122 884 3614 396
+Q 3106 -91 2203 -91
+Q 1297 -91 786 396
+Q 275 884 275 1747
+Q 275 2609 786 3096
+Q 1297 3584 2203 3584
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-78" d="M 1422 1791
+L 159 3500
+L 1344 3500
+L 2059 2463
+L 2784 3500
+L 3969 3500
+L 2706 1797
+L 4031 0
+L 2847 0
+L 2059 1106
+L 1281 0
+L 97 0
+L 1422 1791
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-43" d="M 4288 256
+Q 3956 84 3597 -3
+Q 3238 -91 2847 -91
+Q 1681 -91 1000 561
+Q 319 1213 319 2328
+Q 319 3447 1000 4098
+Q 1681 4750 2847 4750
+Q 3238 4750 3597 4662
+Q 3956 4575 4288 4403
+L 4288 3438
+Q 3953 3666 3628 3772
+Q 3303 3878 2944 3878
+Q 2300 3878 1931 3465
+Q 1563 3053 1563 2328
+Q 1563 1606 1931 1193
+Q 2300 781 2944 781
+Q 3303 781 3628 887
+Q 3953 994 4288 1222
+L 4288 256
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575
+Q 1756 1575 1579 1456
+Q 1403 1338 1403 1106
+Q 1403 894 1545 773
+Q 1688 653 1941 653
+Q 2256 653 2472 879
+Q 2688 1106 2688 1447
+L 2688 1575
+L 2106 1575
+z
+M 3816 1997
+L 3816 0
+L 2688 0
+L 2688 519
+Q 2463 200 2181 54
+Q 1900 -91 1497 -91
+Q 953 -91 614 226
+Q 275 544 275 1050
+Q 275 1666 698 1953
+Q 1122 2241 2028 2241
+L 2688 2241
+L 2688 2328
+Q 2688 2594 2478 2717
+Q 2269 2841 1825 2841
+Q 1466 2841 1156 2769
+Q 847 2697 581 2553
+L 581 3406
+Q 941 3494 1303 3539
+Q 1666 3584 2028 3584
+Q 2975 3584 3395 3211
+Q 3816 2838 3816 1997
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391
+L 3272 2541
+Q 2913 2691 2578 2766
+Q 2244 2841 1947 2841
+Q 1628 2841 1473 2761
+Q 1319 2681 1319 2516
+Q 1319 2381 1436 2309
+Q 1553 2238 1856 2203
+L 2053 2175
+Q 2913 2066 3209 1816
+Q 3506 1566 3506 1031
+Q 3506 472 3093 190
+Q 2681 -91 1863 -91
+Q 1516 -91 1145 -36
+Q 775 19 384 128
+L 384 978
+Q 719 816 1070 734
+Q 1422 653 1784 653
+Q 2113 653 2278 743
+Q 2444 834 2444 1013
+Q 2444 1163 2330 1236
+Q 2216 1309 1875 1350
+L 1678 1375
+Q 931 1469 631 1722
+Q 331 1975 331 2491
+Q 331 3047 712 3315
+Q 1094 3584 1881 3584
+Q 2191 3584 2531 3537
+Q 2872 3491 3272 3391
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494
+L 1759 3500
+L 2913 3500
+L 2913 2700
+L 1759 2700
+L 1759 1216
+Q 1759 972 1856 886
+Q 1953 800 2241 800
+L 2816 800
+L 2816 0
+L 1856 0
+Q 1194 0 917 276
+Q 641 553 641 1216
+L 641 2700
+L 84 2700
+L 84 3500
+L 641 3500
+L 641 4494
+L 1759 4494
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759
+L 4031 1441
+L 1416 1441
+Q 1456 1047 1700 850
+Q 1944 653 2381 653
+Q 2734 653 3104 758
+Q 3475 863 3866 1075
+L 3866 213
+Q 3469 63 3072 -14
+Q 2675 -91 2278 -91
+Q 1328 -91 801 392
+Q 275 875 275 1747
+Q 275 2603 792 3093
+Q 1309 3584 2216 3584
+Q 3041 3584 3536 3087
+Q 4031 2591 4031 1759
+z
+M 2881 2131
+Q 2881 2450 2695 2645
+Q 2509 2841 2209 2841
+Q 1884 2841 1681 2658
+Q 1478 2475 1428 2131
+L 2881 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131
+L 4056 0
+L 2931 0
+L 2931 347
+L 2931 1631
+Q 2931 2084 2911 2256
+Q 2891 2428 2841 2509
+Q 2775 2619 2662 2680
+Q 2550 2741 2406 2741
+Q 2056 2741 1856 2470
+Q 1656 2200 1656 1722
+L 1656 0
+L 538 0
+L 538 3500
+L 1656 3500
+L 1656 2988
+Q 1909 3294 2193 3439
+Q 2478 3584 2822 3584
+Q 3428 3584 3742 3212
+Q 4056 2841 4056 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-64" d="M 2919 2988
+L 2919 4863
+L 4044 4863
+L 4044 0
+L 2919 0
+L 2919 506
+Q 2688 197 2409 53
+Q 2131 -91 1766 -91
+Q 1119 -91 703 423
+Q 288 938 288 1747
+Q 288 2556 703 3070
+Q 1119 3584 1766 3584
+Q 2128 3584 2408 3439
+Q 2688 3294 2919 2988
+z
+M 2181 722
+Q 2541 722 2730 984
+Q 2919 1247 2919 1747
+Q 2919 2247 2730 2509
+Q 2541 2772 2181 2772
+Q 1825 2772 1636 2509
+Q 1447 2247 1447 1747
+Q 1447 1247 1636 984
+Q 1825 722 2181 722
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-70" d="M 1656 506
+L 1656 -1331
+L 538 -1331
+L 538 3500
+L 1656 3500
+L 1656 2988
+Q 1888 3294 2169 3439
+Q 2450 3584 2816 3584
+Q 3463 3584 3878 3070
+Q 4294 2556 4294 1747
+Q 4294 938 3878 423
+Q 3463 -91 2816 -91
+Q 2450 -91 2169 54
+Q 1888 200 1656 506
+z
+M 2400 2772
+Q 2041 2772 1848 2508
+Q 1656 2244 1656 1747
+Q 1656 1250 1848 986
+Q 2041 722 2400 722
+Q 2759 722 2948 984
+Q 3138 1247 3138 1747
+Q 3138 2247 2948 2509
+Q 2759 2772 2400 2772
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-69" d="M 538 3500
+L 1656 3500
+L 1656 0
+L 538 0
+L 538 3500
+z
+M 538 4863
+L 1656 4863
+L 1656 3950
+L 538 3950
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2d" d="M 347 2297
+L 2309 2297
+L 2309 1388
+L 347 1388
+L 347 2297
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-72" d="M 3138 2547
+Q 2991 2616 2845 2648
+Q 2700 2681 2553 2681
+Q 2122 2681 1889 2404
+Q 1656 2128 1656 1613
+L 1656 0
+L 538 0
+L 538 3500
+L 1656 3500
+L 1656 2925
+Q 1872 3269 2151 3426
+Q 2431 3584 2822 3584
+Q 2878 3584 2943 3579
+Q 3009 3575 3134 3559
+L 3138 2547
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391
+L 3366 2478
+Q 3138 2634 2908 2709
+Q 2678 2784 2431 2784
+Q 1963 2784 1702 2511
+Q 1441 2238 1441 1747
+Q 1441 1256 1702 982
+Q 1963 709 2431 709
+Q 2694 709 2930 787
+Q 3166 866 3366 1019
+L 3366 103
+Q 3103 6 2833 -42
+Q 2563 -91 2291 -91
+Q 1344 -91 809 395
+Q 275 881 275 1747
+Q 275 2613 809 3098
+Q 1344 3584 2291 3584
+Q 2566 3584 2833 3536
+Q 3100 3488 3366 3391
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6b" d="M 538 4863
+L 1656 4863
+L 1656 2216
+L 2944 3500
+L 4244 3500
+L 2534 1894
+L 4378 0
+L 3022 0
+L 1656 1459
+L 1656 0
+L 538 0
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-66" d="M 2841 4863
+L 2841 4128
+L 2222 4128
+Q 1984 4128 1890 4042
+Q 1797 3956 1797 3744
+L 1797 3500
+L 2753 3500
+L 2753 2700
+L 1797 2700
+L 1797 0
+L 678 0
+L 678 2700
+L 122 2700
+L 122 3500
+L 678 3500
+L 678 3744
+Q 678 4316 997 4589
+Q 1316 4863 1984 4863
+L 2841 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863
+L 1656 4863
+L 1656 0
+L 538 0
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-79" d="M 78 3500
+L 1197 3500
+L 2138 1125
+L 2938 3500
+L 4056 3500
+L 2584 -331
+Q 2363 -916 2067 -1148
+Q 1772 -1381 1288 -1381
+L 641 -1381
+L 641 -647
+L 991 -647
+Q 1275 -647 1404 -556
+Q 1534 -466 1606 -231
+L 1638 -134
+L 78 3500
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-54"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" x="54.962891"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="123.664062"/>
+     <use xlink:href="#DejaVuSans-Bold-43" x="188.166016"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="261.554688"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="329.035156"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="388.556641"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="436.359375"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="471.173828"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="538.996094"/>
+     <use xlink:href="#DejaVuSans-Bold-64" x="610.1875"/>
+     <use xlink:href="#DejaVuSans-Bold-70" x="681.769531"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" x="753.351562"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="822.052734"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="856.330078"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="927.521484"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="975.324219"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1034.845703"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" x="1069.660156"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1111.164062"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1145.978516"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1193.78125"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1243.097656"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1310.578125"/>
+     <use xlink:href="#DejaVuSans-Bold-6b" x="1369.855469"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="1433.734375"/>
+     <use xlink:href="#DejaVuSans-Bold-64" x="1501.556641"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" x="1573.138672"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1614.642578"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1682.123047"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1731.439453"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="1779.242188"/>
+     <use xlink:href="#DejaVuSans-Bold-66" x="1813.519531"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1857.025391"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1924.505859"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1983.783203"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="2031.585938"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="2066.400391"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="2115.716797"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="2183.539062"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="2251.019531"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="2322.210938"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" x="2389.691406"/>
+     <use xlink:href="#DejaVuSans-Bold-79" x="2423.96875"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="2489.154297"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="2548.675781"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="2582.953125"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_11">
+     <path d="M 381.641094 36.344906
+L 399.641094 36.344906
+L 399.641094 30.044906
+L 381.641094 30.044906
+z
+" style="fill: #4c78a8"/>
+    </g>
+    <g id="text_13">
+     <!-- Source -->
+     <g transform="translate(406.841094 36.344906) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-53" d="M 3425 4513
+L 3425 3897
+Q 3066 4069 2747 4153
+Q 2428 4238 2131 4238
+Q 1616 4238 1336 4038
+Q 1056 3838 1056 3469
+Q 1056 3159 1242 3001
+Q 1428 2844 1947 2747
+L 2328 2669
+Q 3034 2534 3370 2195
+Q 3706 1856 3706 1288
+Q 3706 609 3251 259
+Q 2797 -91 1919 -91
+Q 1588 -91 1214 -16
+Q 841 59 441 206
+L 441 856
+Q 825 641 1194 531
+Q 1563 422 1919 422
+Q 2459 422 2753 634
+Q 3047 847 3047 1241
+Q 3047 1584 2836 1778
+Q 2625 1972 2144 2069
+L 1759 2144
+Q 1053 2284 737 2584
+Q 422 2884 422 3419
+Q 422 4038 858 4394
+Q 1294 4750 2059 4750
+Q 2388 4750 2728 4690
+Q 3069 4631 3425 4513
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381
+L 544 3500
+L 1119 3500
+L 1119 1403
+Q 1119 906 1312 657
+Q 1506 409 1894 409
+Q 2359 409 2629 706
+Q 2900 1003 2900 1516
+L 2900 3500
+L 3475 3500
+L 3475 0
+L 2900 0
+L 2900 538
+Q 2691 219 2414 64
+Q 2138 -91 1772 -91
+Q 1169 -91 856 284
+Q 544 659 544 1381
+z
+M 1991 3584
+L 1991 3584
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-6f" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-75" x="124.658203"/>
+      <use xlink:href="#DejaVuSans-72" x="188.037109"/>
+      <use xlink:href="#DejaVuSans-63" x="226.900391"/>
+      <use xlink:href="#DejaVuSans-65" x="281.880859"/>
+     </g>
+    </g>
+    <g id="patch_12">
+     <path d="M 381.641094 49.555219
+L 399.641094 49.555219
+L 399.641094 43.255219
+L 381.641094 43.255219
+z
+" style="fill: #b279a2"/>
+    </g>
+    <g id="text_14">
+     <!-- Binary -->
+     <g transform="translate(406.841094 49.555219) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-42" d="M 1259 2228
+L 1259 519
+L 2272 519
+Q 2781 519 3026 730
+Q 3272 941 3272 1375
+Q 3272 1813 3026 2020
+Q 2781 2228 2272 2228
+L 1259 2228
+z
+M 1259 4147
+L 1259 2741
+L 2194 2741
+Q 2656 2741 2882 2914
+Q 3109 3088 3109 3444
+Q 3109 3797 2882 3972
+Q 2656 4147 2194 4147
+L 1259 4147
+z
+M 628 4666
+L 2241 4666
+Q 2963 4666 3353 4366
+Q 3744 4066 3744 3513
+Q 3744 3084 3544 2831
+Q 3344 2578 2956 2516
+Q 3422 2416 3680 2098
+Q 3938 1781 3938 1306
+Q 3938 681 3513 340
+Q 3088 0 2303 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-69" x="68.603516"/>
+      <use xlink:href="#DejaVuSans-6e" x="96.386719"/>
+      <use xlink:href="#DejaVuSans-61" x="159.765625"/>
+      <use xlink:href="#DejaVuSans-72" x="221.044922"/>
+      <use xlink:href="#DejaVuSans-79" x="262.158203"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pee68227b19">
+   <rect x="44.089063" y="21.406313" width="401.76" height="232.848"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/tests/test_paper_reproduce.py
+++ b/tests/test_paper_reproduce.py
@@ -1,0 +1,566 @@
+# ruff: noqa: PT009, PT027
+"""Contract tests for the archive-safe paper reproduction runner."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib
+import io
+import json
+import os
+import re
+import shutil
+import socket
+import tempfile
+import unittest
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import NoReturn
+from unittest import mock
+from zipfile import ZIP_DEFLATED, ZipFile
+
+_MPL_CONFIG_DIRECTORY = tempfile.TemporaryDirectory(prefix="oasis-paper-test-mpl-")
+os.environ.setdefault("MPLCONFIGDIR", _MPL_CONFIG_DIRECTORY.name)
+
+reproduce = importlib.import_module("paper.reproduce")
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SHA256_HEX_LENGTH = 64
+ZIP_CENTRAL_CRC_OFFSET = 16
+ZIP_CENTRAL_HEADER_SIGNATURE = b"PK\x01\x02"
+ZIP_CRC_SIZE = 4
+ZIP_LOCAL_EXTRA_LENGTH_OFFSET = 28
+ZIP_LOCAL_FILENAME_LENGTH_OFFSET = 26
+ZIP_LOCAL_HEADER_SIZE = 30
+ZIP_UINT16_SIZE = 2
+EXPECTED_LEDGER_STATUS_COUNTS = {
+    "blocked": 3,
+    "out-of-scope": 1,
+    "reproduced": 7,
+    "reproduced-with-deviation": 42,
+}
+EXPECTED_EXECUTION_OUTCOME_COUNTS = {
+    "blocked": 3,
+    "checked": 32,
+    "documentary-only": 17,
+    "out-of-scope": 1,
+}
+EXPECTED_ACCEPTANCE_CLASS_COUNTS = {
+    "close": 18,
+    "exact": 14,
+    "qualitative": 19,
+    "trace-only": 2,
+}
+TARGET_FIELDS = {
+    "acceptance",
+    "acceptance_class",
+    "artifacts",
+    "availability",
+    "checks",
+    "description",
+    "deviation",
+    "evidence",
+    "evidence_strength",
+    "expected",
+    "execution_outcome",
+    "group",
+    "id",
+    "inputs",
+    "kind",
+    "ledger_status",
+    "limitations",
+    "producer",
+    "source",
+    "summary",
+}
+CHECK_FIELDS = {"id", "target_id", "name", "observed", "expected", "passed"}
+EXPECTED_OUTPUTS = {
+    "classifier-summary.svg",
+    "enrichment-summary.svg",
+    "evidence-coverage.svg",
+    "pod-summary.svg",
+    "report.json",
+    "report.md",
+    "toxcast-summary.svg",
+}
+FOCUSED_SFIG1_OUTPUTS = {"evidence-coverage.svg", "report.json", "report.md"}
+LEDGER_RESULT_FIELDS = {
+    "source": "source",
+    "kind": "kind",
+    "description": "description",
+    "expected": "expected",
+    "acceptance": "acceptance",
+    "producer": "producer",
+    "evidence": "evidence",
+    "deviation": "deviation",
+    "ledger_status": "status",
+}
+
+
+def _input_snapshot() -> tuple[tuple[str, str], ...]:
+    paths = {REPOSITORY_ROOT / relative for relative in reproduce.ALLOWED_INPUTS}
+    for relative in reproduce.PROTECTED_INPUT_TREES:
+        paths.update(path for path in (REPOSITORY_ROOT / relative).rglob("*") if path.is_file())
+    return tuple(
+        (
+            path.relative_to(REPOSITORY_ROOT).as_posix(),
+            hashlib.sha256(path.read_bytes()).hexdigest(),
+        )
+        for path in sorted(paths)
+    )
+
+
+def _rendered_files(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(item for item in root.rglob("*") if item.is_file())
+    }
+
+
+class _NonStandardJsonConstantError(ValueError):
+    """A JSON document contains NaN or Infinity."""
+
+
+def _reject_json_constant(value: str) -> NoReturn:
+    raise _NonStandardJsonConstantError(value)
+
+
+def _mapping_keys(value: object) -> Iterator[str]:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            yield str(key)
+            yield from _mapping_keys(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _mapping_keys(child)
+
+
+def _expected_execution_outcome(recipe: object, *, checks_passed: bool) -> str:
+    if not checks_passed:
+        return "check-failed"
+    availability = recipe.availability
+    if availability == "available":
+        return "checked"
+    if availability == "documentary-only":
+        return "documentary-only"
+    if availability == "blocked":
+        return "blocked"
+    if availability == "out-of-scope":
+        return "out-of-scope"
+    return "invalid-availability"
+
+
+def _copy_inputs(root: Path, relatives: Iterator[str], overrides: Mapping[str, bytes]) -> None:
+    for relative in relatives:
+        destination = root / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if relative in overrides:
+            destination.write_bytes(overrides[relative])
+        else:
+            shutil.copyfile(REPOSITORY_ROOT / relative, destination)
+
+
+def _run_main_with_overrides(
+    validated_inputs: list[str],
+    overrides: Mapping[str, bytes],
+    *,
+    target: str = "TABLE-S1",
+) -> tuple[int, str]:
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        root = Path(temporary_directory)
+        _copy_inputs(root, iter(validated_inputs), overrides)
+        output = root / "output"
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(reproduce, "REPOSITORY_ROOT", root),
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            exit_code = reproduce.main(["--target", target, "--output", os.fspath(output)])
+        return exit_code, stderr.getvalue()
+
+
+def _corrupt_first_central_crc(workbook_bytes: bytes) -> bytes:
+    payload = bytearray(workbook_bytes)
+    with ZipFile(io.BytesIO(workbook_bytes)) as archive:
+        central_offset = archive.start_dir
+    if payload[central_offset : central_offset + len(ZIP_CENTRAL_HEADER_SIGNATURE)] != ZIP_CENTRAL_HEADER_SIGNATURE:
+        message = "XLSX central directory was not found at the declared offset"
+        raise ValueError(message)
+    crc_offset = central_offset + ZIP_CENTRAL_CRC_OFFSET
+    crc = int.from_bytes(payload[crc_offset : crc_offset + ZIP_CRC_SIZE], "little")
+    payload[crc_offset : crc_offset + ZIP_CRC_SIZE] = (crc ^ 1).to_bytes(ZIP_CRC_SIZE, "little")
+    return bytes(payload)
+
+
+def _corrupt_first_deflated_stream(workbook_bytes: bytes) -> bytes:
+    payload = bytearray(workbook_bytes)
+    with ZipFile(io.BytesIO(workbook_bytes)) as archive:
+        member = next(
+            info for info in archive.infolist() if info.compress_type == ZIP_DEFLATED and info.compress_size > 0
+        )
+    local_offset = member.header_offset
+    filename_length = int.from_bytes(
+        payload[
+            local_offset + ZIP_LOCAL_FILENAME_LENGTH_OFFSET : local_offset
+            + ZIP_LOCAL_FILENAME_LENGTH_OFFSET
+            + ZIP_UINT16_SIZE
+        ],
+        "little",
+    )
+    extra_length = int.from_bytes(
+        payload[
+            local_offset + ZIP_LOCAL_EXTRA_LENGTH_OFFSET : local_offset
+            + ZIP_LOCAL_EXTRA_LENGTH_OFFSET
+            + ZIP_UINT16_SIZE
+        ],
+        "little",
+    )
+    stream_offset = local_offset + ZIP_LOCAL_HEADER_SIZE + filename_length + extra_length
+    payload[stream_offset] ^= 0xFF
+    return bytes(payload)
+
+
+class PaperReproductionRunnerTest(unittest.TestCase):
+    """Exercise the public report and rendering contracts on tracked inputs."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Build one canonical report and record input bytes around the build."""
+        cls.before_build = _input_snapshot()
+        cls.report = reproduce.build_report(REPOSITORY_ROOT)
+        cls.after_build = _input_snapshot()
+
+    def test_registry_inventory_and_target_results_match_ledger(self) -> None:
+        """Bind every ledger row to one recipe, checks, inputs, and outcome."""
+        ledger = reproduce.load_targets(REPOSITORY_ROOT)
+        ledger_by_id = {row["id"]: row for row in ledger}
+        recipe_ids = list(reproduce.TARGET_RECIPES)
+
+        self.assertEqual(len(ledger), 53)
+        self.assertEqual(len(recipe_ids), 53)
+        self.assertEqual(len(set(recipe_ids)), 53)
+        self.assertEqual(set(recipe_ids), set(ledger_by_id))
+        self.assertEqual(
+            set(reproduce.TargetRecipe.__dataclass_fields__),
+            {"group", "evidence_strength", "availability", "inputs", "check_builder"},
+        )
+        for obsolete_name in ("REPRODUCED_IDS", "BLOCKED_IDS", "OUT_OF_SCOPE_IDS"):
+            self.assertFalse(hasattr(reproduce, obsolete_name), obsolete_name)
+        self.assertFalse(hasattr(reproduce, "_derive_run_result"))
+
+        self.assertEqual(self.report["schema_version"], 3)
+        self.assertEqual(self.report["summary"]["total"], 53)
+        self.assertEqual(self.report["summary"]["ledger_status_counts"], EXPECTED_LEDGER_STATUS_COUNTS)
+        self.assertEqual(
+            self.report["summary"]["execution_outcome_counts"],
+            EXPECTED_EXECUTION_OUTCOME_COUNTS,
+        )
+        self.assertNotIn("run_result_counts", self.report["summary"])
+        self.assertEqual(self.report["summary"]["acceptance_class_counts"], EXPECTED_ACCEPTANCE_CLASS_COUNTS)
+        self.assertEqual(
+            set(self.report["executed_groups"]),
+            {"sources_design", "activity_pods", "regression_enrichment", "toxcast", "classifier", "external_image"},
+        )
+        for group in self.report["groups"].values():
+            self.assertNotIn("run_result_counts", group)
+            self.assertEqual(sum(group["execution_outcome_counts"].values()), group["target_count"])
+
+        targets = {target["id"]: target for target in self.report["targets"]}
+        self.assertEqual(set(targets), set(ledger_by_id))
+        validated_inputs = set(self.report["validated_inputs"])
+        all_check_ids: list[str] = []
+        target_check_signatures: set[tuple[str, ...]] = set()
+        for target_id, target in targets.items():
+            self.assertEqual(set(target), TARGET_FIELDS)
+            ledger_row = ledger_by_id[target_id]
+            recipe = reproduce.TARGET_RECIPES[target_id]
+            for report_field, ledger_field in LEDGER_RESULT_FIELDS.items():
+                self.assertEqual(target[report_field], ledger_row[ledger_field])
+            self.assertEqual(target["inputs"], list(recipe.inputs))
+            self.assertEqual(target["availability"], recipe.availability)
+            self.assertTrue(target["checks"])
+            self.assertTrue(all(check["passed"] for check in target["checks"]))
+            self.assertEqual(
+                target["execution_outcome"],
+                _expected_execution_outcome(
+                    recipe,
+                    checks_passed=all(check["passed"] for check in target["checks"]),
+                ),
+            )
+            check_ids = tuple(check["id"] for check in target["checks"])
+            target_check_signatures.add(check_ids)
+            all_check_ids.extend(check_ids)
+            for check in target["checks"]:
+                self.assertEqual(set(check), CHECK_FIELDS)
+                self.assertEqual(check["target_id"], target_id)
+                self.assertTrue(check["id"].startswith(f"{target_id}:"))
+            self.assertTrue(set(target["inputs"]) <= validated_inputs)
+            for relative in target["inputs"]:
+                self.assertTrue((REPOSITORY_ROOT / relative).is_file(), relative)
+
+        self.assertEqual(len(all_check_ids), len(set(all_check_ids)))
+        self.assertEqual(len(target_check_signatures), 53)
+        for relative in validated_inputs:
+            self.assertTrue((REPOSITORY_ROOT / relative).is_file(), relative)
+
+        covered_nonpromoted = {
+            "BIOACTIVITY-002": "blocked",
+            "ENRICH-001": "blocked",
+            "ENRICH-002": "blocked",
+            "SFIG-1": "out-of-scope",
+        }
+        for target_id, expected_outcome in covered_nonpromoted.items():
+            self.assertEqual(targets[target_id]["execution_outcome"], expected_outcome)
+        self.assertEqual(targets["FILTER-002"]["ledger_status"], "reproduced-with-deviation")
+        self.assertEqual(targets["FILTER-002"]["execution_outcome"], "checked")
+
+    def test_selected_unknown_and_malformed_target_modes(self) -> None:
+        """Execute only SFIG-1 and fail closed on unknown or malformed targets."""
+        selected = reproduce.build_report(REPOSITORY_ROOT, selected_ids={"SFIG-1"})
+        self.assertEqual(selected["summary"]["total"], 1)
+        self.assertEqual([target["id"] for target in selected["targets"]], ["SFIG-1"])
+        self.assertEqual(selected["executed_groups"], ["external_image"])
+        self.assertEqual(set(selected["analyses"]), {"external_image"})
+        self.assertEqual(set(selected["groups"]), {"external_image"})
+        self.assertEqual(
+            set(selected["validated_inputs"]),
+            {"paper/targets.tsv", "paper/paper.md", "paper/figures/figure-s1.jpg"},
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "selected"
+            written = reproduce.render_outputs(selected, output)
+            self.assertEqual({path.name for path in written}, FOCUSED_SFIG1_OUTPUTS)
+            self.assertEqual(set(_rendered_files(output)), FOCUSED_SFIG1_OUTPUTS)
+
+        with self.assertRaisesRegex(reproduce.InputValidationError, "unknown selected target IDs"):
+            reproduce.build_report(REPOSITORY_ROOT, selected_ids={"UNKNOWN-999"})
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            paper = root / "paper"
+            paper.mkdir()
+            ledger_text = (REPOSITORY_ROOT / "paper/targets.tsv").read_text(encoding="ascii")
+            malformed = ledger_text.replace("\treproduced-with-deviation\t", "\tinvalid-status\t", 1)
+            self.assertNotEqual(malformed, ledger_text)
+            (paper / "targets.tsv").write_text(malformed, encoding="ascii")
+            with self.assertRaisesRegex(reproduce.InputValidationError, "invalid ledger status"):
+                reproduce.load_targets(root)
+
+    def test_main_returns_two_for_malformed_xlsx_and_ascii(self) -> None:
+        """Translate malformed workbook and ASCII inputs into CLI exit code 2."""
+        selected = reproduce.build_report(REPOSITORY_ROOT, selected_ids={"TABLE-S1"})
+        validated_inputs = selected["validated_inputs"]
+        self.assertIn("paper/sources/table-s1.xlsx", validated_inputs)
+        self.assertIn("paper/sources/SHA256SUMS", validated_inputs)
+
+        xlsx_code, xlsx_stderr = _run_main_with_overrides(
+            validated_inputs,
+            {"paper/sources/table-s1.xlsx": b"not an Office ZIP archive"},
+        )
+        self.assertEqual(xlsx_code, 2)
+        self.assertIn("malformed input", xlsx_stderr)
+
+        ascii_code, ascii_stderr = _run_main_with_overrides(
+            validated_inputs,
+            {"paper/sources/SHA256SUMS": b"\xff\xfe"},
+        )
+        self.assertEqual(ascii_code, 2)
+        self.assertIn("malformed input", ascii_stderr)
+
+    def test_main_returns_two_for_activity_xlsx_crc_and_stream_corruption(self) -> None:
+        """Classify activity-workbook CRC and compressed-stream failures as malformed."""
+        selected = reproduce.build_report(REPOSITORY_ROOT, selected_ids={"TABLE-S2"})
+        validated_inputs = selected["validated_inputs"]
+        relative = "paper/sources/table-s2.xlsx"
+        workbook_bytes = (REPOSITORY_ROOT / relative).read_bytes()
+        corruptions = {
+            "central CRC": _corrupt_first_central_crc(workbook_bytes),
+            "compressed stream": _corrupt_first_deflated_stream(workbook_bytes),
+        }
+
+        for label, corrupted_bytes in corruptions.items():
+            with self.subTest(corruption=label):
+                exit_code, stderr = _run_main_with_overrides(
+                    validated_inputs,
+                    {relative: corrupted_bytes},
+                    target="TABLE-S2",
+                )
+                self.assertEqual(exit_code, 2)
+                self.assertIn("malformed input", stderr)
+                self.assertNotIn("Traceback", stderr)
+
+    def test_rendering_is_deterministic_strict_json_and_read_only(self) -> None:
+        """Render identical safe bytes without mutating any input tree."""
+        self.assertEqual(self.before_build, self.after_build)
+        before_render = _input_snapshot()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            first = root / "first"
+            second = root / "second"
+            reproduce.render_outputs(self.report, first)
+            reproduce.render_outputs(self.report, second)
+            first_files = _rendered_files(first)
+            second_files = _rendered_files(second)
+
+            self.assertEqual(set(first_files), EXPECTED_OUTPUTS)
+            self.assertEqual(first_files, second_files)
+            self.assertEqual(len([name for name in first_files if name.endswith(".svg")]), 5)
+            for name, payload in first_files.items():
+                if name.endswith(".svg"):
+                    self.assertTrue(all(line == line.rstrip(" \t") for line in payload.decode("utf-8").splitlines()))
+            self.assertEqual(
+                (first / "report.md").read_bytes().decode("ascii").encode("ascii"),
+                first_files["report.md"],
+            )
+
+            json_bytes = first_files["report.json"]
+            json_text = json_bytes.decode("ascii")
+            parsed = json.loads(json_text, parse_constant=_reject_json_constant)
+            self.assertEqual(parsed, self.report)
+            self.assertNotIn(str(REPOSITORY_ROOT.resolve()), json_text)
+            self.assertNotIn(socket.gethostname(), json_text)
+            self.assertIsNone(re.search(r"\b20\d{2}-\d{2}-\d{2}[T ][0-2]\d:[0-5]\d", json_text))
+            forbidden_keys = {
+                "timestamp",
+                "generated_at",
+                "created_at",
+                "hostname",
+                "commit",
+                "branch",
+                "head",
+                "dirty",
+            }
+            for key in _mapping_keys(parsed):
+                normalized = key.casefold()
+                self.assertNotIn(normalized, forbidden_keys)
+                self.assertFalse(normalized.startswith("git_"))
+
+        self.assertEqual(_input_snapshot(), before_render)
+
+    def test_rendering_reconciles_known_outputs_and_preserves_unknown_files(self) -> None:
+        """Remove stale known outputs while preserving unknown files across scopes."""
+        selected = reproduce.build_report(REPOSITORY_ROOT, selected_ids={"SFIG-1"})
+        sentinel_bytes = b"unknown artifact stays untouched\n"
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "shared"
+            reproduce.render_outputs(self.report, output)
+            sentinel = output / "sentinel.txt"
+            sentinel.write_bytes(sentinel_bytes)
+
+            reproduce.render_outputs(selected, output)
+            focused_files = _rendered_files(output)
+            self.assertEqual(set(focused_files), FOCUSED_SFIG1_OUTPUTS | {"sentinel.txt"})
+            self.assertEqual(focused_files["sentinel.txt"], sentinel_bytes)
+
+            reproduce.render_outputs(self.report, output)
+            full_files = _rendered_files(output)
+            self.assertEqual(set(full_files), EXPECTED_OUTPUTS | {"sentinel.txt"})
+            self.assertEqual(full_files["sentinel.txt"], sentinel_bytes)
+
+    def test_committed_outputs_are_fresh(self) -> None:
+        """Keep the checked-in executable-paper report synchronized with the runner."""
+        committed = REPOSITORY_ROOT / "paper/reproduction"
+        self.assertEqual(set(_rendered_files(committed)), EXPECTED_OUTPUTS)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            generated = Path(temporary_directory) / "generated"
+            reproduce.render_outputs(self.report, generated)
+            self.assertEqual(_rendered_files(committed), _rendered_files(generated))
+
+    def test_protected_output_patterns_are_rejected_without_writes(self) -> None:
+        """Reject every protected input-tree pattern inside a temporary root."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            for relative in (*reproduce.PROTECTED_INPUT_TREES, *reproduce.FORBIDDEN_OUTPUT_TREES):
+                output = root / relative / "generated"
+                with self.subTest(relative=relative):
+                    with self.assertRaisesRegex(reproduce.InputValidationError, "protected input tree"):
+                        reproduce.render_outputs(self.report, output)
+                    self.assertFalse(output.exists())
+
+    def test_source_activity_pod_enrichment_and_toxcast_values(self) -> None:
+        """Pin representative source and scientific reanalysis values."""
+        analyses = self.report["analyses"]
+        sources = analyses["sources_design"]
+        self.assertEqual(sources["source_count"], 8)
+        self.assertEqual(sources["office_archive_count"], 6)
+        self.assertEqual(len(sources["sources"]), 8)
+        self.assertTrue(all(len(source["sha256"]) == SHA256_HEX_LENGTH for source in sources["sources"]))
+        self.assertTrue(all(archive["crc_passed"] for archive in sources["office_archives"]))
+
+        activity = analyses["activity_pods"]
+        self.assertEqual(
+            activity["table_s2_counts"],
+            {"MT": 429, "Cell count": 220, "LDH": 147, "unique_compounds": 437},
+        )
+        figure_2d = activity["figure_2d"]
+        self.assertEqual(figure_2d["complete_case_count"], 121)
+        expected_medians = {
+            "Morphology": 5.05543414478975,
+            "MT": 8.95705965699234,
+            "Cell count": 23.8188547870137,
+            "LDH": 40.5354608552776,
+        }
+        expected_folds = {"mt": 1.78550470485347, "cellcount": 4.28127228016061, "ldh": 8.15371968189112}
+        for name, expected in expected_medians.items():
+            self.assertAlmostEqual(figure_2d["median_pod_um"][name], expected, places=12)
+        for name, expected in expected_folds.items():
+            self.assertAlmostEqual(figure_2d["geometric_fold_ratio_vs_morphology"][name], expected, places=12)
+
+        enrichment = analyses["regression_enrichment"]["files"]
+        self.assertEqual(
+            {name: values["significant_count"] for name, values in enrichment.items()},
+            {
+                "err_higher_targets.csv": 178,
+                "err_lower_targets.csv": 0,
+                "mtt_higher_targets.csv": 147,
+                "mtt_lower_targets.csv": 107,
+            },
+        )
+        toxcast = analyses["toxcast"]
+        self.assertEqual(toxcast["source_endpoint_counts"], {"cellbased": 292, "cellfree": 72, "cytotox": 48})
+        self.assertEqual(toxcast["binary_endpoint_counts"], {"cellbased": 292, "cellfree": 72, "cytotox": 38})
+
+    def test_classifier_denominators_and_table_2_values(self) -> None:
+        """Pin endpoint counts, Table 2, and the FILTER-002 contrast."""
+        classifier = self.report["analyses"]["classifier"]
+        self.assertEqual(
+            classifier["modeled_endpoint_counts"],
+            {"axiom": 2, "toxcast_cytotox": 34, "toxcast_cellbased": 267, "toxcast_cellfree": 53},
+        )
+        expected = {
+            ("LDH", "Cell count"): (0.730446194225722, 0.418537755354911, 840, 127),
+            ("LDH", "Random"): (0.500543682039745, 0.137194940827752, 840, 127),
+            ("LDH", "CellProfiler"): (0.932395950506187, 0.768307081802129, 840, 127),
+            ("LDH", "CP-CNN"): (0.925928008998875, 0.721697609100053, 840, 127),
+            ("LDH", "DINO"): (0.939551209257365, 0.769631728263681, 839, 127),
+            ("MTT", "Cell count"): (0.688951320954717, 0.639079036992903, 589, 378),
+            ("MTT", "Random"): (0.50539431014813, 0.396563421811497, 589, 378),
+            ("MTT", "CellProfiler"): (0.870698251003854, 0.842825856470077, 589, 378),
+            ("MTT", "CP-CNN"): (0.858888410245365, 0.834197186534911, 588, 379),
+            ("MTT", "DINO"): (0.875944822373394, 0.837959459995157, 588, 378),
+        }
+        rows = {(row["endpoint"], row["row"]): row for row in classifier["table2"]["rows"]}
+        self.assertEqual(set(rows), set(expected))
+        for key, (auroc, prauc, count_0, count_1) in expected.items():
+            self.assertAlmostEqual(rows[key]["auroc"], auroc, places=12)
+            self.assertAlmostEqual(rows[key]["prauc"], prauc, places=12)
+            self.assertEqual((rows[key]["count_0"], rows[key]["count_1"]), (count_0, count_1))
+
+        filter_effects = classifier["filter_effects"]
+        self.assertAlmostEqual(
+            filter_effects["toxcast_cellbased"]["auroc"]["mean_difference"],
+            -0.007970189040984989,
+            places=12,
+        )
+        self.assertAlmostEqual(
+            filter_effects["toxcast_cellfree"]["auroc"]["mean_difference"],
+            0.013429166433284439,
+            places=12,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `uv run paper/reproduce.py` as a single archive-safe tracked-evidence audit for all 53 paper targets
- give every target an explicit recipe, validated inputs, target-specific checks, evidence strength, and independent execution outcome
- retain historical ledger statuses while distinguishing 32 checked, 17 documentary-only, 3 blocked, and 1 out-of-scope targets
- commit deterministic Markdown, strict JSON, and five simplified SVG summaries
- add focused execution, malformed-input handling, protected-output checks, and canonical freshness tests

## Scope

This runner reanalyzes committed sources, annotation inputs, and compiled artifacts.
It does not run ignored upstream workflows, notebooks, classifiers, curve fits, external downloads, or GPU jobs.
Known deviations and unavailable evidence remain explicit, including the 963-ID ToxCast annotation union versus the documented 670-ID tested intersection and the 342-versus-156 Figure 2C universe difference.

## Verification

- `uv --cache-dir /tmp/oasis-uv-cache-20260804 run --locked paper/reproduce.py`
- `uv --cache-dir /tmp/oasis-uv-cache-20260804 lock --check --script paper/reproduce.py`
- `pixi run --frozen -e pipeline python -m unittest discover -v` - 22 passed
- `pixi run --frozen -e pipeline ruff check paper/reproduce.py tests/test_paper_reproduce.py`
- `pixi run --frozen -e pipeline ruff format --check paper/reproduce.py tests/test_paper_reproduce.py`
- fresh Git-less `git archive` run produced all seven canonical outputs byte-for-byte
- independent scientific and software/archive audits passed with no blockers

## Review notes

- This is stacked on `codex/paper-reproduction-contract` while PR #39 remains open.
- The full external-data/GPU regeneration path remains documented in `REPRODUCING.md` and is intentionally outside this PR.
