### PR TITLE
Document and verify archive reconstruction

### DIFF
--- a/image_archive/README.md
+++ b/image_archive/README.md
@@ -1,63 +1,121 @@
-# OASIS JPEG XL image archive
+# Reconstruct the Axiom OASIS JPEG XL image archive
 
-This workflow builds a storage derivative of the Axiom OASIS TIFF collection.
+This runbook reconstructs the Axiom OASIS JPEG XL v1 archive from a fresh checkout.
+Run every command from the repository root.
 The original Cell Painting Gallery TIFFs remain the source of truth.
 
-The tracked contract in `image_archive/axiom/source.toml` is the authoritative dataset description.
-It pins the image index, expected inventory, source S3 namespace, codec settings, destination layout, batches, and channels without duplicating those values in Python.
-Its channel-number mapping is DNA 1, ER 2, AGP 3, RNA 4, Mito 5, and Brightfield 6.
-The only v1 codec is JPEG XL HQ with distance 1.0 and effort 5, identified as `jpegxl-d1-e5`.
-Those settings reproduce the `jpegxl_lossy_hq` tier in JUMP_lite's [`compress_tif.py`](https://github.com/afermg/JUMP_lite/blob/5f0fc9be6135e74cfee0b3504fd20a35a9531a22/src/compress_tif.py), pinned at commit `5f0fc9be6135e74cfee0b3504fd20a35a9531a22` and source-file SHA-256 `9bb6bec0a23a8fb091c1e1990f62690c55b74e34d1a49165b21bbb1aabaa54bf`.
-The reference leaves JPEG XL effort at its imagecodecs default, which is byte-identical to explicit effort 5 in the pinned images environment.
-Each complete source TIFF becomes one standard `.jxl` object at:
+Deterministic reconstruction succeeds when the pinned index produces the exact inventory and rejected-row artifacts, every inventory row has the exact ledger-bound source and output evidence recorded by the historical receipt, the final counts and byte totals match, and the deterministic validation report matches.
+Host, timestamps, attempts, retry history, service history, absolute paths, historical command spellings, mtimes, and other execution details are context only.
+They do not need to match the 2026-08-05 run.
 
-```text
-/work/datasets/cpg0037-oasis/axiom/images-jxl/v1/
-  jpegxl-d1-e5/<batch>/images/<plate>/<stem>.jxl
+The `jpegxl-d1-e5` tier is lossy JPEG XL at distance 1.0 and effort 5.
+No channel stacking, normalization, intensity transformation, cropping, resizing, or biological recalibration is performed.
+Biological equivalence to the source TIFFs has not been established for this dataset.
+Use the TIFFs for measurements and scientific results, and use this derivative only for browsing, visualization, and retrieval.
+Issue [#44](https://github.com/broadinstitute/2024_09_09_Axiom_OASIS/issues/44) records the available measurements and the particular Brightfield concern.
+
+## 1. Start from a clean checkout and enter the pinned environment
+
+Confirm that this is the repository root and that the reconstruction inputs are tracked and unmodified:
+
+```bash
+test -f image_archive/axiom/source.toml
+test -f image_archive/records/run-receipt-2026-08-05.toml
+git diff --exit-code -- \
+  image_archive/axiom/source.toml \
+  image_archive/records/run-receipt-2026-08-05.toml \
+  pixi.lock \
+  flake.lock
 ```
 
-The completed Spirit v1 run is frozen in `image_archive/records/run-receipt-2026-08-05.toml`.
-That machine-readable receipt binds the exact source and manifest identities, codec runtime, two conversion phases, a deterministically specified ledger evidence digest and totals, and the external validation report without copying generated image data into Git.
+Approve the repository environment once, install the locked `images` environment without updating the lockfile, and enter it through `direnv` for every command:
 
-No channel stacking, normalization, intensity transformation, cropping, resizing, or biological recalibration is performed.
+```bash
+direnv allow
+direnv exec . pixi install --locked -e images
+direnv exec . pixi run -e images python --version
+git diff --exit-code -- pixi.lock flake.lock
+```
 
-## Known limitation: do not measure from this archive
+The environment remains named `images` because renaming it would rewrite `pixi.lock`.
+Do not update dependencies or regenerate either lockfile during reconstruction.
 
-`jpegxl-d1-e5` is a lossy tier, and no one has checked whether profiles computed from these `.jxl` objects match profiles computed from the source TIFFs for this dataset.
-Use the Cell Painting Gallery TIFFs for anything that ends up in a result, and treat this archive as a storage derivative for browsing, visualization, and retrieval.
+## 2. Verify the tracked contract, lockfiles, and immutable receipt
 
-The tier is not unexamined: JUMP-lite, where these settings come from, evaluates it against a lossless reference on a large JUMP subset.
-That was measured on JUMP, not on Axiom OASIS.
-Brightfield is the weakest channel here by a wide margin, because transmitted light occupies a narrow intensity band that a perceptual codec has no way to know is load-bearing.
+Verify the exact bytes in the current checkout:
 
-Measurements, the codec authors' own guidance on this failure mode, and what remains to be checked are in [issue #44](https://github.com/broadinstitute/2024_09_09_Axiom_OASIS/issues/44).
+```bash
+sha256sum --check <<'EOF'
+a85639eb25908bdf900a67daeba8fc8a755db4c03841d21aff3fed9609d197dd  image_archive/axiom/source.toml
+d4af5e083b90a50a2a891ad1a068cd54510f6da274801388fd81bb1cffba4e99  image_archive/records/run-receipt-2026-08-05.toml
+55665368f14dc6e2b82b5b06bc5b6495abad863ff40fff10f93bea34235fe900  pixi.lock
+8628426df569bbe3fb2b8367fbb411fb4cd4c04f023b1afeeb2cba094b7f8c30  flake.lock
+EOF
+```
 
-## Requirements
+The immutable historical receipt records `pixi_lock_sha256 = f1412dfb...`, which was the whole-repository lockfile at the original archive run.
+Later tracked paper-environment work changed the whole lockfile to the current hash above without changing the pinned `images` package versions recorded in the receipt.
+The receipt comparison therefore treats lockfile hashes and runtime versions as historical context; it does not require a current whole-repository lockfile to reproduce an earlier unrelated environment graph.
+The contract and receipt hashes themselves must remain exact.
 
-Run through the dedicated Pixi environment from the repository root.
-That environment is still named `images` even though the directories were renamed: `pixi.lock` keys environments by name, so renaming it rewrites the lockfile and invalidates the `pixi_lock_sha256` pinned in the run receipt.
-Before any image transfer, provision and register the destination according to the host's storage policy.
-The command-line interface requires the configured destination to exist, be writable, contain no symlinked path components, and reside on a non-root mounted filesystem.
-User, group, registry, and exact-path policy remain in the runbook and service configuration rather than the reusable Python code.
+The contract pins Zenodo record 17067683, `index.parquet` SHA-256 `f83a16fa...`, the public S3 namespace, all inventory counts and mappings, the one-TIFF-to-one-JXL destination rule, and the JUMP_lite codec provenance.
+The inventory command rehashes the downloaded index before accepting it.
 
-Run the archive tests from the repository root:
+## 3. Run the focused tests and inspect the CLI
+
+Run the complete focused archive test suite and both help surfaces before touching external storage:
 
 ```bash
 direnv exec . pixi run -e images python -m unittest discover -s image_archive/tests
+direnv exec . pixi run -e images python -m image_archive --help
+direnv exec . pixi run -e images python -m image_archive verify-receipt --help
 ```
 
-## Ownership
+The workflow engine consists of `inventory`, `archive`, `status`, and `validate`.
+`verify-receipt` is a final read-only comparison and never substitutes for any of those four commands.
 
-The reusable Axiom-style engine is the Python package in `image_archive/`.
-The concrete dataset contract is `image_archive/axiom/source.toml`, the host deployment is in `image_archive/deploy/`, the immutable completed-run record is in `image_archive/records/`, and the focused test suite is in `image_archive/tests/`.
-The engine consumes the canonical manifest columns and the contract; image dimensions and dataset names are not compiled into the runtime.
+## 4. Provision and register the external destination
 
-Generated state is external to Git under the contracted destination.
-`_archive/` owns the inventory, rejected rows, remote reconciliation, schema-v4 ledger, progress, and validation report; `jpegxl-d1-e5/` owns the generated JPEG XL objects; and `.oasis-images.lock` coordinates every mutating workflow.
+The contracted destination is:
 
-## Workflow
+```text
+/work/datasets/cpg0037-oasis/axiom/images-jxl/v1
+```
 
-Run the metadata-only preflight first:
+First verify that `/work/datasets` is available from a non-root mounted filesystem:
+
+```bash
+archive_root=/work/datasets/cpg0037-oasis/axiom/images-jxl/v1
+test -d /work/datasets
+test "$(direnv exec . findmnt -nro TARGET -T /work/datasets)" != "/"
+direnv exec . findmnt -T /work/datasets
+```
+
+Create the exact destination with the operator's registered storage group, then verify writability and path resolution:
+
+```bash
+archive_root=/work/datasets/cpg0037-oasis/axiom/images-jxl/v1
+archive_group=$(id -gn)
+sudo install -d -o "$(id -un)" -g "$archive_group" -m 2770 "$archive_root"
+test -d "$archive_root"
+test -w "$archive_root"
+direnv exec . namei -l "$archive_root"
+```
+
+Register this exact root in `/work/datasets/REGISTRY.yaml` using the schema and ownership fields of the adjacent `cpg0037-oasis` entry:
+
+```bash
+sudoedit /work/datasets/REGISTRY.yaml
+rg -n 'cpg0037-oasis|axiom/images-jxl/v1' /work/datasets/REGISTRY.yaml
+```
+
+Stop if the mount, group, registry entry, or exact path is wrong.
+The CLI also rejects a missing destination, a root-filesystem destination, a non-writable destination, or any symlinked path component.
+Generated state belongs under `$archive_root/_archive`, generated objects under `$archive_root/jpegxl-d1-e5`, and the destination-scoped coordination file is `$archive_root/.oasis-images.lock`.
+
+## 5. Build and review the remote inventory
+
+Run the metadata-only preflight before transferring any TIFF pixels:
 
 ```bash
 direnv exec . pixi run -e images python -m image_archive inventory \
