### PR TITLE
Generalize image archive reconstruction runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ This repository contains the Axiom OASIS analysis, its paper reproduction record
 - `1_snakemake/` contains the primary analysis pipeline.
 - `2_downstream_analysis/` contains manuscript and exploratory notebooks plus compiled results.
 - `paper/` contains the published sources, target ledger, evidence, executable paper, and end-to-end reproduction workflow.
-- `image_archive/` contains the reusable image-archive package and the completed Axiom JPEG XL archive record.
+- `image_archive/` contains the canonical-manifest adaptation runbook, reusable archive engine, and completed Axiom JPEG XL archive record.
 
 ## Reproduction and archive entry points
 
 Run `uv run paper/reproduce.py` for the repository-only executable paper.
 Run `uv run paper/reproduce_all.py` for the isolated, resumable end-to-end reproduction, or add `--dry-run` to inspect its exact plan first.
 See [paper/README.md](paper/README.md) for the paper evidence workflow and [paper/REPRODUCING.md](paper/REPRODUCING.md) for the manual from-scratch recipe, acceptance boundaries, and known deviations.
-See [image_archive/README.md](image_archive/README.md) for the restartable JPEG XL archive workflow and completed-run evidence.
+See [image_archive/README.md](image_archive/README.md) to adapt the JPEG XL archive engine to a supported Cell Painting dataset, or [image_archive/axiom/README.md](image_archive/axiom/README.md) for exact Axiom reconstruction and completed-run evidence.
 
 The data-preparation notes below describe the original analysis workflow.
 Some original scripts do not run as published; `paper/REPRODUCING.md` identifies the repairs and remaining boundaries.

--- a/image_archive/README.md
+++ b/image_archive/README.md
@@ -1,34 +1,57 @@
-# Reconstruct the Axiom OASIS JPEG XL image archive
+# Adapt the JPEG XL archive to another Cell Painting dataset
 
-This runbook reconstructs the Axiom OASIS JPEG XL v1 archive from a fresh checkout.
-Run every command from the repository root.
-The original Cell Painting Gallery TIFFs remain the source of truth.
+This is the agent-facing runbook for adapting the existing archive engine to one unfamiliar Cell Painting dataset.
+Run every command from a clean isolated checkout and stop at the first failed assertion.
+The only reusable handoff is a deterministic post-preflight `inventory.parquet`, pinned contract, rejected-row artifact, and `summary.json` remote-preflight result.
+Source discovery and normalization remain direct dataset-specific code.
+The archive, resume, status, validation, locking, atomic-write, circuit-breaker, and schema-v4 ledger paths remain unchanged.
 
-Deterministic reconstruction succeeds when the pinned index produces the exact inventory and rejected-row artifacts, every inventory row has the exact ledger-bound source and output evidence recorded by the historical receipt, the final counts and byte totals match, and the deterministic validation report matches.
-Host, timestamps, attempts, retry history, service history, absolute paths, historical command spellings, mtimes, and other execution details are context only.
-They do not need to match the 2026-08-05 run.
+The source TIFFs remain the source of truth.
+The current `jpegxl-d1-e5` derivative is lossy JPEG XL at distance 1.0 and effort 5.
+It is for browsing, visualization, and retrieval, and this workflow makes no claim of biological equivalence.
 
