### PR TITLE
Add a clean-room image archive agent prompt

### DIFF
--- a/image_archive/README.md
+++ b/image_archive/README.md
@@ -4,7 +4,9 @@
 
 The original Cell Painting images used by this project are TIFF files in the public [Cell Painting Gallery](https://github.com/broadinstitute/cellpainting-gallery).
 This directory is storage infrastructure, not part of the phenotype-analysis pipeline.
-It was built to convert the 2,017,182 selected Axiom OASIS TIFFs, totaling 17.8 TB, into a 323 GB local JPEG XL derivative while keeping every output traceable and every interrupted run resumable.
+`Axiom` here refers to Axiom Bio, the contributing institution identified by the `axiom` source segment in the Gallery path; it is not the name of the archive engine.
+The specific dataset analyzed by this repository contains primary human hepatocytes treated with compounds for the OASIS (Omics for Assessing Signatures for Integrated Safety) project and is published under `cpg0037-oasis/axiom/images/`.
+The completed archive was built for that dataset and converted its 2,017,182 selected TIFFs, totaling 17.8 TB, into a 323 GB local JPEG XL derivative while keeping every output traceable and every interrupted run resumable.
 The tooling and audit records remain here so that the completed archive can be inspected or reconstructed and the same narrow process can be applied to another compatible source dataset.
 For every selected TIFF, the archive engine downloads the source object, encodes one `.jxl` file, writes it atomically, and records durable progress and checksums in a schema-v4 SQLite ledger.
 An interrupted run can resume from that ledger, and a separate validation pass hashes and decodes every completed output.
@@ -25,6 +27,26 @@ The files are organized by ownership:
 - `tests/` contains focused engine and receipt tests.
 - `deploy/` contains the optional Axiom systemd service used for the completed deployment.
 - `records/` contains the immutable receipt for the historical Axiom run.
+
+## Use this with a coding agent
+
+Start a capable coding agent in a clean checkout of this repository, replace the dataset pointer below, and paste this prompt:
+
+```text
+Use this repository to archive the following Cell Painting dataset:
+
+<DATASET URL, IDENTIFIER, INDEX, OR S3 PREFIX>
+
+Read image_archive/README.md completely and follow its runbook.
+First inspect the source and determine whether it satisfies the supported boundary.
+If it does not, stop and explain why.
+If it does, implement the smallest dataset-specific normalization needed and carry the run through inventory, an intentional interruption and resume, status, a completed no-op, full validation, and immutable run evidence.
+
+In this repository, Axiom OASIS means the historical OASIS dataset contributed by Axiom Bio and stored at cpg0037-oasis/axiom/images/; it is neither the archive engine nor the new dataset.
+Preserve the reusable archive engine behavior and do not modify or invalidate the Axiom dataset's pinned contract, immutable receipt, completed outputs, or Axiom-only verification surfaces.
+Do not add dependencies, frameworks, registries, adapter layers, base classes, workflow machinery, compatibility shims, or speculative multi-dataset abstractions.
+Before expensive conversion, resolve the source scope, storage ownership, destination, and manifest pins; ask for direction if any of those require a user decision.
+```
 
 ## Adapt the JPEG XL archive to another Cell Painting dataset
 

--- a/image_archive/README.md
+++ b/image_archive/README.md
@@ -80,14 +80,15 @@ Do not add dependencies, frameworks, parser registries, adapter layers or protoc
 ## 1. Start from a clean isolated checkout
 
 Begin in a clean repository root and create a dedicated worktree and branch for this one adaptation.
-Choose a short stable dataset slug before running these commands:
+Choose a short stable lowercase Python package name for the dataset, using only letters, digits, and underscores and starting with a letter, such as `garcia_fossa_agnp`.
+Use that name as the dataset slug in every command below:
 
 ```bash
 set -euo pipefail
 test -f image_archive/axiom/source.toml
 test -z "$(git status --porcelain)"
-dataset_slug=replace_with_dataset_slug
-test "$dataset_slug" != replace_with_dataset_slug
+dataset_slug=replace_with_python_package_name
+test "$dataset_slug" != replace_with_python_package_name
 worktree_parent=/work/users/"$(id -un)"/worktrees
 install -d -m 0770 "$worktree_parent"
 worktree="$worktree_parent/2024_09_09_Axiom_OASIS-image-archive-$dataset_slug"
@@ -222,7 +223,8 @@ State that limitation in the ambiguity log and run record.
 
 ## 5. Implement one direct dataset normalizer
 
-In the isolated branch, add only the concrete files needed for the real dataset, normally a `source.toml`, one ordinary normalization script, and a short source README under `image_archive/<dataset_slug>/`.
+In the isolated branch, add only the concrete files needed for the real dataset, normally `__init__.py`, `source.toml`, one ordinary `prepare_manifest.py` normalization module, and a short source README under `image_archive/<dataset_slug>/`.
+Keep module import free of source, destination, or network side effects.
 Hard-code the reviewed source columns, URL expansion, channel mapping, path grammar, and selection rules in that script.
 Do not add dataset-name branches to `image_archive/inventory.py` and do not call its Axiom-only `build_inventory` compiler.
 
@@ -243,6 +245,15 @@ It must contain a `remote_snapshot` object with integer `indexed_missing_count` 
 Keep the separate prefix-extra artifact even when that count is zero.
 No failed rerun may leave an earlier zero-missing summary in place, because that stale summary could authorize `archive` or `validate` against mismatched artifacts.
 Every retained dataset normalizer must have a focused regression equivalent to `test_missing_source_rerun_replaces_successful_preflight`: create a successful preflight, rerun after one selected remote object is missing, require the rerun to fail, require `require_remote_inventory` to refuse the work directory, and assert that the replacement summary records the failure.
+
+Before bootstrapping artifacts, prove that the dataset module imports from the repository root through the locked environment:
+
+```bash
+test -f "image_archive/$dataset_slug/__init__.py"
+direnv exec . pixi run -e images python \
+  -m "image_archive.$dataset_slug.prepare_manifest" \
+  --help
+```
 
 Use no TIFF pixel downloads in this step.
 Keep the implementation small enough that another agent can compare every rule with the upstream index and object layout.
@@ -269,7 +280,7 @@ bootstrap_work="$qualification_root/bootstrap"
 test ! -e "$bootstrap_work"
 install -d -m 0770 "$bootstrap_work"
 direnv exec . pixi run -e images python \
-  "image_archive/$dataset_slug/prepare_manifest.py" \
+  -m "image_archive.$dataset_slug.prepare_manifest" \
   --contract "image_archive/$dataset_slug/source.toml" \
   --work-dir "$bootstrap_work" \
   --remote-snapshot
@@ -297,7 +308,7 @@ pinned_work="$qualification_root/pinned"
 test ! -e "$pinned_work"
 install -d -m 0770 "$pinned_work"
 direnv exec . pixi run -e images python \
-  "image_archive/$dataset_slug/prepare_manifest.py" \
+  -m "image_archive.$dataset_slug.prepare_manifest" \
   --contract "image_archive/$dataset_slug/source.toml" \
   --work-dir "$pinned_work" \
   --remote-snapshot
@@ -370,7 +381,7 @@ Run the exact pinned normalizer into the canonical work directory:
 
 ```bash
 direnv exec . pixi run -e images python \
-  "image_archive/$dataset_slug/prepare_manifest.py" \
+  -m "image_archive.$dataset_slug.prepare_manifest" \
   --contract "image_archive/$dataset_slug/source.toml" \
   --work-dir "$archive_work" \
   --remote-snapshot


### PR DESCRIPTION
## Summary

- Define Axiom as the Axiom Bio source contribution to the historical OASIS dataset, not the reusable archive engine.
- Add a concise copy-paste prompt that starts from one Cell Painting dataset pointer.
- Preserve the detailed adaptation runbook and its narrow supported boundary.
- Correct the dataset-normalizer invocation uncovered by the clean-room run.

## Independent clean-room acceptance

A fresh agent started from exact PR SHA `f98a40d82d48bcc6c6f0c7086fc2f5ebf9add4f7` with only the published prompt and a public cpg0040 Garcia-Fossa plate pointer.
It was prohibited from inspecting or reusing earlier cpg0040 adaptations, worktrees, branches, archives, evidence, task history, or memory.

The agent independently:

- Resolved the stale literal pointer from public source evidence to the sole matching `unicamp` plate and pinned its same-plate `load_data.csv`.
- Normalized 1,620 field rows into 6,480 TIFFs totaling 14,379,307,374 bytes, with zero rejected, missing, or extra objects.
- Froze signed implementation SHA `7544c2255d5e7b2a5c15773f6821c3674bf307d5` without changing Axiom files or lockfiles.
- Deliberately interrupted at 181 verified, 16 running, and 6,283 pending rows with zero errors.
- Resumed identically, recovered all 16 running rows, and completed all 6,480 outputs with zero failures.
- Proved a completed no-op selected zero rows and rewrote no output.
- Fully validated all 6,480 outputs with `complete: true`, `audit_passed: true`, and `invalid: 0`.
- Froze a 19-file external evidence set with a zero-WAL schema-v4 ledger snapshot and a verified `SHA256SUMS` digest of `3717db3c74f2254990751852ec72ba5e5d344589ee1c1d4eea8c45cf1f95e4d3`.

## Finding and resolution

The published direct-script form initially failed with `ModuleNotFoundError: image_archive` because executing `image_archive/<dataset>/prepare_manifest.py` did not put the repository root on `sys.path`.

Commit `487a6673353e103ec6077950210c9adb36173b64` resolves the finding by requiring an importable dataset package, adding a no-side-effects import/help gate, and invoking every normalizer run as `python -m image_archive.<dataset>.prepare_manifest`.
The corrected command was exercised successfully against the independent Garcia-Fossa implementation.

## Remaining limitations

- The initially supplied plate prefix was stale, but the public dataset exposed one unambiguous matching source and index; the deviation is retained in the evidence transcript and ambiguity log.
- Anonymous S3 supplied no version IDs.
- The isolated task had no reviewed site-level snapshot or object-lock destination, so evidence is checksummed and read-only rather than protected by verified immutable storage policy.
- Validation establishes archive integrity, not biological equivalence; the TIFFs remain the scientific source of truth.

## PR validation

- Pandoc Markdown rendering
- Local-link and ASCII checks
- `git diff --check`
- Signed commit verification
- Corrected module invocation against the independent implementation
- Independent verification of all 19 evidence hashes, SQLite integrity `ok`, schema version 4, 6,480 verified ledger rows, clean validation, and completed no-op

The PR remains unmerged pending final review.