@@ -65,15 +123,26 @@ direnv exec . pixi run -e images python -m image_archive inventory \
   --remote-snapshot
 ```
 
-The inventory command is the preflight: it verifies `image_archive/axiom/source.toml` and the pinned `index.parquet` artifact, checks the expected row, batch, plate, field, channel, complete-URI, and incomplete-row counts, and plans destination keys.
-It paginates the four public S3 batch prefixes without downloading TIFF pixels and records size, ETag, last-modified time, storage class, and version ID where available.
-Missing indexed objects fail the preflight.
-Prefix-extra objects are preserved in a separate report and never added silently to the pinned-index scope.
-The final enriched inventory and rejected-row artifact are SHA-256 pinned in `image_archive/axiom/source.toml`.
-The summary reports remote reconciliation, while the two contract pins and the ledger manifest binding protect the build scope directly.
-It must not download any source TIFF or write any JPEG XL object.
+This verifies the pinned index bytes and exact six-column Axiom schema, requires 2,019,342 index rows, plans 2,017,182 complete unique TIFFs, preserves 2,160 incomplete rows as explicit rejections, and reconciles every indexed object against the four public S3 batch prefixes.
+It records prefix extras separately and never adds them to the pinned scope.
+It does not download TIFF pixels or write JPEG XL objects.
 
-After reviewing the preflight report and confirming storage registration, start or resume the archive explicitly:
+Review the generated summary and exact artifacts:
+
+```bash
+archive_work=/work/datasets/cpg0037-oasis/axiom/images-jxl/v1/_archive
+direnv exec . pixi run -e images python -m json.tool "$archive_work/summary.json"
+sha256sum --check <<'EOF'
+b8c20a37213831b55161a8ed9fe0a1c60522c8951f2b5e19713c7105c8200381  /work/datasets/cpg0037-oasis/axiom/images-jxl/v1/_archive/inventory.parquet
+0bd61c7b852530c8d3ec491f2a99bab2f4cf15bbf1b015389c571ca7c768a66a  /work/datasets/cpg0037-oasis/axiom/images-jxl/v1/_archive/rejected.parquet
+EOF
+```
+
+Do not start conversion unless `indexed_missing_count` is zero, `indexed_present_count` is 2,017,182, `indexed_present_bytes` is 17,825,492,086,890, the inventory and rejected counts are exact, and both hashes pass.
+
+## 6. Start or resume conversion with the direct CLI
+
+The direct CLI is the primary launch path:
 
 ```bash
 direnv exec . pixi run -e images python -m image_archive archive \
@@ -84,17 +153,21 @@ direnv exec . pixi run -e images python -m image_archive archive \
   --max-consecutive-failures 32
 ```
 
-Each selected TIFF is downloaded, checked against its pinned size, ETag, and version ID when available, decoded as one 2D uint16 plane, encoded, decoded again at the same shape and dtype, and promoted through an atomic sibling write.
-The ledger stores full source and output SHA-256 evidence and retries failures up to five times in the same invocation.
-The run stops scheduling new images after 32 consecutive failed conversion attempts, leaving untouched rows pending instead of repeating a systemic storage, codec, or network failure across the full inventory.
-Normal resume verifies the exact manifest binding without rereading terabytes of prior outputs.
-Use `archive --audit-verified` only when a full pre-resume hash/decode scan is warranted; it is intentionally expensive.
-The inventory, archive, and validation workflows share one destination-scoped exclusive lock, so only one process can mutate the archive at a time.
+Each selected TIFF is checked against its remote size, ETag, and version ID when available, decoded as one 2D uint16 plane, encoded by a single-threaded codec worker, decoded at the same shape and dtype, and promoted through an atomic sibling write.
+The schema-v4 SQLite ledger binds the exact manifest and stores source and output hashes and byte counts.
+The circuit breaker stops new scheduling after 32 consecutive failed conversion attempts so that a systemic failure does not sweep the inventory.
 
-After correcting the cause of a terminal error, resume with a cumulative attempt ceiling above the recorded count, for example `archive --max-attempts 10` after the default five attempts are exhausted.
-Do not edit or delete ledger rows to force a retry.
+An interruption is safe.
+Rerun the exact same command to recover `running` rows to `pending` and resume from the durable ledger.
+Normal resume trusts only exact manifest binding and prior `verified` ledger evidence; it does not treat file existence as completion.
+Use `archive --audit-verified` only when an expensive full hash/decode scan before resume is specifically warranted.
+After correcting a terminal error, raise the cumulative ceiling, for example to `--max-attempts 10`, instead of editing or deleting ledger rows.
 
-For an unattended full build, install the tracked user service from the canonical repository checkout:
+## 7. Optionally use the tracked systemd service
+
+This is an optional Spirit-specific wrapper around the same `archive` command and the same 64-worker, 128-in-flight profile.
+Choose either the direct CLI in step 6 or the service for a given run; the destination lock prevents both from mutating the archive together.
+The unit assumes the canonical checkout at `/work/users/shsingh/GitHub/oasis/2024_09_09_Axiom_OASIS` and `/work/datasets` as a mount point.
 
 ```bash
 mkdir -p ~/.config/systemd/user
@@ -105,26 +178,93 @@ systemctl --user daemon-reload
 systemctl --user enable --now oasis-axiom-jpegxl.service
 ```
 
-The service needs user lingering enabled to survive SSH logout.
-Monitor it with `systemctl --user status oasis-axiom-jpegxl.service` and `journalctl --user -fu oasis-axiom-jpegxl.service`.
-It uses the completed Spirit run's setting of 64 single-threaded codec workers and at most 128 conversions in flight, lowers CPU and I/O scheduling priority, and stops for inspection after an ordinary terminal failure.
+User lingering must already be enabled for the service to survive SSH logout.
+The service lowers CPU and I/O priority and stops for inspection after an ordinary terminal failure.
+It performs conversion only; it never runs final validation or receipt verification.
 
-The conversion service stops after ledger completion and does not run the whole-archive validator.
-After conversion has stopped and released the destination lock, inspect durable progress and run the final completeness gate separately:
+## 8. Monitor and resume without changing evidence
+
+`status` reads durable ledger progress and does not hash or decode outputs:
 
 ```bash
 direnv exec . pixi run -e images python -m image_archive status \
   --contract image_archive/axiom/source.toml