-The `jpegxl-d1-e5` tier is lossy JPEG XL at distance 1.0 and effort 5.
-No channel stacking, normalization, intensity transformation, cropping, resizing, or biological recalibration is performed.
-Biological equivalence to the source TIFFs has not been established for this dataset.
-Use the TIFFs for measurements and scientific results, and use this derivative only for browsing, visualization, and retrieval.
-Issue [#44](https://github.com/broadinstitute/2024_09_09_Axiom_OASIS/issues/44) records the available measurements and the particular Brightfield concern.
+The exact completed Axiom reconstruction procedure is in [axiom/README.md](axiom/README.md).
+Four surfaces are Axiom-only: the CLI `DEFAULT_CONTRACT`, the six-column `inventory` reference compiler, the optional systemd service, and `verify-receipt`.
+Do not weaken or generalize `verify-receipt`; it is pinned to one historical Axiom receipt.
 
-## 1. Start from a clean checkout and enter the pinned environment
+## Supported boundary and stop conditions
 
-Confirm that this is the repository root and that the reconstruction inputs are tracked and unmodified:
+Proceed only when all of these statements are true:
+
+- The source is public anonymous S3 under one exact bucket and prefix.
+- Every selected source object ends in `.tif` or `.tiff`.
+- Every selected TIFF decodes as exactly one two-dimensional uint16 plane.
+- Each selected TIFF maps to exactly one `.jxl` object.
+- The unchanged JPEG XL codec and settings are acceptable.
+- No channel stacking, cropping, resizing, normalization, intensity transformation, biological recalibration, or other pixel transform is required.
+- The existing contract can state the selected image count, rejected count, fixed channel cardinality, source scope, codec, and destination honestly.
+- A reviewable authoritative index or explicit source-selection artifact exists.
+
+Stop and request a separate design before any conversion if one statement is false.
+Do not make a dataset fit by weakening validation or hiding ambiguity.
+Do not add dependencies, frameworks, parser registries, adapter layers or protocols, base classes, Makefiles, workflow engines, generic services, receipt hierarchies, dataset templates, or speculative multi-dataset machinery.
+
+## 1. Start from a clean isolated checkout
+
+Begin in a clean repository root and create a dedicated worktree and branch for this one adaptation.
+Choose a short stable dataset slug before running these commands:
 
 ```bash
+set -euo pipefail
 test -f image_archive/axiom/source.toml
-test -f image_archive/records/run-receipt-2026-08-05.toml
-git diff --exit-code -- \
-  image_archive/axiom/source.toml \
-  image_archive/records/run-receipt-2026-08-05.toml \
-  pixi.lock \
-  flake.lock
+test -z "$(git status --porcelain)"
+dataset_slug=replace_with_dataset_slug
+test "$dataset_slug" != replace_with_dataset_slug
+worktree_parent=/work/users/"$(id -un)"/worktrees
+install -d -m 0770 "$worktree_parent"
+worktree="$worktree_parent/2024_09_09_Axiom_OASIS-image-archive-$dataset_slug"
+test ! -e "$worktree"
+git worktree add "$worktree" -b "codex/image-archive-$dataset_slug" HEAD
+cd "$worktree"
+test -z "$(git status --porcelain)"
 ```
 
-Approve the repository environment once, install the locked `images` environment without updating the lockfile, and enter it through `direnv` for every command:
+Approve the repository environment once in the isolated checkout and use `direnv` for every Python command:
 
 ```bash
 direnv allow
@@ -37,242 +60,442 @@ direnv exec . pixi run -e images python --version
 git diff --exit-code -- pixi.lock flake.lock
 ```
 
-The environment remains named `images` because renaming it would rewrite `pixi.lock`.
-Do not update dependencies or regenerate either lockfile during reconstruction.
-
-## 2. Verify the tracked contract, lockfiles, and immutable receipt
-
-Verify the exact bytes in the current checkout:
+Do not update dependencies or regenerate either lockfile.
+Create an external qualification directory under the normal `/work/users` policy and start a terminal transcript before source discovery:
 
 ```bash
-sha256sum --check <<'EOF'
-a85639eb25908bdf900a67daeba8fc8a755db4c03841d21aff3fed9609d197dd  image_archive/axiom/source.toml
-d4af5e083b90a50a2a891ad1a068cd54510f6da274801388fd81bb1cffba4e99  image_archive/records/run-receipt-2026-08-05.toml
-55665368f14dc6e2b82b5b06bc5b6495abad863ff40fff10f93bea34235fe900  pixi.lock
-8628426df569bbe3fb2b8367fbb411fb4cd4c04f023b1afeeb2cba094b7f8c30  flake.lock
-EOF
+export dataset_slug
+export qualification_root=/work/users/"$(id -un)"/image-archive-qualification/"$dataset_slug"
+install -d -m 0770 "$qualification_root"
+command -v script
+script -q -e -f "$qualification_root/terminal.typescript"
 ```
 
-The immutable historical receipt records `pixi_lock_sha256 = f1412dfb...`, which was the whole-repository lockfile at the original archive run.
-Later tracked paper-environment work changed the whole lockfile to the current hash above without changing the pinned `images` package versions recorded in the receipt.
-The receipt comparison therefore treats lockfile hashes and runtime versions as historical context; it does not require a current whole-repository lockfile to reproduce an earlier unrelated environment graph.
-The contract and receipt hashes themselves must remain exact.
+Continue the remaining steps inside that recorded shell and run `set -euo pipefail` there.
+The raw transcript is execution evidence.
+Do not reconstruct commands from shell history after the run.
 
-The contract pins Zenodo record 17067683, `index.parquet` SHA-256 `f83a16fa...`, the public S3 namespace, all inventory counts and mappings, the one-TIFF-to-one-JXL destination rule, and the JUMP_lite codec provenance.
-The inventory command rehashes the downloaded index before accepting it.
+## 2. Discover and define the source without changing it
 
-## 3. Run the focused tests and inspect the CLI
+Keep discovery read-only.
+Inspect upstream documentation, the authoritative index, anonymous S3 listings, and representative TIFF headers without writing to the source or destination.
+Do not start by editing the Axiom parser.
 
-Run the complete focused archive test suite and both help surfaces before touching external storage:
+Record these facts in a small dataset-specific README and in an ambiguity log:
+
+- The authoritative index URL, upstream record or version, filename, byte size, upstream MD5 when supplied, and locally computed SHA-256.
+- Why that index or selection artifact is authoritative for the intended source scope.
+- The exact S3 bucket, prefix, and any narrower selected subpaths.
+- What one physical row in the raw index represents.
+- What one normalized image row represents.
+- Every expansion, selection, exclusion, channel mapping, filename rule, and destination mapping.
+- Raw index rows, normalized image rows, rejected rows, fields, plates, channels, selected bytes, and prefix extras as separate counts.
+- Every unresolved or judgment-dependent source ambiguity and its resolution.
+
+The raw index grain and normalized image-row grain are often different.
+For example, one raw row may describe a field while several columns or URLs expand to one normalized row per channel image.
+The contract's `row_count`, `complete_unique_tiff_uris`, and `incomplete_rows` describe the normalized image-row input to this engine, not an unrelated physical-row count from upstream.
+Preserve the raw count separately rather than forcing the two grains to agree.
+
+Verify the local authoritative index bytes before parsing:
 
 ```bash
-direnv exec . pixi run -e images python -m unittest discover -s image_archive/tests
-direnv exec . pixi run -e images python -m image_archive --help
-direnv exec . pixi run -e images python -m image_archive verify-receipt --help
+index_path=replace_with_local_authoritative_index_path
+test -f "$index_path"
+stat -c '%s %n' "$index_path"
+md5sum "$index_path"
+sha256sum "$index_path"
 ```
 
-The workflow engine consists of `inventory`, `archive`, `status`, and `validate`.
-`verify-receipt` is a final read-only comparison and never substitutes for any of those four commands.
+MD5 is only an upstream identity check when the source publishes it.
+SHA-256 is the local frozen identity.
 
-## 4. Provision and register the external destination
+## 3. Resolve current storage policy and the destination contract
 
-The contracted destination is:
+The absolute destination root is contract-bound, so resolve it before writing `source.toml`, bootstrapping artifacts, or freezing the implementation SHA.
+Storage ownership is site- and dataset-specific.
+Do not copy Axiom's group or invent one universal archive group.
 
-```text
-/work/datasets/cpg0037-oasis/axiom/images-jxl/v1
-```
-
-First verify that `/work/datasets` is available from a non-root mounted filesystem:
+Before server administration, resolve a reviewed host-appropriate checkout of `imaging-server-maintenance`.
+On a `/work` server, use its verified server path rather than assuming a Mac home-directory layout.
+Read its current `MAINTENANCE_LOG.md`, reconcile older runbook text against it, inspect `/work/datasets/REGISTRY.yaml`, and inspect the intended mount:
 
 ```bash
-archive_root=/work/datasets/cpg0037-oasis/axiom/images-jxl/v1
-test -d /work/datasets
-test "$(direnv exec . findmnt -nro TARGET -T /work/datasets)" != "/"
+maintenance_root=replace_with_reviewed_host_maintenance_checkout
+test "$maintenance_root" != replace_with_reviewed_host_maintenance_checkout
+test -f "$maintenance_root/MAINTENANCE_LOG.md"
+sed -n '1,240p' "$maintenance_root/MAINTENANCE_LOG.md"
+test -f /work/datasets/REGISTRY.yaml
+sed -n '1,240p' /work/datasets/REGISTRY.yaml
 direnv exec . findmnt -T /work/datasets
+test "$(direnv exec . findmnt -nro TARGET -T /work/datasets)" != "/"
 ```
 
-The storage-policy group for this hierarchy is `nogroup`.
-Require that membership explicitly, create the exact destination, and verify its ownership, mode, writability, and path resolution:
+Resolve and record the exact destination, owner, group, and mode from current policy:
 
 ```bash
-archive_root=/work/datasets/cpg0037-oasis/axiom/images-jxl/v1
-archive_group=nogroup
-id -nG | tr ' ' '\n' | grep -Fx "$archive_group"
-sudo install -d -o "$(id -un)" -g "$archive_group" -m 2770 "$archive_root"
-test -d "$archive_root"
-test -w "$archive_root"
-test "$(direnv exec . stat -c '%U:%G:%a' "$archive_root")" = "$(id -un):nogroup:2770"
-direnv exec . stat -c '%U:%G %a %n' "$archive_root"
-direnv exec . namei -l "$archive_root"
+archive_root=replace_with_policy_approved_absolute_path
+archive_owner=replace_with_policy_owner
+archive_group=replace_with_policy_group
+archive_mode=replace_with_policy_mode
+test "$archive_root" != replace_with_policy_approved_absolute_path
+test "$archive_owner" != replace_with_policy_owner
+test "$archive_group" != replace_with_policy_group
+test "$archive_mode" != replace_with_policy_mode
 ```
 
-Register this exact root in `/work/datasets/REGISTRY.yaml` with its existing `name`, `description`, `date_added`, and `owner` fields.
-The registry does not carry a group field; `nogroup` is enforced by filesystem ownership and membership:
+Put that exact `archive_root` into the dataset contract created in step 5.
+Record the required registry entry, but defer the registry edit and destination creation until the contract and implementation are reviewed and frozen.
+Stop if the mount, registry placement, owner, group, mode, or exact path is unresolved.
 
-```bash
-sudoedit /work/datasets/REGISTRY.yaml
-rg -n 'cpg0037-oasis|axiom/images-jxl/v1' /work/datasets/REGISTRY.yaml
+## 4. Map normalized rows to the canonical manifest
+
+The unchanged executor reads these identities from `inventory.parquet`:
+
+| Column | Required meaning |
+| --- | --- |
+| `source_key` | Non-null unique S3 key under the contracted prefix, ending in `.tif` or `.tiff` |
+| `source_uri` | Non-null unique exact `s3://<bucket>/<source_key>` identity |
+| `destination_relative` | Non-null unique safe relative path ending in lowercase `.jxl` |
+| `source_size` | Non-null positive integer from the frozen remote snapshot |
+| `etag` | Non-null nonempty S3 ETag with surrounding quotes removed |
+| `version_id` | Optional nonempty S3 version ID, or null when the listing does not provide one |
+
+Use explicit column types and sort deterministically by `source_key` before writing Parquet.
+Reject duplicate keys, duplicate URIs, destination collisions, unsafe paths, objects outside the contracted bucket or prefix, missing remote metadata, and URI-key disagreement.
+The ledger independently enforces unique source keys, source URIs, and destination paths when it binds the manifest.
+
+The manifest may carry narrowly useful audit columns, but the six identities above are the reusable seam.
+For a new dataset, prefer those six columns unless an additional column is required to review the source-specific mapping.
+Write `rejected.parquet` deterministically with a stable upstream identifier and an explicit reason for every rejected normalized row.
+
+Anonymous S3 listings commonly omit version IDs.
+Use null rather than an empty or invented value when no version ID is available.
+In that case the evidence binds the observed key, size, ETag, pinned index, and the source SHA-256 captured during conversion, but it does not prove upstream version-pinned immutability.
+State that limitation in the ambiguity log and run record.
+
+## 5. Implement one direct dataset normalizer
+
+In the isolated branch, add only the concrete files needed for the real dataset, normally a `source.toml`, one ordinary normalization script, and a short source README under `image_archive/<dataset_slug>/`.
+Hard-code the reviewed source columns, URL expansion, channel mapping, path grammar, and selection rules in that script.
+Do not add dataset-name branches to `image_archive/inventory.py` and do not call its Axiom-only `build_inventory` compiler.
+
+The normalizer must use the existing locked environment and must:
+
+1. Verify the exact index URL, size, MD5 when available, and SHA-256 before parsing.
+2. Assert the raw schema and raw row grain before normalization.
+3. Expand or select rows into one row per TIFF using the documented dataset rules.
+4. Reconcile every selected key against one frozen anonymous S3 metadata snapshot.
+5. Fail when any selected key is missing and report prefix extras separately without adding them to scope.
+6. Assert all counts, field and channel cardinality, source identities, and destination uniqueness.
+7. Atomically write `inventory.parquet`, `rejected.parquet`, `summary.json`, the remote snapshot, the zero-missing artifact, and the separate prefix-extra artifact.
+8. Atomically replace any earlier successful `summary.json` with a non-authorizing result before a remote-snapshot rerun can fail or raise.
+9. Refuse a nonempty contract pin mismatch.
+
+The CLI preflight gate reads `summary.json` before both `archive` and `validate`.
+It must contain a `remote_snapshot` object with integer `indexed_missing_count` equal to zero and integer `prefix_extra_count` greater than or equal to zero.
+Keep the separate prefix-extra artifact even when that count is zero.
+No failed rerun may leave an earlier zero-missing summary in place, because that stale summary could authorize `archive` or `validate` against mismatched artifacts.
+Every retained dataset normalizer must have a focused regression equivalent to `test_missing_source_rerun_replaces_successful_preflight`: create a successful preflight, rerun after one selected remote object is missing, require the rerun to fail, require `require_remote_inventory` to refuse the work directory, and assert that the replacement summary records the failure.
+
+Use no TIFF pixel downloads in this step.
+Keep the implementation small enough that another agent can compare every rule with the upstream index and object layout.
+If the existing TOML contract cannot describe the normalized rows truthfully, stop instead of expanding the shared contract model speculatively.
+
+## 6. Bootstrap artifacts with empty pins
+
+Set only these two artifact pins to empty strings for the first metadata-only run:
+
+```toml
+[inventory]
+manifest_sha256 = ""
+rejected_sha256 = ""
 ```
 
-Stop if the mount, group, registry entry, or exact path is wrong.
-The CLI also rejects a missing destination, a root-filesystem destination, a non-writable destination, or any symlinked path component.
-Generated state belongs under `$archive_root/_archive`, generated objects under `$archive_root/jpegxl-d1-e5`, and the destination-scoped coordination file is `$archive_root/.oasis-images.lock`.
+All source identities, counts, codec settings, and destination rules must already be concrete.
+The empty pins are a bootstrap state, not permission to convert.
+The unchanged archive CLI refuses to proceed without both nonempty artifact pins.
 
-## 5. Build and review the remote inventory
-
-Run the metadata-only preflight before transferring any TIFF pixels:
+Run the dataset normalizer in a new qualification directory with the remote snapshot enabled:
 
 ```bash
-direnv exec . pixi run -e images python -m image_archive inventory \
-  --contract image_archive/axiom/source.toml \
+bootstrap_work="$qualification_root/bootstrap"
+test ! -e "$bootstrap_work"
+install -d -m 0770 "$bootstrap_work"
+direnv exec . pixi run -e images python \
+  "image_archive/$dataset_slug/prepare_manifest.py" \
+  --contract "image_archive/$dataset_slug/source.toml" \
+  --work-dir "$bootstrap_work" \
   --remote-snapshot
 ```
 
-This verifies the pinned index bytes and exact six-column Axiom schema, requires 2,019,342 index rows, plans 2,017,182 complete unique TIFFs, preserves 2,160 incomplete rows as explicit rejections, and reconciles every indexed object against the four public S3 batch prefixes.
-It records prefix extras separately and never adds them to the pinned scope.
-It does not download TIFF pixels or write JPEG XL objects.
-
-Review the generated summary and exact artifacts:
+Review the summary, both Parquet schemas, sample mappings, rejection reasons, and exact hashes:
 
 ```bash
-archive_work=/work/datasets/cpg0037-oasis/axiom/images-jxl/v1/_archive
-direnv exec . pixi run -e images python -m json.tool "$archive_work/summary.json"
-sha256sum --check <<'EOF'
-b8c20a37213831b55161a8ed9fe0a1c60522c8951f2b5e19713c7105c8200381  /work/datasets/cpg0037-oasis/axiom/images-jxl/v1/_archive/inventory.parquet
-0bd61c7b852530c8d3ec491f2a99bab2f4cf15bbf1b015389c571ca7c768a66a  /work/datasets/cpg0037-oasis/axiom/images-jxl/v1/_archive/rejected.parquet
-EOF
+direnv exec . pixi run -e images python -m json.tool "$bootstrap_work/summary.json"
+sha256sum "$bootstrap_work/inventory.parquet" "$bootstrap_work/rejected.parquet"
 ```
 
-Do not start conversion unless `indexed_missing_count` is zero, `indexed_present_count` is 2,017,182, `indexed_present_bytes` is 17,825,492,086,890, the inventory and rejected counts are exact, and both hashes pass.
+Require `indexed_missing_count` to be zero.
+Review every category and count of prefix extras separately.
+Do not continue if an extra object was silently included, a selected object lacks metadata, or the raw and normalized grains are not both explicit.
 
-## 6. Start or resume conversion with the direct CLI
+## 7. Pin the artifacts and rerun from fresh state
 
-The direct CLI is the primary launch path:
+Put the reviewed inventory and rejected-row SHA-256 values into the dataset contract.
+Update its normalized counts from reviewed evidence, not from assumptions.
+Then run the same normalizer in a second empty directory:
 
 ```bash
+pinned_work="$qualification_root/pinned"
+test ! -e "$pinned_work"
+install -d -m 0770 "$pinned_work"
+direnv exec . pixi run -e images python \
+  "image_archive/$dataset_slug/prepare_manifest.py" \
+  --contract "image_archive/$dataset_slug/source.toml" \
+  --work-dir "$pinned_work" \
+  --remote-snapshot
+cmp --silent "$bootstrap_work/inventory.parquet" "$pinned_work/inventory.parquet"
+cmp --silent "$bootstrap_work/rejected.parquet" "$pinned_work/rejected.parquet"
+sha256sum "$pinned_work/inventory.parquet" "$pinned_work/rejected.parquet"
+```
+
+This second run must enforce the nonempty pins and produce the exact reviewed artifact bytes in fresh state.
+If the source changed between runs, stop, investigate, and repeat qualification from the beginning with a new explicit source identity.
+
+## 8. Test and freeze the exact implementation SHA
+
+Run the focused checks before any conversion:
+
+```bash
+direnv exec . pixi run -e images python -m unittest discover -s image_archive/tests
+direnv exec . pixi run -e images ruff check image_archive
+direnv exec . pixi run -e images ruff format --check image_archive
+direnv exec . pixi run -e images pyright \
+  --pythonpath "$PWD/.pixi/envs/images/bin/python" image_archive
+git diff --check
+git diff --exit-code -- pixi.lock flake.lock
+```
+
+Commit the reviewed dataset contract, normalizer, source README, and tests on the isolated run branch.
+Never launch conversion from uncommitted code.
+Freeze the exact implementation SHA outside Git and prove the checkout is clean:
+
+```bash
+test -z "$(git status --porcelain)"
+implementation_sha=$(git rev-parse HEAD)
+git show --format=fuller --stat "$implementation_sha"
+printf '%s\n' "$implementation_sha" > "$qualification_root/implementation-sha.txt"
+```
+
+Keep recording the exact commands and their output in the terminal transcript started in step 1.
+Do not replace the raw transcript with a reconstructed command appendix.
+
+## 9. Install the frozen preflight at the destination
+
+Reconfirm that the checkout still has the frozen SHA and no changes.
+Register the exact root according to current policy, then provision the already contracted root and assert its actual filesystem state:
+
+```bash
+test "$(git rev-parse HEAD)" = "$implementation_sha"
+test -z "$(git status --porcelain)"
+id -nG | tr ' ' '\n' | grep -Fx "$archive_group"
+test ! -e "$archive_root"
+sudo install -d -o "$archive_owner" -g "$archive_group" -m "$archive_mode" "$archive_root"
+test -d "$archive_root"
+test -w "$archive_root"
+test "$(direnv exec . stat -c '%U:%G:%a' "$archive_root")" = \
+  "$archive_owner:$archive_group:$archive_mode"
+direnv exec . stat -c '%U:%G %a %n' "$archive_root"
+direnv exec . namei -l "$archive_root"
+first_destination_entry=$(direnv exec . find "$archive_root" -mindepth 1 -maxdepth 1 -print -quit)
+test -z "$first_destination_entry"
+archive_work="$archive_root/_archive"
+test ! -e "$archive_work"
+sudo install -d -o "$archive_owner" -g "$archive_group" -m "$archive_mode" "$archive_work"
+```
+
+Stop if the registry entry, path resolution, writability, owner, group, or mode assertion is wrong.
+The root-absence assertion must run before `sudo install` or any archive CLI, and a pre-existing root is a stop even when it is empty.
+The post-provision empty-root assertion detects unexpected entries before `_archive`, `.oasis-images.lock`, or an output object can be created.
+Full validation is manifest-bound and does not enumerate or certify unrelated destination extras, so clean-room qualification requires the entire contracted root to start empty.
+
+Run the exact pinned normalizer into the canonical work directory:
+
+```bash
+direnv exec . pixi run -e images python \
+  "image_archive/$dataset_slug/prepare_manifest.py" \
+  --contract "image_archive/$dataset_slug/source.toml" \
+  --work-dir "$archive_work" \
+  --remote-snapshot
+cmp --silent "$pinned_work/inventory.parquet" "$archive_work/inventory.parquet"
+cmp --silent "$pinned_work/rejected.parquet" "$archive_work/rejected.parquet"
+direnv exec . pixi run -e images python -m json.tool "$archive_work/summary.json"
+```
+
+Require the frozen remote snapshot to report zero indexed objects missing.
+Require prefix extras to remain a separate artifact and count, never part of the selected manifest.
+Recheck both contract pins and normalized row counts before any TIFF transfer.
+
+## 10. Qualify interruption, resume, status, and the completed no-op
+
+Choose conservative worker limits for the first real run and record the reason for them.
+Use the direct CLI because the tracked systemd service is Axiom-only:
+
+```bash
+workers=replace_with_reviewed_worker_count
+max_in_flight=replace_with_reviewed_in_flight_count
+set +e
 direnv exec . pixi run -e images python -m image_archive archive \
-  --contract image_archive/axiom/source.toml \
-  --workers 64 \
-  --max-in-flight 128 \
+  --contract "image_archive/$dataset_slug/source.toml" \
+  --workers "$workers" \
+  --max-in-flight "$max_in_flight" \
   --max-attempts 5 \
   --max-consecutive-failures 32
+interrupted_status=$?
+set -e
+printf 'intentional interruption status: %s\n' "$interrupted_status"
+test "$interrupted_status" -ne 0
 ```
 
-Each selected TIFF is checked against its remote size, ETag, and version ID when available, decoded as one 2D uint16 plane, encoded by a single-threaded codec worker, decoded at the same shape and dtype, and promoted through an atomic sibling write.
-The schema-v4 SQLite ledger binds the exact manifest and stores source and output hashes and byte counts.
-The circuit breaker stops new scheduling after 32 consecutive failed conversion attempts so that a systemic failure does not sweep the inventory.
-
-An interruption is safe.
-Rerun the exact same command to recover `running` rows to `pending` and resume from the durable ledger.
-Normal resume trusts only exact manifest binding and prior `verified` ledger evidence; it does not treat file existence as completion.
-Use `archive --audit-verified` only when an expensive full hash/decode scan before resume is specifically warranted.
-After correcting a terminal error, raise the cumulative ceiling, for example to `--max-attempts 10`, instead of editing or deleting ledger rows.
-
-## 7. Optionally use the tracked systemd service
-
-This is an optional Spirit-specific wrapper around the same `archive` command and the same 64-worker, 128-in-flight profile.
-Choose either the direct CLI in step 6 or the service for a given run; the destination lock prevents both from mutating the archive together.
-The unit assumes the canonical checkout at `/work/users/shsingh/GitHub/oasis/2024_09_09_Axiom_OASIS` and `/work/datasets` as a mount point.
-
-```bash
-mkdir -p ~/.config/systemd/user
-ln -sfn \
-  /work/users/shsingh/GitHub/oasis/2024_09_09_Axiom_OASIS/image_archive/deploy/oasis-axiom-jpegxl.service \
-  ~/.config/systemd/user/oasis-axiom-jpegxl.service
-systemctl --user daemon-reload
-systemctl --user enable --now oasis-axiom-jpegxl.service
-```
-
-User lingering must already be enabled for the service to survive SSH logout.
-The service lowers CPU and I/O priority and stops for inspection after an ordinary terminal failure.
-It performs conversion only; it never runs final validation or receipt verification.
-
-## 8. Monitor and resume without changing evidence
-
-`status` reads durable ledger progress and does not hash or decode outputs:
+For a new dataset, deliberately interrupt once after the ledger has verified a nonzero sample.
+Record the interruption point in the live transcript.
+The `set +e` exception applies only to this deliberate Ctrl-C because Pixi may return 1 or 130 for it.
+Fail-fast mode is restored immediately, and the transcript plus ledger status must distinguish the expected interruption from a systemic failure.
+Read status without writing a report:
 
 ```bash
 direnv exec . pixi run -e images python -m image_archive status \
-  --contract image_archive/axiom/source.toml
+  --contract "image_archive/$dataset_slug/source.toml"
 ```
 
-For the optional service, monitor its wrapper separately:
+Rerun the exact archive command to recover `running` rows and resume from the schema-v4 ledger.
+Do not edit or delete ledger rows.
+The circuit breaker must remain enabled.
+After completion, status must report the exact manifest binding, every selected row `verified`, and zero `pending`, `running`, `error`, and `unresolved` rows.
+
+Run the exact archive command one more time against the completed destination and capture its JSON:
 
 ```bash
-systemctl --user status oasis-axiom-jpegxl.service
-journalctl --user -fu oasis-axiom-jpegxl.service
+direnv exec . pixi run -e images python -m image_archive archive \
+  --contract "image_archive/$dataset_slug/source.toml" \
+  --workers "$workers" \
+  --max-in-flight "$max_in_flight" \
+  --max-attempts 5 \
+  --max-consecutive-failures 32 \
+  > "$qualification_root/completed-noop.json"
+direnv exec . pixi run -e images python -m json.tool \
+  "$qualification_root/completed-noop.json"
 ```
 
-If the service is active, stop it and wait for lock release before using the direct CLI:
+The completed invocation must select zero rows, recover zero running rows, and download or rewrite no output.
+Run `status --write` once after completion to freeze `_archive/progress.json` as evidence.
 
 ```bash
-systemctl --user stop oasis-axiom-jpegxl.service
-systemctl --user is-active oasis-axiom-jpegxl.service
+direnv exec . pixi run -e images python -m image_archive status \
+  --contract "image_archive/$dataset_slug/source.toml" \
+  --write
 ```
 
-Conversion is ledger-complete only when `verified` is 2,017,182, `pending`, `running`, `error`, and `unresolved` are zero, the manifest binding matches, and `ledger_complete` is true.
-This is not yet full archive validation.
-
-## 9. Run the separate full validation gate
+## 11. Run full validation
 
 After conversion has stopped and released the destination lock, hash and decode every verified output:
 
 ```bash
 direnv exec . pixi run -e images python -m image_archive validate \
-  --contract image_archive/axiom/source.toml \
-  --workers 64 \
+  --contract "image_archive/$dataset_slug/source.toml" \
+  --workers "$workers" \
   --max-attempts 5
 ```
 
-This is the expensive whole-archive validator.
-It checks output byte identity against the ledger, JPEG XL decoding, shape and dtype, inventory and rejected-row counts, manifest binding, and final completeness.
-Any invalid or unresolved object produces a nonzero exit status.
-The required result is `complete: true`, `audit_passed: true`, `checked: 2017182`, `invalid: 0`, and no failures or unresolved rows.
-The deterministic report is written to `_archive/validation.json`.
+The required result is `complete: true`, `audit_passed: true`, the exact expected inventory count, `invalid: 0`, and zero unresolved rows.
+The deterministic report is `_archive/validation.json`.
+This is archive integrity evidence only.
+It does not establish biological equivalence or scientific replacement of the source TIFFs.
 
-## 10. Compare reconstructed evidence with the historical receipt
+## 12. Freeze one external evidence set
 
-Run the focused comparison only after full validation:
+Stop all archive commands and confirm that no service or agent can mutate the destination.
+Close the recorded shell before copying or hashing evidence:
 
 ```bash
-direnv exec . pixi run -e images python -m image_archive verify-receipt \
-  --contract image_archive/axiom/source.toml \
-  --receipt image_archive/records/run-receipt-2026-08-05.toml
+exit
 ```
 
-`verify-receipt` first requires the receipt's deterministic projection to match the single historical production anchor, before it resolves the destination or any archive artifact.
-That projection binds every receipt value used as a reconstruction expectation while excluding host, timestamps, attempts, retries, service history, absolute paths, and mtimes.
-It then checks the receipt schema, receipt ID, contract byte hash, and pinned index identity.
-It then acquires the existing destination lock in shared nonblocking mode and refuses to run while `inventory`, `archive`, or `validate` holds the exclusive lock.
-While holding the shared lock, it also refuses any nonempty `state.sqlite3-wal` before opening the main database as immutable.
-It hashes the inventory, rejected rows, and validation report; checks Parquet row counts; recomputes the manifest identity; opens SQLite with `mode=ro`, `immutable=1`, and `PRAGMA query_only`; checks schema, record count, exact manifest binding, final counts, and byte totals; and streams the receipt-defined canonical ledger evidence digest.
-It does not create a directory or lock, recover or migrate a ledger, invoke another workflow, inspect or rewrite JPEG XL objects, or write a report.
-All deterministic mismatches are printed together and the command exits nonzero.
+Wait until `script` returns to its parent shell so `terminal.typescript` is closed and flushed.
+Do not run any evidence-copy or SHA-256 command from the still-recorded shell.
+Restore fail-fast mode and the exact recorded paths in the parent shell:
 
-The required output has `matches: true` and an empty `mismatches` list.
-The expected deterministic evidence includes:
-
-```text
-manifest identity SHA-256: 24a0621ce8b5e88914e50fb4710515811b9f382450cad38d675dba001507b207
-ledger evidence SHA-256:   bae3ad62b1940e9f97b964a9fc658ad0d8e13ba0d5e5d9fcb6ecedb7c0b2112a
-source bytes:              17825492086890
-output bytes:              323337920405
-validation report SHA-256: 83ad5f170295039102fe619c6108c7f76c70eede2678baf1b391513b3e4cb457
+```bash
+set -euo pipefail
+archive_root=replace_with_policy_approved_absolute_path
+archive_work="$archive_root/_archive"
+implementation_sha=$(cat "$qualification_root/implementation-sha.txt")
+test -s "$qualification_root/terminal.typescript"
+test "$(git rev-parse HEAD)" = "$implementation_sha"
+test -z "$(git status --porcelain)"
 ```
 
-The output also reports historical host, paths, attempt distribution, and timestamps as context.
-Those fields may differ and never cause reconstruction failure.
+Choose one policy-approved external run directory outside the checkout and object tree, and keep the evidence flat rather than creating a generic receipt system.
+Include all of the following:
 
-## 11. Declare reconstruction complete
+- The exact implementation SHA and clean-tree assertion.
+- A tracked source archive generated from that exact clean implementation SHA, plus its commit metadata.
+- The exact contract and authoritative index bytes.
+- `inventory.parquet`, `rejected.parquet`, `summary.json`, and the frozen remote, zero-missing, and prefix-extra artifacts.
+- The raw command transcript captured during execution.
+- The ambiguity log, including source grain and version-ID limitations.
+- A schema-v4 ledger snapshot with a missing or zero-byte WAL.
+- `progress.json`, `validation.json`, and the completed no-op result.
+- One plain run record containing counts, bytes, interruption and resume facts, codec settings, storage owner/group/mode, and final conclusions.
+- One SHA-256 manifest over every evidence file.
 
-Reconstruction is complete only when all of the following are true:
+Acquire the same destination lock while copying the ledger and refuse a live WAL:
 
-1. The tracked contract and historical receipt retain their exact SHA-256 hashes.
-2. The pinned index and remote inventory preflight pass with zero indexed objects missing.
-3. `inventory.parquet` and `rejected.parquet` have the exact hashes and counts in the contract and receipt.
-4. `status` reports 2,017,182 verified rows, zero unresolved rows, and an exact manifest binding.
-5. The separate full validator reports `complete: true` and `audit_passed: true` for all 2,017,182 outputs and 2,160 rejected rows.
-6. `verify-receipt` reports `matches: true` with no deterministic mismatch.
-7. No claim is made that the lossy derivative is biologically equivalent to the source TIFFs.
+```bash
+evidence_dir=replace_with_policy_approved_external_run_directory
+test "$evidence_dir" != replace_with_policy_approved_external_run_directory
+test ! -e "$evidence_dir"
+install -d -m 0770 "$evidence_dir"
+cp "$qualification_root/terminal.typescript" "$evidence_dir/terminal.typescript"
+cp "$qualification_root/implementation-sha.txt" "$evidence_dir/implementation-sha.txt"
+git show --no-patch --format=fuller "$implementation_sha" \
+  > "$evidence_dir/implementation-commit.txt"
+git archive --format=tar.gz \
+  --output="$evidence_dir/implementation-$implementation_sha.tar.gz" \
+  "$implementation_sha" -- \
+  .envrc README.md image_archive pixi.toml pyproject.toml pixi.lock flake.nix flake.lock
+test -s "$evidence_dir/implementation-$implementation_sha.tar.gz"
+test -f "$archive_root/.oasis-images.lock"
+flock -n "$archive_root/.oasis-images.lock" \
+  sh -eu -c '
+    test ! -s "$1/state.sqlite3-wal"
+    cp --reflink=auto "$1/state.sqlite3" "$2/state.sqlite3"
+    test ! -s "$2/state.sqlite3-wal"
+  ' sh "$archive_work" "$evidence_dir"
+```
 
-Do not recompress an already verified archive merely to reproduce historical timestamps, attempts, host details, command paths, or service history.
+A nonempty WAL is a stop condition.
+Do not certify or copy only the main SQLite file while committed frames remain in a WAL.
+The source archive above is generated only after the recorded HEAD and clean-tree assertions pass.
+It is an exact tracked snapshot from the frozen SHA and requires no push.
+Do not substitute a working-tree patch, which can omit untracked files.
+
+After copying the remaining listed artifacts, create and verify a standard manifest:
+
+```bash
+cd "$evidence_dir"
+find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+sha256sum --check SHA256SUMS
+```
+
+Place the evidence directory under the site's current immutable or versioned retention policy and verify that retained copy.
+A new dataset uses its plain run record and SHA-256 manifest.
+Do not add it to `image_archive/records/` or change the Axiom-only `verify-receipt` command.
+
+## 13. Completion criteria
+
+The adaptation is complete only when the exact tracked implementation SHA produced a pinned deterministic manifest in fresh state, the final remote snapshot has zero selected objects missing, prefix extras remain separate, the interrupted run resumed safely, the completed rerun selected zero rows, full validation passed every object, the external ledger snapshot has no nonempty WAL, and the external SHA-256 manifest verifies.
+
+Report any unavailable upstream version IDs as a limitation.
+Preserve the original TIFFs as the scientific source of truth and make no biological-equivalence claim for the lossy derivative.

--- a/image_archive/__main__.py
+++ b/image_archive/__main__.py
@@ -23,7 +23,7 @@ METADATA_DIRECTORY: Final = "_archive"
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m image_archive",
-        description="Build and verify a local JPEG XL image archive from a dataset contract.",
+        description="Run the canonical-manifest JPEG XL archive engine; Axiom is the default contract.",
     )
     parser.add_argument(
         "--log-level",
@@ -34,7 +34,7 @@ def _parser() -> argparse.ArgumentParser:
 
     inventory = commands.add_parser(
         "inventory",
-        help="verify the pinned index and optionally snapshot public S3 metadata",
+        help="run the Axiom-only index compiler and optional public S3 snapshot",
     )
     _add_contract_and_work_dir(inventory)
     inventory.add_argument("--index", type=Path, help="reuse an exact local copy of the pinned index")
@@ -73,15 +73,25 @@ def _parser() -> argparse.ArgumentParser:
 
     receipt = commands.add_parser(
         "verify-receipt",
-        help="compare deterministic archive evidence with a historical receipt",
+        help="verify the Axiom-only historical receipt",
     )
-    receipt.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT)
+    receipt.add_argument(
+        "--contract",
+        type=Path,
+        default=DEFAULT_CONTRACT,
+        help="archive contract (default: Axiom OASIS)",
+    )
     receipt.add_argument("--receipt", type=Path, required=True)
     return parser
 
 
 def _add_contract_and_work_dir(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT)
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=DEFAULT_CONTRACT,
+        help="archive contract (default: Axiom OASIS)",
+    )
     parser.add_argument(
         "--work-dir",
         type=Path,

--- a/image_archive/axiom/README.md
+++ b/image_archive/axiom/README.md
@@ -1,0 +1,285 @@
+# Reconstruct the Axiom OASIS JPEG XL image archive
+
+This runbook reconstructs the Axiom OASIS JPEG XL v1 archive from a fresh checkout.
+Run every command from the repository root.
+The original Cell Painting Gallery TIFFs remain the source of truth.
+For a new supported dataset, start with the canonical-manifest adaptation runbook in [the package README](../README.md).
+
+The CLI `DEFAULT_CONTRACT`, the six-column inventory reference compiler, the optional systemd service, and `verify-receipt` are Axiom-only boundaries.
+They remain here for completed-run compatibility and historical reconstruction.
+
+Deterministic reconstruction succeeds when the pinned index produces the exact inventory and rejected-row artifacts, every inventory row has the exact ledger-bound source and output evidence recorded by the historical receipt, the final counts and byte totals match, and the deterministic validation report matches.
+Host, timestamps, attempts, retry history, service history, absolute paths, historical command spellings, mtimes, and other execution details are context only.
+They do not need to match the 2026-08-05 run.
+
+The `jpegxl-d1-e5` tier is lossy JPEG XL at distance 1.0 and effort 5.
+No channel stacking, normalization, intensity transformation, cropping, resizing, or biological recalibration is performed.
+Biological equivalence to the source TIFFs has not been established for this dataset.
+Use the TIFFs for measurements and scientific results, and use this derivative only for browsing, visualization, and retrieval.
+Issue [#44](https://github.com/broadinstitute/2024_09_09_Axiom_OASIS/issues/44) records the available measurements and the particular Brightfield concern.
+
+## 1. Start from a clean checkout and enter the pinned environment
+
+Confirm that this is the repository root and that the reconstruction inputs are tracked and unmodified:
+
+```bash
+test -f image_archive/axiom/source.toml
+test -f image_archive/records/run-receipt-2026-08-05.toml
+git diff --exit-code -- \
+  image_archive/axiom/source.toml \
+  image_archive/records/run-receipt-2026-08-05.toml \
+  pixi.lock \
+  flake.lock
+```
+
+Approve the repository environment once, install the locked `images` environment without updating the lockfile, and enter it through `direnv` for every command:
+
+```bash
+direnv allow
+direnv exec . pixi install --locked -e images
+direnv exec . pixi run -e images python --version
+git diff --exit-code -- pixi.lock flake.lock
+```
+
+The environment remains named `images` because renaming it would rewrite `pixi.lock`.
+Do not update dependencies or regenerate either lockfile during reconstruction.
+
+## 2. Verify the tracked contract, lockfiles, and immutable receipt
+
+Verify the exact bytes in the current checkout:
+
+```bash
+sha256sum --check <<'EOF'
+a85639eb25908bdf900a67daeba8fc8a755db4c03841d21aff3fed9609d197dd  image_archive/axiom/source.toml
+d4af5e083b90a50a2a891ad1a068cd54510f6da274801388fd81bb1cffba4e99  image_archive/records/run-receipt-2026-08-05.toml
+55665368f14dc6e2b82b5b06bc5b6495abad863ff40fff10f93bea34235fe900  pixi.lock
+8628426df569bbe3fb2b8367fbb411fb4cd4c04f023b1afeeb2cba094b7f8c30  flake.lock
+EOF
+```
+
+The immutable historical receipt records `pixi_lock_sha256 = f1412dfb...`, which was the whole-repository lockfile at the original archive run.
+Later tracked paper-environment work changed the whole lockfile to the current hash above without changing the pinned `images` package versions recorded in the receipt.
+The receipt comparison therefore treats lockfile hashes and runtime versions as historical context; it does not require a current whole-repository lockfile to reproduce an earlier unrelated environment graph.
+The contract and receipt hashes themselves must remain exact.
+
+The contract pins Zenodo record 17067683, `index.parquet` SHA-256 `f83a16fa...`, the public S3 namespace, all inventory counts and mappings, the one-TIFF-to-one-JXL destination rule, and the JUMP_lite codec provenance.
+The inventory command rehashes the downloaded index before accepting it.
+
+## 3. Run the focused tests and inspect the CLI
+
+Run the complete focused archive test suite and both help surfaces before touching external storage:
+
+```bash
+direnv exec . pixi run -e images python -m unittest discover -s image_archive/tests
+direnv exec . pixi run -e images python -m image_archive --help
+direnv exec . pixi run -e images python -m image_archive verify-receipt --help
+```
+
+For Axiom, the workflow consists of `inventory`, `archive`, `status`, and `validate`.
+The `inventory` command invokes the Axiom-only six-column reference compiler.
+New supported datasets hand a separately normalized canonical manifest to the unchanged `archive`, `status`, and `validate` boundary described in [the package README](../README.md).
+`verify-receipt` is a final read-only comparison and never substitutes for any of those four commands.
+
+## 4. Provision and register the external destination
+
+The contracted destination is:
+
+```text
+/work/datasets/cpg0037-oasis/axiom/images-jxl/v1
+```
+
+First verify that `/work/datasets` is available from a non-root mounted filesystem:
+
+```bash
+archive_root=/work/datasets/cpg0037-oasis/axiom/images-jxl/v1
+test -d /work/datasets
+test "$(direnv exec . findmnt -nro TARGET -T /work/datasets)" != "/"
+direnv exec . findmnt -T /work/datasets
+```
+
+The storage-policy group for this hierarchy is `nogroup`.
+Require that membership explicitly, create the exact destination, and verify its ownership, mode, writability, and path resolution:
+
+```bash
+archive_root=/work/datasets/cpg0037-oasis/axiom/images-jxl/v1
+archive_group=nogroup
+id -nG | tr ' ' '\n' | grep -Fx "$archive_group"
+sudo install -d -o "$(id -un)" -g "$archive_group" -m 2770 "$archive_root"
+test -d "$archive_root"
+test -w "$archive_root"
+test "$(direnv exec . stat -c '%U:%G:%a' "$archive_root")" = "$(id -un):nogroup:2770"
+direnv exec . stat -c '%U:%G %a %n' "$archive_root"
+direnv exec . namei -l "$archive_root"
+```
+
+Register this exact root in `/work/datasets/REGISTRY.yaml` with its existing `name`, `description`, `date_added`, and `owner` fields.
+The registry does not carry a group field; `nogroup` is enforced by filesystem ownership and membership:
+
+```bash
+sudoedit /work/datasets/REGISTRY.yaml
+rg -n 'cpg0037-oasis|axiom/images-jxl/v1' /work/datasets/REGISTRY.yaml
+```
+
+Stop if the mount, group, registry entry, or exact path is wrong.
+The CLI also rejects a missing destination, a root-filesystem destination, a non-writable destination, or any symlinked path component.
+Generated state belongs under `$archive_root/_archive`, generated objects under `$archive_root/jpegxl-d1-e5`, and the destination-scoped coordination file is `$archive_root/.oasis-images.lock`.
+
+## 5. Build and review the remote inventory
+
+Run the metadata-only preflight before transferring any TIFF pixels:
+
+```bash
+direnv exec . pixi run -e images python -m image_archive inventory \
+  --contract image_archive/axiom/source.toml \
+  --remote-snapshot
+```
+
+This verifies the pinned index bytes and exact six-column Axiom schema, requires 2,019,342 index rows, plans 2,017,182 complete unique TIFFs, preserves 2,160 incomplete rows as explicit rejections, and reconciles every indexed object against the four public S3 batch prefixes.
+It records prefix extras separately and never adds them to the pinned scope.
+It does not download TIFF pixels or write JPEG XL objects.
+
+Review the generated summary and exact artifacts:
+
+```bash
+archive_work=/work/datasets/cpg0037-oasis/axiom/images-jxl/v1/_archive
+direnv exec . pixi run -e images python -m json.tool "$archive_work/summary.json"
+sha256sum --check <<'EOF'
+b8c20a37213831b55161a8ed9fe0a1c60522c8951f2b5e19713c7105c8200381  /work/datasets/cpg0037-oasis/axiom/images-jxl/v1/_archive/inventory.parquet
+0bd61c7b852530c8d3ec491f2a99bab2f4cf15bbf1b015389c571ca7c768a66a  /work/datasets/cpg0037-oasis/axiom/images-jxl/v1/_archive/rejected.parquet
+EOF
+```
+
+Do not start conversion unless `indexed_missing_count` is zero, `indexed_present_count` is 2,017,182, `indexed_present_bytes` is 17,825,492,086,890, the inventory and rejected counts are exact, and both hashes pass.
+
+## 6. Start or resume conversion with the direct CLI
+
+The direct CLI is the primary launch path:
+
+```bash
+direnv exec . pixi run -e images python -m image_archive archive \
+  --contract image_archive/axiom/source.toml \
+  --workers 64 \
+  --max-in-flight 128 \
+  --max-attempts 5 \
+  --max-consecutive-failures 32
+```
+
+Each selected TIFF is checked against its remote size, ETag, and version ID when available, decoded as one 2D uint16 plane, encoded by a single-threaded codec worker, decoded at the same shape and dtype, and promoted through an atomic sibling write.
+The schema-v4 SQLite ledger binds the exact manifest and stores source and output hashes and byte counts.
+The circuit breaker stops new scheduling after 32 consecutive failed conversion attempts so that a systemic failure does not sweep the inventory.
+
+An interruption is safe.
+Rerun the exact same command to recover `running` rows to `pending` and resume from the durable ledger.
+Normal resume trusts only exact manifest binding and prior `verified` ledger evidence; it does not treat file existence as completion.
+Use `archive --audit-verified` only when an expensive full hash/decode scan before resume is specifically warranted.
+After correcting a terminal error, raise the cumulative ceiling, for example to `--max-attempts 10`, instead of editing or deleting ledger rows.
+
+## 7. Optionally use the Axiom-only tracked systemd service
+
+This is an optional Spirit-specific wrapper around the same `archive` command and the same 64-worker, 128-in-flight profile.
+Choose either the direct CLI in step 6 or the service for a given run; the destination lock prevents both from mutating the archive together.
+The unit assumes the canonical checkout at `/work/users/shsingh/GitHub/oasis/2024_09_09_Axiom_OASIS` and `/work/datasets` as a mount point.
+
+```bash
+mkdir -p ~/.config/systemd/user
+ln -sfn \
+  /work/users/shsingh/GitHub/oasis/2024_09_09_Axiom_OASIS/image_archive/deploy/oasis-axiom-jpegxl.service \
+  ~/.config/systemd/user/oasis-axiom-jpegxl.service
+systemctl --user daemon-reload
+systemctl --user enable --now oasis-axiom-jpegxl.service
+```
+
+User lingering must already be enabled for the service to survive SSH logout.
+The service lowers CPU and I/O priority and stops for inspection after an ordinary terminal failure.
+It performs conversion only; it never runs final validation or receipt verification.
+
+## 8. Monitor and resume without changing evidence
+
+`status` reads durable ledger progress and does not hash or decode outputs:
+
+```bash
+direnv exec . pixi run -e images python -m image_archive status \
+  --contract image_archive/axiom/source.toml
+```
+
+For the optional service, monitor its wrapper separately:
+
+```bash
+systemctl --user status oasis-axiom-jpegxl.service
+journalctl --user -fu oasis-axiom-jpegxl.service
+```
+
+If the service is active, stop it and wait for lock release before using the direct CLI:
+
+```bash
+systemctl --user stop oasis-axiom-jpegxl.service
+systemctl --user is-active oasis-axiom-jpegxl.service
+```
+
+Conversion is ledger-complete only when `verified` is 2,017,182, `pending`, `running`, `error`, and `unresolved` are zero, the manifest binding matches, and `ledger_complete` is true.
+This is not yet full archive validation.
+
+## 9. Run the separate full validation gate
+
+After conversion has stopped and released the destination lock, hash and decode every verified output:
+
+```bash
+direnv exec . pixi run -e images python -m image_archive validate \
+  --contract image_archive/axiom/source.toml \
+  --workers 64 \
+  --max-attempts 5
+```
+
+This is the expensive whole-archive validator.
+It checks output byte identity against the ledger, JPEG XL decoding, shape and dtype, inventory and rejected-row counts, manifest binding, and final completeness.
+Any invalid or unresolved object produces a nonzero exit status.
+The required result is `complete: true`, `audit_passed: true`, `checked: 2017182`, `invalid: 0`, and no failures or unresolved rows.
+The deterministic report is written to `_archive/validation.json`.
+
+## 10. Use the Axiom-only historical receipt verifier
+
+Run the focused comparison only after full validation:
+
+```bash
+direnv exec . pixi run -e images python -m image_archive verify-receipt \
+  --contract image_archive/axiom/source.toml \
+  --receipt image_archive/records/run-receipt-2026-08-05.toml
+```
+
+`verify-receipt` first requires the receipt's deterministic projection to match the single historical production anchor, before it resolves the destination or any archive artifact.
+It is intentionally fixed to this completed Axiom run and must not be generalized or used to certify another dataset.
+That projection binds every receipt value used as a reconstruction expectation while excluding host, timestamps, attempts, retries, service history, absolute paths, and mtimes.
+It then checks the receipt schema, receipt ID, contract byte hash, and pinned index identity.
+It then acquires the existing destination lock in shared nonblocking mode and refuses to run while `inventory`, `archive`, or `validate` holds the exclusive lock.
+While holding the shared lock, it also refuses any nonempty `state.sqlite3-wal` before opening the main database as immutable.
+It hashes the inventory, rejected rows, and validation report; checks Parquet row counts; recomputes the manifest identity; opens SQLite with `mode=ro`, `immutable=1`, and `PRAGMA query_only`; checks schema, record count, exact manifest binding, final counts, and byte totals; and streams the receipt-defined canonical ledger evidence digest.
+It does not create a directory or lock, recover or migrate a ledger, invoke another workflow, inspect or rewrite JPEG XL objects, or write a report.
+All deterministic mismatches are printed together and the command exits nonzero.
+
+The required output has `matches: true` and an empty `mismatches` list.
+The expected deterministic evidence includes:
+
+```text
+manifest identity SHA-256: 24a0621ce8b5e88914e50fb4710515811b9f382450cad38d675dba001507b207
+ledger evidence SHA-256:   bae3ad62b1940e9f97b964a9fc658ad0d8e13ba0d5e5d9fcb6ecedb7c0b2112a
+source bytes:              17825492086890
+output bytes:              323337920405
+validation report SHA-256: 83ad5f170295039102fe619c6108c7f76c70eede2678baf1b391513b3e4cb457
+```
+
+The output also reports historical host, paths, attempt distribution, and timestamps as context.
+Those fields may differ and never cause reconstruction failure.
+
+## 11. Declare reconstruction complete
+
+Reconstruction is complete only when all of the following are true:
+
+1. The tracked contract and historical receipt retain their exact SHA-256 hashes.
+2. The pinned index and remote inventory preflight pass with zero indexed objects missing.
+3. `inventory.parquet` and `rejected.parquet` have the exact hashes and counts in the contract and receipt.
+4. `status` reports 2,017,182 verified rows, zero unresolved rows, and an exact manifest binding.
+5. The separate full validator reports `complete: true` and `audit_passed: true` for all 2,017,182 outputs and 2,160 rejected rows.
+6. `verify-receipt` reports `matches: true` with no deterministic mismatch.
+7. No claim is made that the lossy derivative is biologically equivalent to the source TIFFs.
+
+Do not recompress an already verified archive merely to reproduce historical timestamps, attempts, host details, command paths, or service history.

--- a/image_archive/tests/test_image_archive.py
+++ b/image_archive/tests/test_image_archive.py
@@ -45,6 +45,8 @@ PREFIX = "demo-images"
 BATCH = "batch_demo"
 PLATE = "plate_00000042"
 CHANNEL = "Nuclei"
+DIRECT_SOURCE_KEY = f"{PREFIX}/vendor-flat/raw/acquisition-x/image-7.tif"
+DIRECT_DESTINATION_RELATIVE = "jpegxl-d1-e5/freeform/image-7.jxl"
 
 
 class _Body:
@@ -203,6 +205,66 @@ def _inventory(root: Path, rows: int = 1) -> tuple[Contract, Path, _S3]:
     return replace(contract, inventory=pinned), work_dir, client
 
 
+def _direct_manifest(root: Path) -> tuple[Contract, Path, _S3]:
+    contract, _, _ = _fixture(root)
+    work_dir = root / "archive" / "_archive"
+    work_dir.mkdir()
+    payload = _tiff(7)
+    client = _S3({DIRECT_SOURCE_KEY: payload})
+    inventory_path = work_dir / "inventory.parquet"
+    pl.DataFrame(
+        {
+            "source_key": [DIRECT_SOURCE_KEY],
+            "source_uri": [f"s3://{BUCKET}/{DIRECT_SOURCE_KEY}"],
+            "destination_relative": [DIRECT_DESTINATION_RELATIVE],
+            "source_size": [len(payload)],
+            "etag": [client.etags[DIRECT_SOURCE_KEY]],
+            "version_id": [None],
+        },
+        schema={
+            "source_key": pl.String,
+            "source_uri": pl.String,
+            "destination_relative": pl.String,
+            "source_size": pl.Int64,
+            "etag": pl.String,
+            "version_id": pl.String,
+        },
+    ).write_parquet(inventory_path, compression="zstd", statistics=True)
+    rejected_path = work_dir / "rejected.parquet"
+    pl.DataFrame(
+        {
+            "source_identifier": ["raw-row-without-uri"],
+            "reason": ["missing image URI"],
+        },
+        schema={"source_identifier": pl.String, "reason": pl.String},
+    ).write_parquet(rejected_path, compression="zstd", statistics=True)
+    (work_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "remote_snapshot": {
+                    "indexed_missing_count": 0,
+                    "prefix_extra_count": 0,
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )
+    return (
+        replace(
+            contract,
+            inventory=replace(
+                contract.inventory,
+                manifest_sha256=sha256_file(inventory_path),
+                rejected_sha256=sha256_file(rejected_path),
+            ),
+        ),
+        work_dir,
+        client,
+    )
+
+
 class ImageArchiveTest(unittest.TestCase):
     def test_missing_source_rerun_replaces_successful_preflight(self) -> None:
         with TemporaryDirectory() as directory:
@@ -225,13 +287,17 @@ class ImageArchiveTest(unittest.TestCase):
             summary = json.loads((work_dir / "summary.json").read_text())
             self.assertEqual(summary["remote_snapshot"]["indexed_missing_count"], 1)
 
-    def test_non_oasis_inventory_resume_report_validate_and_repair(self) -> None:
+    def test_direct_manifest_resume_status_validate_and_repair(self) -> None:
         with TemporaryDirectory() as directory:
             root = Path(directory)
-            contract, work_dir, client = _inventory(root)
+            contract, work_dir, client = _direct_manifest(root)
             inventory_path = work_dir / "inventory.parquet"
+            rejected_path = work_dir / "rejected.parquet"
             state_path = work_dir / "state.sqlite3"
             manifest = list(iter_manifest_identities(inventory_path, contract))
+            self.assertEqual(manifest[0].source_key, DIRECT_SOURCE_KEY)
+            self.assertEqual(manifest[0].destination_relative, DIRECT_DESTINATION_RELATIVE)
+            require_remote_inventory(contract, work_dir)
             with ArchiveState(state_path) as state:
                 state.initialize(
                     manifest,
@@ -240,7 +306,6 @@ class ImageArchiveTest(unittest.TestCase):
                 )
                 state.mark_running(manifest[0].source_key)
 
-            require_remote_inventory(contract, work_dir)
             with patch("image_archive.archive._s3_client", return_value=client):
                 first = run_archive(
                     contract,
@@ -258,22 +323,31 @@ class ImageArchiveTest(unittest.TestCase):
                 )
 
             self.assertEqual(first.recovered_running, 1)
+            self.assertEqual(first.selected, 1)
             self.assertEqual(first.verified, 1)
             self.assertEqual(resumed.selected, 0)
+            self.assertEqual(resumed.verified, 0)
+            self.assertEqual(resumed.recovered_running, 0)
             self.assertEqual(client.downloads, 1)
             progress = state_report(state_path)
             self.assertEqual(progress["counts"]["verified"], 1)
+            self.assertEqual(progress["counts"]["unresolved"], 0)
+            self.assertEqual(
+                progress["manifest_binding"]["artifact_sha256"],
+                contract.inventory.manifest_sha256,
+            )
 
             report_path = work_dir / "validation.json"
             valid = validate_archive(
                 contract,
                 inventory_path=inventory_path,
-                rejected_path=work_dir / "rejected.parquet",
+                rejected_path=rejected_path,
                 state_path=state_path,
                 workers=1,
                 report_path=report_path,
             )
             self.assertTrue(valid.complete)
+            self.assertTrue(valid.audit_passed)
             self.assertTrue(json.loads(report_path.read_text())["complete"])
 
             output = contract.destination.root / manifest[0].destination_relative
@@ -282,7 +356,7 @@ class ImageArchiveTest(unittest.TestCase):
                 validate_archive(
                     contract,
                     inventory_path=inventory_path,
-                    rejected_path=work_dir / "rejected.parquet",
+                    rejected_path=rejected_path,
                     state_path=state_path,
                     workers=1,
                 ).complete,


### PR DESCRIPTION
## Summary

- Separate the agent-facing canonical-manifest adaptation runbook from the exact Axiom reconstruction record.
- Clarify Axiom-only CLI surfaces while preserving engine behavior and completed-run compatibility.
- Add direct post-preflight manifest regression coverage without generalized machinery or new dependencies.

## Review

- A dedicated executor implemented the approved structure.
- A first independent read-only reviewer returned confirmed findings to the executor; the revised tree was re-reviewed until no actionable findings remained.
- A second fresh independent read-only reviewer audited the final five-file diff and also reported no actionable findings.
- The executor acted on the clean verdict by making no speculative edits and confirming all scoped file hashes were unchanged.

## Validation

- 12 focused image archive tests
- Ruff check and format check
- Pyright with the pinned images environment
- Markdown render, link, fence, heading, and ASCII checks
- git diff --check
- Read-only completed-ledger status: 2,017,182 verified and zero unresolved
- Read-only schema-v4 receipt verification: matches true with no mismatches

No recompression, full completed-archive validation, external mutation, or data publication was performed.