+```
+
+For the optional service, monitor its wrapper separately:
+
+```bash
+systemctl --user status oasis-axiom-jpegxl.service
+journalctl --user -fu oasis-axiom-jpegxl.service
+```
+
+If the service is active, stop it and wait for lock release before using the direct CLI:
+
+```bash
+systemctl --user stop oasis-axiom-jpegxl.service
+systemctl --user is-active oasis-axiom-jpegxl.service
+```
+
+Conversion is ledger-complete only when `verified` is 2,017,182, `pending`, `running`, `error`, and `unresolved` are zero, the manifest binding matches, and `ledger_complete` is true.
+This is not yet full archive validation.
+
+## 9. Run the separate full validation gate
+
+After conversion has stopped and released the destination lock, hash and decode every verified output:
+
+```bash
 direnv exec . pixi run -e images python -m image_archive validate \
   --contract image_archive/axiom/source.toml \
   --workers 64 \
   --max-attempts 5
 ```
 
-Conversion is complete only when all 2,017,182 complete unique TIFF URIs have verified JPEG XL objects and all 2,160 incomplete index rows remain explicitly accounted for.
-The archive is fully validated only when the separate full `validate` command reports `complete: true` after hashing and decoding all 2,017,182 outputs.
-Resume trusts only rows that reached `verified` after source identity checks, JPEG XL decoding, atomic promotion, and an on-disk output hash/decode check.
-It never treats bare file existence as completion.
-The full validator detects later corruption, and `archive --audit-verified` requeues invalid outputs for atomic replacement.
-Any unresolved transfer, encode, decode, contract, count, or completeness error produces a nonzero exit status and prevents a complete status.
-`status` reports durable ledger progress and is not an on-disk completeness gate; only the full `validate` command hashes and decodes every verified JPEG XL object.
+This is the expensive whole-archive validator.
+It checks output byte identity against the ledger, JPEG XL decoding, shape and dtype, inventory and rejected-row counts, manifest binding, and final completeness.
+Any invalid or unresolved object produces a nonzero exit status.
+The required result is `complete: true`, `audit_passed: true`, `checked: 2017182`, `invalid: 0`, and no failures or unresolved rows.
+The deterministic report is written to `_archive/validation.json`.
+
+## 10. Compare reconstructed evidence with the historical receipt
+
+Run the focused comparison only after full validation:
+
+```bash
+direnv exec . pixi run -e images python -m image_archive verify-receipt \
+  --contract image_archive/axiom/source.toml \
+  --receipt image_archive/records/run-receipt-2026-08-05.toml
+```
+
+`verify-receipt` first checks the receipt schema, receipt ID, contract byte hash, and pinned index identity.
+It then acquires the existing destination lock in shared nonblocking mode and refuses to run while `inventory`, `archive`, or `validate` holds the exclusive lock.
+It hashes the inventory, rejected rows, and validation report; checks Parquet row counts; recomputes the manifest identity; opens SQLite with `mode=ro`, `immutable=1`, and `PRAGMA query_only`; checks schema, record count, exact manifest binding, final counts, and byte totals; and streams the receipt-defined canonical ledger evidence digest.
+It does not create a directory or lock, recover or migrate a ledger, invoke another workflow, inspect or rewrite JPEG XL objects, or write a report.
+All deterministic mismatches are printed together and the command exits nonzero.
+
+The required output has `matches: true` and an empty `mismatches` list.
+The expected deterministic evidence includes:
+
+```text
+manifest identity SHA-256: 24a0621ce8b5e88914e50fb4710515811b9f382450cad38d675dba001507b207
+ledger evidence SHA-256:   bae3ad62b1940e9f97b964a9fc658ad0d8e13ba0d5e5d9fcb6ecedb7c0b2112a
+source bytes:              17825492086890
+output bytes:              323337920405
+validation report SHA-256: 83ad5f170295039102fe619c6108c7f76c70eede2678baf1b391513b3e4cb457
+```
+
+The output also reports historical host, paths, attempt distribution, and timestamps as context.
+Those fields may differ and never cause reconstruction failure.
+
+## 11. Declare reconstruction complete
+
+Reconstruction is complete only when all of the following are true:
+
+1. The tracked contract and historical receipt retain their exact SHA-256 hashes.
+2. The pinned index and remote inventory preflight pass with zero indexed objects missing.
+3. `inventory.parquet` and `rejected.parquet` have the exact hashes and counts in the contract and receipt.
+4. `status` reports 2,017,182 verified rows, zero unresolved rows, and an exact manifest binding.
+5. The separate full validator reports `complete: true` and `audit_passed: true` for all 2,017,182 outputs and 2,160 rejected rows.
+6. `verify-receipt` reports `matches: true` with no deterministic mismatch.
+7. No claim is made that the lossy derivative is biologically equivalent to the source TIFFs.
+
+Do not recompress an already verified archive merely to reproduce historical timestamps, attempts, host details, command paths, or service history.

--- a/image_archive/README.md
+++ b/image_archive/README.md
@@ -91,18 +91,23 @@ test "$(direnv exec . findmnt -nro TARGET -T /work/datasets)" != "/"
 direnv exec . findmnt -T /work/datasets
 ```
 
-Create the exact destination with the operator's registered storage group, then verify writability and path resolution:
+The storage-policy group for this hierarchy is `nogroup`.
+Require that membership explicitly, create the exact destination, and verify its ownership, mode, writability, and path resolution:
 
 ```bash
 archive_root=/work/datasets/cpg0037-oasis/axiom/images-jxl/v1
-archive_group=$(id -gn)
+archive_group=nogroup
+id -nG | tr ' ' '\n' | grep -Fx "$archive_group"
 sudo install -d -o "$(id -un)" -g "$archive_group" -m 2770 "$archive_root"
 test -d "$archive_root"
 test -w "$archive_root"
+test "$(direnv exec . stat -c '%U:%G:%a' "$archive_root")" = "$(id -un):nogroup:2770"
+direnv exec . stat -c '%U:%G %a %n' "$archive_root"
 direnv exec . namei -l "$archive_root"
 ```
 
-Register this exact root in `/work/datasets/REGISTRY.yaml` using the schema and ownership fields of the adjacent `cpg0037-oasis` entry:
+Register this exact root in `/work/datasets/REGISTRY.yaml` with its existing `name`, `description`, `date_added`, and `owner` fields.
+The registry does not carry a group field; `nogroup` is enforced by filesystem ownership and membership:
 
 ```bash
 sudoedit /work/datasets/REGISTRY.yaml
@@ -235,8 +240,11 @@ direnv exec . pixi run -e images python -m image_archive verify-receipt \
   --receipt image_archive/records/run-receipt-2026-08-05.toml
 ```
 
-`verify-receipt` first checks the receipt schema, receipt ID, contract byte hash, and pinned index identity.
+`verify-receipt` first requires the receipt's deterministic projection to match the single historical production anchor, before it resolves the destination or any archive artifact.
+That projection binds every receipt value used as a reconstruction expectation while excluding host, timestamps, attempts, retries, service history, absolute paths, and mtimes.
+It then checks the receipt schema, receipt ID, contract byte hash, and pinned index identity.
 It then acquires the existing destination lock in shared nonblocking mode and refuses to run while `inventory`, `archive`, or `validate` holds the exclusive lock.
+While holding the shared lock, it also refuses any nonempty `state.sqlite3-wal` before opening the main database as immutable.
 It hashes the inventory, rejected rows, and validation report; checks Parquet row counts; recomputes the manifest identity; opens SQLite with `mode=ro`, `immutable=1`, and `PRAGMA query_only`; checks schema, record count, exact manifest binding, final counts, and byte totals; and streams the receipt-defined canonical ledger evidence digest.
 It does not create a directory or lock, recover or migrate a ledger, invoke another workflow, inspect or rewrite JPEG XL objects, or write a report.
 All deterministic mismatches are printed together and the command exits nonzero.

--- a/image_archive/__main__.py
+++ b/image_archive/__main__.py
@@ -14,6 +14,7 @@ from .archive import DEFAULT_MAX_CONSECUTIVE_FAILURES, print_json, run_archive, 
 from .contract import Contract, load_contract
 from .inventory import build_inventory, require_remote_inventory
 from .io import atomic_write_json, ensure_group_directories, exclusive_workflow_lock
+from .receipt import verify_receipt
 
 DEFAULT_CONTRACT: Final = Path("image_archive/axiom/source.toml")
 METADATA_DIRECTORY: Final = "_archive"
@@ -69,6 +70,13 @@ def _parser() -> argparse.ArgumentParser:
     _add_contract_and_work_dir(validate)
     validate.add_argument("--workers", type=int, default=_default_workers())
     validate.add_argument("--max-attempts", type=int, default=5)
+
+    receipt = commands.add_parser(
+        "verify-receipt",
+        help="compare deterministic archive evidence with a historical receipt",
+    )
+    receipt.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT)
+    receipt.add_argument("--receipt", type=Path, required=True)
     return parser
 
 
@@ -90,6 +98,8 @@ def main(arguments: list[str] | None = None) -> int:  # noqa: PLR0911
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
     try:
+        if parsed.command == "verify-receipt":
+            return _verify_receipt_command(parsed)
         contract = load_contract(parsed.contract)
         work_dir = parsed.work_dir or contract.destination.root / METADATA_DIRECTORY
         if parsed.command == "inventory":
@@ -214,6 +224,12 @@ def _validate_command(parsed: argparse.Namespace, contract: Contract, work_dir: 
         )
     print_json(result)
     return 0 if result.complete else 1
+
+
+def _verify_receipt_command(parsed: argparse.Namespace) -> int:
+    result = verify_receipt(parsed.contract, parsed.receipt)
+    print_json(result)
+    return 0 if result["matches"] else 1
 
 
 def _require_destination_storage(destination_root: Path) -> None:

--- a/image_archive/io.py
+++ b/image_archive/io.py
@@ -51,6 +51,23 @@ def exclusive_workflow_lock(path: Path, operation: str) -> Iterator[None]:
             fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
 
 
+@contextmanager
+def read_only_workflow_lock(path: Path) -> Iterator[None]:
+    """Share an existing workflow lock without creating or changing it."""
+    if not path.is_file():
+        raise FileNotFoundError(f"archive workflow lock does not exist: {path}")
+    with path.open("r", encoding="utf-8") as stream:
+        try:
+            fcntl.flock(stream.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            holder = stream.read().strip() or "holder metadata unavailable"
+            raise RuntimeError(f"archive workflow lock is already held at {path}: {holder}") from error
+        try:
+            yield
+        finally:
+            fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+
+
 def sha256_bytes(data: bytes) -> str:
     """Return the lowercase SHA-256 digest for in-memory bytes."""
     return hashlib.sha256(data).hexdigest()

--- a/image_archive/receipt.py
+++ b/image_archive/receipt.py
@@ -43,6 +43,27 @@ _EVIDENCE_SQL: Final = (
     "source_bytes, output_bytes, shape, dtype FROM archive_records ORDER BY source_key ASC"
 )
 _FINAL_COUNT_FIELDS: Final = ("total", "verified", "pending", "running", "error", "unresolved")
+_INDEX_FIELDS: Final = ("record_id", "filename", "url", "size_bytes", "md5", "sha256")
+_MANIFEST_EXPECTATION_FIELDS: Final = (
+    "inventory_sha256",
+    "identity_sha256",
+    "complete_unique_tiff_uris",
+    "rejected_sha256",
+    "rejected_rows",
+)
+_LEDGER_EXPECTATION_FIELDS: Final = (
+    "schema_version",
+    "record_count",
+    "evidence_sha256_scope",
+    "evidence_sha256_order",
+    "evidence_sha256_fields",
+    "evidence_sql",
+    "evidence_row_serialization",
+    "evidence_value_types",
+    "evidence_encoding",
+    "evidence_line_terminator",
+    "evidence_sha256",
+)
 _VALIDATION_FIELDS: Final = (
     "audit_passed",
     "complete",
@@ -53,6 +74,7 @@ _VALIDATION_FIELDS: Final = (
     "inventory_rows",
     "rejected_rows",
 )
+_HISTORICAL_RECEIPT_PROJECTION_SHA256: Final = "2ce25b61ecee83fc8fe436c711019712679ec1c25abc2e1d2f877687e6846ef1"
 
 
 def verify_receipt(contract_path: Path, receipt_path: Path) -> dict[str, Any]:
@@ -65,6 +87,7 @@ def verify_receipt(contract_path: Path, receipt_path: Path) -> dict[str, Any]:
         raise FileNotFoundError(f"receipt does not exist: {receipt_path}")
 
     receipt = _load_receipt(receipt_path)
+    _require_historical_receipt(receipt)
     contract_sha256 = sha256_file(contract_path)
     contract = load_contract(contract_path)
     mismatches: list[str] = []
@@ -75,7 +98,7 @@ def verify_receipt(contract_path: Path, receipt_path: Path) -> dict[str, Any]:
         _compare(mismatches, "receipt ID", receipt_id, "non-empty text")
     _compare(mismatches, "contract SHA-256", contract_sha256, receipt.get("contract_sha256"))
     index = _table(receipt, "index")
-    for field in ("record_id", "filename", "url", "size_bytes", "md5", "sha256"):
+    for field in _INDEX_FIELDS:
         _compare(mismatches, f"index {field}", getattr(contract.index, field), index.get(field))
 
     manifest = _table(receipt, "manifest")
@@ -93,6 +116,7 @@ def verify_receipt(contract_path: Path, receipt_path: Path) -> dict[str, Any]:
     lock_path = contract.destination.root / ".oasis-images.lock"
 
     with read_only_workflow_lock(lock_path):
+        _require_no_nonempty_wal(state_path)
         inventory_sha256 = sha256_file(inventory_path)
         rejected_sha256 = sha256_file(rejected_path)
         inventory_rows = _parquet_rows(inventory_path)
@@ -217,6 +241,50 @@ def _load_receipt(path: Path) -> dict[str, Any]:
         raise ValueError(f"cannot read receipt {path}: {error}") from error
 
 
+def _require_historical_receipt(receipt: Mapping[str, Any]) -> None:
+    actual = _receipt_projection_sha256(receipt)
+    if actual != _HISTORICAL_RECEIPT_PROJECTION_SHA256:
+        raise ValueError(
+            "historical receipt deterministic projection differs: "
+            f"expected={_HISTORICAL_RECEIPT_PROJECTION_SHA256}, actual={actual}",
+        )
+
+
+def _receipt_projection_sha256(receipt: Mapping[str, Any]) -> str:
+    projection = _receipt_projection(receipt)
+    payload = json.dumps(projection, ensure_ascii=True, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return hashlib.sha256(payload.encode("ascii")).hexdigest()
+
+
+def _receipt_projection(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    index = _table(receipt, "index")
+    manifest = _table(receipt, "manifest")
+    ledger = _table(receipt, "ledger")
+    conversion_result = _table(_table(receipt, "conversion"), "result")
+    validation = _table(receipt, "validation")
+    validation_result = _table(validation, "result")
+    validation_report = _table(validation, "report")
+    return {
+        "contract_sha256": receipt.get("contract_sha256"),
+        "index": {field: index.get(field) for field in _INDEX_FIELDS},
+        "manifest": {field: manifest.get(field) for field in _MANIFEST_EXPECTATION_FIELDS},
+        "ledger": {field: ledger.get(field) for field in _LEDGER_EXPECTATION_FIELDS},
+        "conversion_result": {
+            field: conversion_result.get(field) for field in (*_FINAL_COUNT_FIELDS, "source_bytes", "output_bytes")
+        },
+        "receipt_id": receipt.get("receipt_id"),
+        "schema_version": receipt.get("schema_version"),
+        "validation": {
+            "report_sha256": validation_report.get("sha256"),
+            "result": {
+                field: validation_result.get(field)
+                for field in (*_VALIDATION_FIELDS, "failure_count", *_FINAL_COUNT_FIELDS)
+            },
+            "verified_only": validation.get("verified_only"),
+        },
+    }
+
+
 def _load_json(path: Path) -> dict[str, Any]:
     try:
         value = json.loads(path.read_bytes())
@@ -273,6 +341,16 @@ def _open_immutable_ledger(path: Path) -> sqlite3.Connection:
         connection.close()
         raise
     return connection
+
+
+def _require_no_nonempty_wal(state_path: Path) -> None:
+    wal_path = Path(f"{state_path}-wal")
+    try:
+        size = wal_path.stat().st_size
+    except FileNotFoundError:
+        return
+    if size:
+        raise RuntimeError(f"archive ledger WAL is nonempty; refusing immutable read: path={wal_path}, size={size}")
 
 
 def _ledger_counts(connection: sqlite3.Connection) -> dict[str, int]:

--- a/image_archive/receipt.py
+++ b/image_archive/receipt.py
@@ -1,0 +1,367 @@
+# Copyright (c) 2026 Broad Institute.
+# ruff: noqa: EM101, EM102, PLR0915, TRY003, TRY301
+"""Read-only comparison of a reconstructed archive with a historical receipt."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+import pyarrow.parquet as pq
+import tomllib
+
+from .archive import iter_manifest_identities
+from .contract import Contract, load_contract
+from .io import read_only_workflow_lock, sha256_file
+from .state import SCHEMA_VERSION
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_EVIDENCE_FIELDS: Final = (
+    "source_key",
+    "source_uri",
+    "destination_relative",
+    "expected_size",
+    "expected_etag",
+    "expected_version_id",
+    "status",
+    "source_sha256",
+    "output_sha256",
+    "source_bytes",
+    "output_bytes",
+    "shape",
+    "dtype",
+)
+_EVIDENCE_SQL: Final = (
+    "SELECT source_key, source_uri, destination_relative, expected_size, "
+    "expected_etag, expected_version_id, status, source_sha256, output_sha256, "
+    "source_bytes, output_bytes, shape, dtype FROM archive_records ORDER BY source_key ASC"
+)
+_FINAL_COUNT_FIELDS: Final = ("total", "verified", "pending", "running", "error", "unresolved")
+_VALIDATION_FIELDS: Final = (
+    "audit_passed",
+    "complete",
+    "checked",
+    "expected_complete",
+    "invalid",
+    "failure_details_truncated",
+    "inventory_rows",
+    "rejected_rows",
+)
+
+
+def verify_receipt(contract_path: Path, receipt_path: Path) -> dict[str, Any]:
+    """Compare deterministic archive evidence without changing archive state."""
+    contract_path = Path(contract_path)
+    receipt_path = Path(receipt_path)
+    if not contract_path.is_file():
+        raise FileNotFoundError(f"contract does not exist: {contract_path}")
+    if not receipt_path.is_file():
+        raise FileNotFoundError(f"receipt does not exist: {receipt_path}")
+
+    receipt = _load_receipt(receipt_path)
+    contract_sha256 = sha256_file(contract_path)
+    contract = load_contract(contract_path)
+    mismatches: list[str] = []
+
+    _compare(mismatches, "receipt schema version", receipt.get("schema_version"), 1)
+    receipt_id = receipt.get("receipt_id")
+    if not isinstance(receipt_id, str) or not receipt_id:
+        _compare(mismatches, "receipt ID", receipt_id, "non-empty text")
+    _compare(mismatches, "contract SHA-256", contract_sha256, receipt.get("contract_sha256"))
+    index = _table(receipt, "index")
+    for field in ("record_id", "filename", "url", "size_bytes", "md5", "sha256"):
+        _compare(mismatches, f"index {field}", getattr(contract.index, field), index.get(field))
+
+    manifest = _table(receipt, "manifest")
+    ledger = _table(receipt, "ledger")
+    conversion_result = _table(_table(receipt, "conversion"), "result")
+    validation = _table(receipt, "validation")
+    validation_result = _table(validation, "result")
+    validation_receipt_report = _table(validation, "report")
+
+    work_dir = contract.destination.root / "_archive"
+    inventory_path = work_dir / "inventory.parquet"
+    rejected_path = work_dir / "rejected.parquet"
+    state_path = work_dir / "state.sqlite3"
+    validation_path = work_dir / "validation.json"
+    lock_path = contract.destination.root / ".oasis-images.lock"
+
+    with read_only_workflow_lock(lock_path):
+        inventory_sha256 = sha256_file(inventory_path)
+        rejected_sha256 = sha256_file(rejected_path)
+        inventory_rows = _parquet_rows(inventory_path)
+        rejected_rows = _parquet_rows(rejected_path)
+        manifest_identity_sha256 = _manifest_identity_sha256(inventory_path, contract)
+
+        _compare(mismatches, "inventory SHA-256 against contract", inventory_sha256, contract.inventory.manifest_sha256)
+        _compare(mismatches, "inventory SHA-256 against receipt", inventory_sha256, manifest.get("inventory_sha256"))
+        _compare(
+            mismatches,
+            "inventory row count against contract",
+            inventory_rows,
+            contract.inventory.complete_unique_tiff_uris,
+        )
+        _compare(
+            mismatches,
+            "inventory row count against receipt",
+            inventory_rows,
+            manifest.get("complete_unique_tiff_uris"),
+        )
+        _compare(mismatches, "rejected SHA-256 against contract", rejected_sha256, contract.inventory.rejected_sha256)
+        _compare(mismatches, "rejected SHA-256 against receipt", rejected_sha256, manifest.get("rejected_sha256"))
+        _compare(
+            mismatches,
+            "rejected row count against contract",
+            rejected_rows,
+            contract.inventory.incomplete_rows,
+        )
+        _compare(mismatches, "rejected row count against receipt", rejected_rows, manifest.get("rejected_rows"))
+        _compare(
+            mismatches,
+            "manifest identity SHA-256",
+            manifest_identity_sha256,
+            manifest.get("identity_sha256"),
+        )
+
+        with closing(_open_immutable_ledger(state_path)) as connection:
+            ledger_schema = int(connection.execute("PRAGMA user_version").fetchone()[0])
+            ledger_rows = int(connection.execute("SELECT COUNT(*) FROM archive_records").fetchone()[0])
+            binding = connection.execute(
+                "SELECT sha256, artifact_sha256, record_count FROM archive_manifest_binding WHERE singleton = 1",
+            ).fetchone()
+            counts = _ledger_counts(connection)
+            byte_totals = _ledger_byte_totals(connection)
+            ledger_evidence_sha256 = _ledger_evidence_sha256(connection, ledger, mismatches)
+
+        _compare(mismatches, "ledger schema against implementation", ledger_schema, SCHEMA_VERSION)
+        _compare(mismatches, "ledger schema against receipt", ledger_schema, ledger.get("schema_version"))
+        _compare(mismatches, "ledger record count against inventory", ledger_rows, inventory_rows)
+        _compare(mismatches, "ledger record count against receipt", ledger_rows, ledger.get("record_count"))
+        if binding is None:
+            mismatches.append("ledger manifest binding: expected one binding row, actual=None")
+        else:
+            _compare(mismatches, "ledger manifest identity binding", str(binding[0]), manifest_identity_sha256)
+            _compare(mismatches, "ledger manifest artifact binding", str(binding[1]), inventory_sha256)
+            _compare(mismatches, "ledger manifest record binding", int(binding[2]), inventory_rows)
+        _compare(
+            mismatches,
+            "ledger evidence SHA-256",
+            ledger_evidence_sha256,
+            ledger.get("evidence_sha256"),
+        )
+        for field in _FINAL_COUNT_FIELDS:
+            _compare(mismatches, f"final ledger count {field}", counts[field], conversion_result.get(field))
+        for field in ("source_bytes", "output_bytes"):
+            _compare(mismatches, f"final ledger {field}", byte_totals[field], conversion_result.get(field))
+
+        validation_report_sha256 = sha256_file(validation_path)
+        validation_report = _load_json(validation_path)
+        _compare(
+            mismatches,
+            "validation report SHA-256",
+            validation_report_sha256,
+            validation_receipt_report.get("sha256"),
+        )
+        _compare(
+            mismatches,
+            "validation verified_only",
+            validation_report.get("verified_only"),
+            validation.get("verified_only"),
+        )
+        for field in _VALIDATION_FIELDS:
+            _compare(
+                mismatches,
+                f"validation result {field}",
+                validation_report.get(field),
+                validation_result.get(field),
+            )
+        failures = validation_report.get("failures")
+        failure_count = len(failures) if isinstance(failures, list) else None
+        _compare(mismatches, "validation result failure_count", failure_count, validation_result.get("failure_count"))
+        validation_counts = validation_report.get("state_counts")
+        for field in _FINAL_COUNT_FIELDS:
+            actual = validation_counts.get(field) if isinstance(validation_counts, dict) else None
+            _compare(mismatches, f"validation result {field}", actual, validation_result.get(field))
+
+    return {
+        "checked": {
+            "contract_sha256": contract_sha256,
+            "inventory_rows": inventory_rows,
+            "inventory_sha256": inventory_sha256,
+            "ledger_evidence_sha256": ledger_evidence_sha256,
+            "ledger_record_count": ledger_rows,
+            "ledger_schema_version": ledger_schema,
+            "manifest_identity_sha256": manifest_identity_sha256,
+            "rejected_rows": rejected_rows,
+            "rejected_sha256": rejected_sha256,
+            "validation_report_sha256": validation_report_sha256,
+        },
+        "historical_context": _historical_context(receipt),
+        "matches": not mismatches,
+        "mismatches": mismatches,
+        "receipt_id": receipt_id,
+    }
+
+
+def _load_receipt(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("rb") as stream:
+            return tomllib.load(stream)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ValueError(f"cannot read receipt {path}: {error}") from error
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_bytes())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read validation report {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise TypeError(f"validation report is not a JSON object: {path}")
+    return value
+
+
+def _table(value: Mapping[str, Any], name: str) -> Mapping[str, Any]:
+    table = value.get(name)
+    if not isinstance(table, dict):
+        raise TypeError(f"receipt [{name}] is missing or is not a table")
+    return table
+
+
+def _compare(mismatches: list[str], label: str, actual: object, expected: object) -> None:
+    if actual != expected:
+        mismatches.append(f"{label}: expected={expected!r}, actual={actual!r}")
+
+
+def _parquet_rows(path: Path) -> int:
+    if not path.is_file():
+        raise FileNotFoundError(f"required Parquet artifact is absent: {path}")
+    return pq.ParquetFile(path).metadata.num_rows
+
+
+def _manifest_identity_sha256(path: Path, contract: Contract) -> str:
+    digest = hashlib.sha256()
+    for record in iter_manifest_identities(path, contract):
+        values = (
+            record.source_key,
+            record.source_uri,
+            record.destination_relative,
+            record.expected_size,
+            record.expected_etag,
+            record.expected_version_id,
+        )
+        payload = json.dumps(values, ensure_ascii=True, separators=(",", ":"), allow_nan=False)
+        digest.update(f"{payload}\n".encode("ascii"))
+    return digest.hexdigest()
+
+
+def _open_immutable_ledger(path: Path) -> sqlite3.Connection:
+    if not path.is_file():
+        raise FileNotFoundError(f"archive ledger does not exist: {path}")
+    connection = sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro&immutable=1", uri=True)
+    try:
+        connection.execute("PRAGMA query_only = ON")
+        if int(connection.execute("PRAGMA query_only").fetchone()[0]) != 1:
+            raise RuntimeError("SQLite query_only could not be enabled")
+    except BaseException:
+        connection.close()
+        raise
+    return connection
+
+
+def _ledger_counts(connection: sqlite3.Connection) -> dict[str, int]:
+    row = connection.execute(
+        """
+        SELECT COUNT(*) AS total,
+               COALESCE(SUM(status = 'pending'), 0) AS pending,
+               COALESCE(SUM(status = 'running'), 0) AS running,
+               COALESCE(SUM(status = 'verified'), 0) AS verified,
+               COALESCE(SUM(status = 'error'), 0) AS error
+        FROM archive_records
+        """,
+    ).fetchone()
+    counts = {
+        "total": int(row[0]),
+        "pending": int(row[1]),
+        "running": int(row[2]),
+        "verified": int(row[3]),
+        "error": int(row[4]),
+    }
+    counts["unresolved"] = counts["total"] - counts["verified"]
+    return counts
+
+
+def _ledger_byte_totals(connection: sqlite3.Connection) -> dict[str, int]:
+    row = connection.execute(
+        """
+        SELECT COALESCE(SUM(source_bytes), 0), COALESCE(SUM(output_bytes), 0)
+        FROM archive_records WHERE status = 'verified'
+        """,
+    ).fetchone()
+    return {"source_bytes": int(row[0]), "output_bytes": int(row[1])}
+
+
+def _ledger_evidence_sha256(
+    connection: sqlite3.Connection,
+    ledger: Mapping[str, Any],
+    mismatches: list[str],
+) -> str:
+    _compare(
+        mismatches,
+        "ledger evidence scope",
+        ledger.get("evidence_sha256_scope"),
+        "archive_record_evidence_canonical_json_lines_v1",
+    )
+    _compare(mismatches, "ledger evidence order", ledger.get("evidence_sha256_order"), "source_key ASC")
+    _compare(mismatches, "ledger evidence fields", ledger.get("evidence_sha256_fields"), list(_EVIDENCE_FIELDS))
+    _compare(mismatches, "ledger evidence SQL", ledger.get("evidence_sql"), _EVIDENCE_SQL)
+    _compare(
+        mismatches,
+        "ledger evidence row serialization",
+        ledger.get("evidence_row_serialization"),
+        "CPython 3.11.15 json.dumps(list(row), ensure_ascii=True, separators=(',', ':'), allow_nan=False)",
+    )
+    _compare(
+        mismatches,
+        "ledger evidence value types",
+        ledger.get("evidence_value_types"),
+        "SQLite NULL becomes JSON null, INTEGER becomes a JSON integer, and TEXT becomes a JSON string; "
+        "selected columns contain no REAL or BLOB values",
+    )
+    _compare(mismatches, "ledger evidence encoding", ledger.get("evidence_encoding"), "ASCII")
+    _compare(
+        mismatches,
+        "ledger evidence line terminator",
+        ledger.get("evidence_line_terminator"),
+        "one LF byte after every row, including the final row",
+    )
+    digest = hashlib.sha256()
+    for row in connection.execute(_EVIDENCE_SQL):
+        payload = json.dumps(list(row), ensure_ascii=True, separators=(",", ":"), allow_nan=False)
+        digest.update(f"{payload}\n".encode("ascii"))
+    return digest.hexdigest()
+
+
+def _historical_context(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    ledger = receipt.get("ledger")
+    execution = receipt.get("execution")
+    validation = receipt.get("validation")
+    report = validation.get("report") if isinstance(validation, dict) else None
+    return {
+        "attempt_1_rows": ledger.get("attempt_1_rows") if isinstance(ledger, dict) else None,
+        "attempt_2_rows": ledger.get("attempt_2_rows") if isinstance(ledger, dict) else None,
+        "contract_path": receipt.get("contract_path"),
+        "created_at_utc": receipt.get("created_at_utc"),
+        "host": receipt.get("host"),
+        "implementation_commit": receipt.get("implementation_commit"),
+        "ledger_path": ledger.get("path") if isinstance(ledger, dict) else None,
+        "total_attempts": ledger.get("total_attempts") if isinstance(ledger, dict) else None,
+        "validation_report_path": report.get("path") if isinstance(report, dict) else None,
+        "working_directory": execution.get("working_directory") if isinstance(execution, dict) else None,
+    }

--- a/image_archive/tests/test_receipt.py
+++ b/image_archive/tests/test_receipt.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 Broad Institute.
-# ruff: noqa: D101, D102, PT009, PT027
+# ruff: noqa: D101, D102, PT009, PT027, SLF001
 """Regression tests for deterministic, read-only receipt verification."""
 
 from __future__ import annotations
@@ -15,6 +15,9 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+import tomllib
+
+from image_archive import receipt as receipt_module
 from image_archive.__main__ import main
 from image_archive.archive import iter_manifest_identities, run_archive, validate_archive
 from image_archive.io import exclusive_workflow_lock, sha256_file
@@ -294,14 +297,31 @@ def _snapshot(root: Path) -> dict[str, tuple[int, str]]:
     }
 
 
+def _synthetic_anchor(receipt_path: Path) -> str:
+    return receipt_module._receipt_projection_sha256(tomllib.loads(receipt_path.read_text()))
+
+
 class ReceiptVerificationTest(unittest.TestCase):
+    def test_historical_receipt_matches_the_production_anchor(self) -> None:
+        receipt_path = Path(__file__).resolve().parents[1] / "records" / "run-receipt-2026-08-05.toml"
+
+        self.assertEqual(
+            _synthetic_anchor(receipt_path),
+            receipt_module._HISTORICAL_RECEIPT_PROJECTION_SHA256,
+        )
+
     def test_success_is_deterministic_and_changes_no_files(self) -> None:
         with TemporaryDirectory() as directory:
             root = Path(directory)
             _, contract_path, receipt_path = _completed_fixture(root)
             before = _snapshot(root)
 
-            result = verify_receipt(contract_path, receipt_path)
+            with patch.object(
+                receipt_module,
+                "_HISTORICAL_RECEIPT_PROJECTION_SHA256",
+                _synthetic_anchor(receipt_path),
+            ):
+                result = verify_receipt(contract_path, receipt_path)
 
             self.assertTrue(result["matches"])
             self.assertEqual(result["mismatches"], [])
@@ -338,7 +358,14 @@ class ReceiptVerificationTest(unittest.TestCase):
                 connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
             stdout = io.StringIO()
 
-            with redirect_stdout(stdout):
+            with (
+                patch.object(
+                    receipt_module,
+                    "_HISTORICAL_RECEIPT_PROJECTION_SHA256",
+                    _synthetic_anchor(receipt_path),
+                ),
+                redirect_stdout(stdout),
+            ):
                 status = main(
                     [
                         "verify-receipt",
@@ -371,6 +398,7 @@ class ReceiptVerificationTest(unittest.TestCase):
         with TemporaryDirectory() as directory:
             root = Path(directory)
             _, contract_path, receipt_path = _completed_fixture(root)
+            anchor = _synthetic_anchor(receipt_path)
             text = receipt_path.read_text()
             text = text.replace('host = "historical-host"', 'host = "another-host"')
             text = text.replace("1900-01-01T00:00:00Z", "2099-01-01T00:00:00Z")
@@ -391,7 +419,8 @@ class ReceiptVerificationTest(unittest.TestCase):
             text = text.replace("1900-01-03T00:00:00Z", "2099-01-03T00:00:00Z")
             receipt_path.write_text(text, encoding="utf-8")
 
-            result = verify_receipt(contract_path, receipt_path)
+            with patch.object(receipt_module, "_HISTORICAL_RECEIPT_PROJECTION_SHA256", anchor):
+                result = verify_receipt(contract_path, receipt_path)
 
             self.assertTrue(result["matches"])
             self.assertEqual(result["historical_context"]["host"], "another-host")
@@ -403,10 +432,73 @@ class ReceiptVerificationTest(unittest.TestCase):
             lock_path = contract.destination.root / ".oasis-images.lock"
 
             with (
+                patch.object(
+                    receipt_module,
+                    "_HISTORICAL_RECEIPT_PROJECTION_SHA256",
+                    _synthetic_anchor(receipt_path),
+                ),
                 exclusive_workflow_lock(lock_path, "archive"),
                 self.assertRaisesRegex(RuntimeError, "already held"),
             ):
                 verify_receipt(contract_path, receipt_path)
+
+    def test_receipt_anchor_rejects_matching_deterministic_tampering(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            contract, contract_path, receipt_path = _completed_fixture(root)
+            work_dir = contract.destination.root / "_archive"
+            report_path = work_dir / "validation.json"
+            report = json.loads(report_path.read_text())
+            report["complete"] = False
+            report_path.write_text(f"{json.dumps(report, indent=2, sort_keys=True)}\n", encoding="utf-8")
+            _write_receipt(receipt_path, contract_path, contract, work_dir)
+            receipt = tomllib.loads(receipt_path.read_text())
+
+            self.assertFalse(report["complete"])
+            self.assertFalse(receipt["validation"]["result"]["complete"])
+            self.assertEqual(receipt["validation"]["report"]["sha256"], sha256_file(report_path))
+            with (
+                patch(
+                    "image_archive.receipt.read_only_workflow_lock",
+                    side_effect=AssertionError("archive artifacts were resolved"),
+                ),
+                self.assertRaisesRegex(ValueError, "historical receipt deterministic projection differs"),
+            ):
+                verify_receipt(contract_path, receipt_path)
+
+    def test_refuses_nonempty_committed_wal_before_immutable_read(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            contract, contract_path, receipt_path = _completed_fixture(root)
+            state_path = contract.destination.root / "_archive" / "state.sqlite3"
+            wal_path = Path(f"{state_path}-wal")
+            with sqlite3.connect(state_path) as writer:
+                writer.execute("PRAGMA wal_autocheckpoint = 0")
+                original = int(writer.execute("SELECT output_bytes FROM archive_records").fetchone()[0])
+                writer.execute("UPDATE archive_records SET output_bytes = ?", (original + 1,))
+                writer.commit()
+
+                immutable = sqlite3.connect(f"{state_path.resolve().as_uri()}?mode=ro&immutable=1", uri=True)
+                try:
+                    stale = int(immutable.execute("SELECT output_bytes FROM archive_records").fetchone()[0])
+                finally:
+                    immutable.close()
+                self.assertEqual(stale, original)
+                self.assertEqual(
+                    int(writer.execute("SELECT output_bytes FROM archive_records").fetchone()[0]),
+                    original + 1,
+                )
+                self.assertGreater(wal_path.stat().st_size, 0)
+
+                with (
+                    patch.object(
+                        receipt_module,
+                        "_HISTORICAL_RECEIPT_PROJECTION_SHA256",
+                        _synthetic_anchor(receipt_path),
+                    ),
+                    self.assertRaisesRegex(RuntimeError, "archive ledger WAL is nonempty"),
+                ):
+                    verify_receipt(contract_path, receipt_path)
 
 
 if __name__ == "__main__":

--- a/image_archive/tests/test_receipt.py
+++ b/image_archive/tests/test_receipt.py
@@ -1,0 +1,413 @@
+# Copyright (c) 2026 Broad Institute.
+# ruff: noqa: D101, D102, PT009, PT027
+"""Regression tests for deterministic, read-only receipt verification."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import sqlite3
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from image_archive.__main__ import main
+from image_archive.archive import iter_manifest_identities, run_archive, validate_archive
+from image_archive.io import exclusive_workflow_lock, sha256_file
+from image_archive.receipt import verify_receipt
+from image_archive.tests.test_image_archive import _inventory
+
+if TYPE_CHECKING:
+    from image_archive.contract import Contract
+
+_EVIDENCE_SQL = (
+    "SELECT source_key, source_uri, destination_relative, expected_size, "
+    "expected_etag, expected_version_id, status, source_sha256, output_sha256, "
+    "source_bytes, output_bytes, shape, dtype FROM archive_records ORDER BY source_key ASC"
+)
+_EVIDENCE_ROW_SERIALIZATION = (
+    "CPython 3.11.15 json.dumps(list(row), ensure_ascii=True, separators=(',', ':'), allow_nan=False)"
+)
+_EVIDENCE_VALUE_TYPES = (
+    "SQLite NULL becomes JSON null, INTEGER becomes a JSON integer, and TEXT becomes a JSON string; "
+    "selected columns contain no REAL or BLOB values"
+)
+
+
+def _write_contract(path: Path, contract: Contract) -> None:
+    channels = "\n".join(
+        f"[[channels]]\nsource = {json.dumps(source)}\ndestination = {json.dumps(source)}\nchannel_number = {number}"
+        for source, number in contract.channels.items()
+    )
+    batches = "\n".join(f"[[batches]]\nname = {json.dumps(name)}" for name in contract.batches)
+    path.write_text(
+        f"""[index]
+record_id = {contract.index.record_id}
+filename = {json.dumps(contract.index.filename)}
+url = {json.dumps(contract.index.url)}
+size_bytes = {contract.index.size_bytes}
+md5 = {json.dumps(contract.index.md5)}
+sha256 = {json.dumps(contract.index.sha256)}
+
+[source]
+bucket = {json.dumps(contract.source.bucket)}
+prefix = {json.dumps(contract.source.prefix)}
+anonymous = true
+
+[inventory]
+row_count = {contract.inventory.row_count}
+complete_unique_tiff_uris = {contract.inventory.complete_unique_tiff_uris}
+incomplete_rows = {contract.inventory.incomplete_rows}
+field_count = {contract.inventory.field_count}
+plate_count = {contract.inventory.plate_count}
+channel_count = {contract.inventory.channel_count}
+manifest_sha256 = {json.dumps(contract.inventory.manifest_sha256)}
+rejected_sha256 = {json.dumps(contract.inventory.rejected_sha256)}
+
+[codec]
+id = {json.dumps(contract.codec.id)}
+name = {json.dumps(contract.codec.name)}
+profile = {json.dumps(contract.codec.profile)}
+lossless = false
+distance = {contract.codec.distance}
+effort = {contract.codec.effort}
+reference_repository = {json.dumps(contract.codec.reference_repository)}
+reference_commit = {json.dumps(contract.codec.reference_commit)}
+reference_path = {json.dumps(contract.codec.reference_path)}
+reference_sha256 = {json.dumps(contract.codec.reference_sha256)}
+reference_tier = {json.dumps(contract.codec.reference_tier)}
+
+[destination]
+root = {json.dumps(str(contract.destination.root))}
+object_template = {json.dumps(contract.destination.object_template)}
+
+{channels}
+
+{batches}
+""",
+        encoding="utf-8",
+    )
+
+
+def _canonical_rows_digest(connection: sqlite3.Connection) -> str:
+    digest = hashlib.sha256()
+    for row in connection.execute(_EVIDENCE_SQL):
+        payload = json.dumps(list(row), ensure_ascii=True, separators=(",", ":"), allow_nan=False)
+        digest.update(f"{payload}\n".encode("ascii"))
+    return digest.hexdigest()
+
+
+def _manifest_digest(contract: Contract, inventory_path: Path) -> str:
+    digest = hashlib.sha256()
+    for row in iter_manifest_identities(inventory_path, contract):
+        values = [
+            row.source_key,
+            row.source_uri,
+            row.destination_relative,
+            row.expected_size,
+            row.expected_etag,
+            row.expected_version_id,
+        ]
+        payload = json.dumps(values, ensure_ascii=True, separators=(",", ":"), allow_nan=False)
+        digest.update(f"{payload}\n".encode("ascii"))
+    return digest.hexdigest()
+
+
+def _write_receipt(
+    path: Path,
+    contract_path: Path,
+    contract: Contract,
+    work_dir: Path,
+    *,
+    overrides: dict[str, object] | None = None,
+) -> None:
+    values = overrides or {}
+
+    def expected(name: str, default: object) -> object:
+        return values.get(name, default)
+
+    inventory_path = work_dir / "inventory.parquet"
+    rejected_path = work_dir / "rejected.parquet"
+    state_path = work_dir / "state.sqlite3"
+    validation_path = work_dir / "validation.json"
+    validation = json.loads(validation_path.read_text())
+    with sqlite3.connect(state_path) as connection:
+        row = connection.execute(
+            """
+            SELECT COUNT(*), SUM(status = 'verified'), SUM(status = 'pending'),
+                   SUM(status = 'running'), SUM(status = 'error'),
+                   SUM(source_bytes), SUM(output_bytes)
+            FROM archive_records
+            """,
+        ).fetchone()
+        evidence_sha256 = _canonical_rows_digest(connection)
+    total, verified, pending, running, error, source_bytes, output_bytes = map(int, row)
+    unresolved = total - verified
+    manifest_sha256 = sha256_file(inventory_path)
+    rejected_sha256 = sha256_file(rejected_path)
+    manifest_identity = _manifest_digest(contract, inventory_path)
+    failures = validation["failures"]
+    state_counts = validation["state_counts"]
+    path.write_text(
+        f"""schema_version = 1
+receipt_id = "synthetic-reconstruction"
+created_at_utc = "1900-01-01T00:00:00Z"
+host = "historical-host"
+implementation_commit = "historical-commit"
+contract_path = "/historical/checkout/images/source.toml"
+contract_sha256 = {json.dumps(expected("contract_sha256", sha256_file(contract_path)))}
+
+[index]
+record_id = {contract.index.record_id}
+filename = {json.dumps(contract.index.filename)}
+url = {json.dumps(contract.index.url)}
+size_bytes = {contract.index.size_bytes}
+md5 = {json.dumps(contract.index.md5)}
+sha256 = {json.dumps(contract.index.sha256)}
+
+[manifest]
+inventory_sha256 = {json.dumps(expected("inventory_sha256", manifest_sha256))}
+identity_sha256 = {json.dumps(expected("identity_sha256", manifest_identity))}
+complete_unique_tiff_uris = {contract.inventory.complete_unique_tiff_uris}
+rejected_sha256 = {json.dumps(expected("rejected_sha256", rejected_sha256))}
+rejected_rows = {contract.inventory.incomplete_rows}
+
+[ledger]
+path = "/historical/archive/state.sqlite3"
+schema_version = 4
+record_count = {total}
+evidence_sha256_scope = "archive_record_evidence_canonical_json_lines_v1"
+evidence_sha256_order = "source_key ASC"
+evidence_sha256_fields = [
+  "source_key",
+  "source_uri",
+  "destination_relative",
+  "expected_size",
+  "expected_etag",
+  "expected_version_id",
+  "status",
+  "source_sha256",
+  "output_sha256",
+  "source_bytes",
+  "output_bytes",
+  "shape",
+  "dtype",
+]
+evidence_sql = {json.dumps(_EVIDENCE_SQL)}
+evidence_row_serialization = {json.dumps(_EVIDENCE_ROW_SERIALIZATION)}
+evidence_value_types = {json.dumps(_EVIDENCE_VALUE_TYPES)}
+evidence_encoding = "ASCII"
+evidence_line_terminator = "one LF byte after every row, including the final row"
+evidence_sha256 = {json.dumps(expected("evidence_sha256", evidence_sha256))}
+total_attempts = 999
+attempt_1_rows = 998
+attempt_2_rows = 1
+
+[execution]
+working_directory = "/historical/checkout"
+
+[conversion]
+service_completed_at_utc = "1900-01-02T00:00:00Z"
+historical_command = ["old-package", "archive", "--old-path"]
+
+[conversion.result]
+total = {total}
+verified = {verified}
+pending = {pending}
+running = {running}
+error = {error}
+unresolved = {unresolved}
+source_bytes = {source_bytes}
+output_bytes = {expected("output_bytes", output_bytes)}
+
+[validation]
+verified_only = false
+command = ["old-package", "validate", "--old-path"]
+
+[validation.result]
+audit_passed = {str(validation["audit_passed"]).lower()}
+complete = {str(expected("validation_complete", validation["complete"])).lower()}
+checked = {validation["checked"]}
+expected_complete = {validation["expected_complete"]}
+invalid = {validation["invalid"]}
+failure_count = {len(failures)}
+failure_details_truncated = {str(validation["failure_details_truncated"]).lower()}
+inventory_rows = {validation["inventory_rows"]}
+rejected_rows = {validation["rejected_rows"]}
+total = {state_counts["total"]}
+verified = {state_counts["verified"]}
+pending = {state_counts["pending"]}
+running = {state_counts["running"]}
+error = {state_counts["error"]}
+unresolved = {state_counts["unresolved"]}
+
+[validation.report]
+path = "/historical/archive/validation.json"
+sha256 = {json.dumps(expected("validation_sha256", sha256_file(validation_path)))}
+mtime_utc = "1900-01-03T00:00:00Z"
+""",
+        encoding="utf-8",
+    )
+
+
+def _completed_fixture(root: Path) -> tuple[Contract, Path, Path]:
+    contract, work_dir, client = _inventory(root)
+    inventory_path = work_dir / "inventory.parquet"
+    state_path = work_dir / "state.sqlite3"
+    with patch("image_archive.archive._s3_client", return_value=client):
+        result = run_archive(
+            contract,
+            inventory_path=inventory_path,
+            state_path=state_path,
+            workers=1,
+            max_in_flight=1,
+        )
+    if result.state_counts["verified"] != 1:
+        raise AssertionError(result)
+    validation = validate_archive(
+        contract,
+        inventory_path=inventory_path,
+        rejected_path=work_dir / "rejected.parquet",
+        state_path=state_path,
+        workers=1,
+        report_path=work_dir / "validation.json",
+    )
+    if not validation.complete:
+        raise AssertionError(validation)
+    (contract.destination.root / ".oasis-images.lock").write_text("{}\n", encoding="utf-8")
+    contract_path = root / "source.toml"
+    receipt_path = root / "receipt.toml"
+    _write_contract(contract_path, contract)
+    _write_receipt(receipt_path, contract_path, contract, work_dir)
+    return contract, contract_path, receipt_path
+
+
+def _snapshot(root: Path) -> dict[str, tuple[int, str]]:
+    return {
+        path.relative_to(root).as_posix(): (path.stat().st_mtime_ns, sha256_file(path))
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+class ReceiptVerificationTest(unittest.TestCase):
+    def test_success_is_deterministic_and_changes_no_files(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            _, contract_path, receipt_path = _completed_fixture(root)
+            before = _snapshot(root)
+
+            result = verify_receipt(contract_path, receipt_path)
+
+            self.assertTrue(result["matches"])
+            self.assertEqual(result["mismatches"], [])
+            self.assertEqual(_snapshot(root), before)
+
+    def test_cli_aggregates_deterministic_mismatches(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            contract, contract_path, receipt_path = _completed_fixture(root)
+            work_dir = contract.destination.root / "_archive"
+            _write_receipt(
+                receipt_path,
+                contract_path,
+                contract,
+                work_dir,
+                overrides={
+                    "contract_sha256": "0" * 64,
+                    "evidence_sha256": "4" * 64,
+                    "identity_sha256": "3" * 64,
+                    "inventory_sha256": "1" * 64,
+                    "output_bytes": 999,
+                    "rejected_sha256": "2" * 64,
+                    "validation_complete": False,
+                    "validation_sha256": "5" * 64,
+                },
+            )
+            with sqlite3.connect(work_dir / "state.sqlite3") as connection:
+                connection.execute("PRAGMA user_version = 3")
+                connection.execute(
+                    "UPDATE archive_manifest_binding SET artifact_sha256 = ? WHERE singleton = 1",
+                    ("6" * 64,),
+                )
+                connection.commit()
+                connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                status = main(
+                    [
+                        "verify-receipt",
+                        "--contract",
+                        str(contract_path),
+                        "--receipt",
+                        str(receipt_path),
+                    ],
+                )
+
+            report = json.loads(stdout.getvalue())
+            self.assertEqual(status, 1)
+            self.assertFalse(report["matches"])
+            joined = "\n".join(report["mismatches"])
+            for label in (
+                "contract SHA-256",
+                "inventory SHA-256 against receipt",
+                "rejected SHA-256 against receipt",
+                "manifest identity SHA-256",
+                "ledger schema against implementation",
+                "ledger manifest artifact binding",
+                "ledger evidence SHA-256",
+                "final ledger output_bytes",
+                "validation report SHA-256",
+                "validation result complete",
+            ):
+                self.assertIn(label, joined)
+
+    def test_historical_execution_metadata_is_ignored(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            _, contract_path, receipt_path = _completed_fixture(root)
+            text = receipt_path.read_text()
+            text = text.replace('host = "historical-host"', 'host = "another-host"')
+            text = text.replace("1900-01-01T00:00:00Z", "2099-01-01T00:00:00Z")
+            text = text.replace(
+                'contract_path = "/historical/checkout/images/source.toml"',
+                'contract_path = "old/path"',
+            )
+            text = text.replace("total_attempts = 999", "total_attempts = 123456")
+            text = text.replace("attempt_1_rows = 998", "attempt_1_rows = 1")
+            text = text.replace("attempt_2_rows = 1", "attempt_2_rows = 123455")
+            text = text.replace('working_directory = "/historical/checkout"', 'working_directory = "/elsewhere"')
+            text = text.replace("1900-01-02T00:00:00Z", "2099-01-02T00:00:00Z")
+            text = text.replace(
+                'historical_command = ["old-package", "archive", "--old-path"]',
+                'historical_command = ["other"]',
+            )
+            text = text.replace('command = ["old-package", "validate", "--old-path"]', 'command = ["other"]')
+            text = text.replace("1900-01-03T00:00:00Z", "2099-01-03T00:00:00Z")
+            receipt_path.write_text(text, encoding="utf-8")
+
+            result = verify_receipt(contract_path, receipt_path)
+
+            self.assertTrue(result["matches"])
+            self.assertEqual(result["historical_context"]["host"], "another-host")
+
+    def test_refuses_to_read_while_mutating_lock_is_held(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            contract, contract_path, receipt_path = _completed_fixture(root)
+            lock_path = contract.destination.root / ".oasis-images.lock"
+
+            with (
+                exclusive_workflow_lock(lock_path, "archive"),
+                self.assertRaisesRegex(RuntimeError, "already held"),
+            ):
+                verify_receipt(contract_path, receipt_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- turn `image_archive/README.md` into a numbered, copy-pasteable reconstruction runbook from fresh checkout through final evidence verification
- add a read-only `verify-receipt` command that compares deterministic contract, manifest, schema-v4 ledger, byte-total, and validation evidence with the immutable historical receipt
- preserve the existing inventory, archive/resume, status, and validate workflow, with systemd remaining an optional host-specific wrapper

## Safety and compatibility

- independently anchor the deterministic projection of the historical receipt before resolving archive state
- hold the existing shared workflow lock and refuse nonempty SQLite WAL state before immutable/query-only ledger access
- aggregate mismatches, exit nonzero, and create or modify no archive files
- keep historical host, timestamps, attempts, retry distribution, service history, paths, and mtimes non-binding
- preserve `source.toml` and the historical receipt byte-for-byte
- add no dependency, lockfile change, Makefile, wrapper script, framework, registry, adapter, base class, compatibility shim, or speculative dataset machinery

## Validation

- 12 focused image archive tests
- Ruff lint and format checks
- Pyright with zero diagnostics
- top-level and `verify-receipt` CLI help
- synthetic success, aggregated mismatch, deterministic tampering, lock, WAL, historical-metadata, and non-mutation coverage
- completed archive read-only comparison: `matches: true`, zero mismatches, exact 2,017,182-row manifest identity and canonical ledger evidence digest
- identical pre/post hashes for the lock, inventory, rejected rows, ledger, zero-byte WAL, and validation report

No recompression, full archive validation, biological-equivalence work, data publication, or unrelated repository change was performed.

## Independent review

Initial review confirmed three findings: caller-controlled receipts lacked an independent evidence anchor, immutable SQLite could ignore committed WAL frames, and the runbook inferred the wrong storage group. Commit `baa951b6d4a6c33289c7a6993daf78a888b83ddc` anchors the deterministic receipt projection, refuses nonempty WAL state under the shared lock, and requires and verifies the explicit `nogroup` storage policy. Regression coverage was added for each defect.

The reviewer re-inspected the exact pushed corrective SHA and reported: `NO ACTIONABLE FINDINGS.`
